### PR TITLE
Example for moving pda initialization/access code to helper functions

### DIFF
--- a/solana/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -72,11 +72,6 @@ impl Processor {
             verification_session_account.key,
         )?;
 
-        // Check: the incoming message PDA already approved
-        incoming_message_pda
-            .check_uninitialized_pda()
-            .map_err(|_err| GatewayError::MessageAlreadyInitialised)?;
-
         // Check: signature verification session is complete
         if !session.signature_verification.is_valid() {
             return Err(GatewayError::SigningSessionNotValid.into());
@@ -99,7 +94,7 @@ impl Processor {
         // crate a PDA where we write the message metadata contents
         let message = message.leaf.message;
         
-        IncomingMessage::create(
+        IncomingMessage::populate(
             incoming_message_pda,
             funder,
             system_program,

--- a/solana/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -1,22 +1,16 @@
 use axelar_solana_encoding::hasher::SolanaSyscallHasher;
 use axelar_solana_encoding::types::execute_data::MerkleisedMessage;
 use axelar_solana_encoding::{rs_merkle, LeafHash};
-use core::str::FromStr;
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
-use solana_program::log::sol_log_data;
-use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 
 use super::Processor;
 use crate::error::GatewayError;
-use crate::state::incoming_message::{command_id, IncomingMessage, MessageStatus};
+use crate::state::incoming_message::IncomingMessage;
 use crate::state::signature_verification_pda::SignatureVerificationSessionData;
-use crate::{
-    assert_valid_incoming_message_pda, assert_valid_signature_verification_pda, event_prefixes,
-    get_incoming_message_pda, get_validate_message_signing_pda, seed_prefixes,
-};
+use crate::assert_valid_signature_verification_pda;
 
 impl Processor {
     /// Approves an array of messages, signed by the Axelar signers.
@@ -89,7 +83,6 @@ impl Processor {
         }
 
         let leaf_hash = message.leaf.hash::<SolanaSyscallHasher>();
-        let message_hash = message.leaf.message.hash::<SolanaSyscallHasher>();
         let proof = rs_merkle::MerkleProof::<SolanaSyscallHasher>::from_bytes(&message.proof)
             .map_err(|_err| GatewayError::InvalidMerkleProof)?;
 
@@ -105,64 +98,14 @@ impl Processor {
 
         // crate a PDA where we write the message metadata contents
         let message = message.leaf.message;
-        let cc_id = message.cc_id;
-        let command_id = command_id(&cc_id.chain, &cc_id.id);
-
-        let (_, incoming_message_pda_bump) = get_incoming_message_pda(&command_id);
-        assert_valid_incoming_message_pda(
-            &command_id,
-            incoming_message_pda_bump,
-            incoming_message_pda.key,
-        )?;
-
-        let seeds = &[
-            seed_prefixes::INCOMING_MESSAGE_SEED,
-            &command_id,
-            &[incoming_message_pda_bump],
-        ];
-        program_utils::init_pda_raw(
-            funder,
+        
+        IncomingMessage::create(
             incoming_message_pda,
-            program_id,
+            funder,
             system_program,
-            IncomingMessage::LEN.try_into().map_err(|_err| {
-                solana_program::msg!("unexpected u64 overflow in struct size");
-                ProgramError::ArithmeticOverflow
-            })?,
-            seeds,
+            program_id,
+            message,
         )?;
-
-        let destination_address =
-            Pubkey::from_str(&message.destination_address).map_err(|_err| {
-                solana_program::msg!("Invalid destination address");
-                GatewayError::InvalidDestinationAddress
-            })?;
-        let (_, signing_pda_bump) =
-            get_validate_message_signing_pda(destination_address, command_id);
-
-        // Persist a new incoming message with "in progress" status in the PDA data.
-        let mut data = incoming_message_pda.try_borrow_mut_data()?;
-        let incoming_message_data =
-            IncomingMessage::read_mut(&mut data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
-        *incoming_message_data = IncomingMessage::new(
-            incoming_message_pda_bump,
-            signing_pda_bump,
-            MessageStatus::approved(),
-            message_hash,
-            message.payload_hash,
-        );
-
-        // Emit an event
-        sol_log_data(&[
-            event_prefixes::MESSAGE_APPROVED,
-            &command_id,
-            &destination_address.to_bytes(),
-            &message.payload_hash,
-            cc_id.chain.as_bytes(),
-            cc_id.id.as_bytes(),
-            message.source_address.as_bytes(),
-            message.destination_chain.as_bytes(),
-        ]);
 
         Ok(())
     }

--- a/solana/programs/axelar-solana-gateway/src/processor/initialize_config.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/initialize_config.rs
@@ -2,7 +2,7 @@ use core::mem::size_of;
 
 use axelar_message_primitives::U256;
 use itertools::Itertools;
-use program_utils::{BytemuckedPda, ValidPDA};
+use program_utils::BytemuckedPda;
 use role_management::processor::ensure_upgrade_authority;
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::clock::Clock;
@@ -18,8 +18,8 @@ use crate::instructions::InitializeConfig;
 use crate::state::verifier_set_tracker::VerifierSetTracker;
 use crate::state::GatewayConfig;
 use crate::{
-    assert_valid_gateway_root_pda, assert_valid_verifier_set_tracker_pda,
-    get_gateway_root_config_internal, get_verifier_set_tracker_pda, seed_prefixes,
+    assert_valid_gateway_root_pda,
+    get_gateway_root_config_internal, seed_prefixes,
 };
 
 impl Processor {

--- a/solana/programs/axelar-solana-gateway/src/processor/initialize_config.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/initialize_config.rs
@@ -89,34 +89,14 @@ impl Processor {
                 .map_err(|_err| ProgramError::InvalidInstructionData)?;
             let epoch = U256::from_u64(idx.saturating_add(1));
 
-            let (_, pda_bump) = get_verifier_set_tracker_pda(*verifier_set_hash);
-            verifier_set_pda.check_uninitialized_pda()?;
-
-            // Initialize the tracker account
-            program_utils::init_pda_raw(
+            VerifierSetTracker::create(
+                program_id,
                 payer,
                 verifier_set_pda,
-                program_id,
                 system_account,
-                size_of::<VerifierSetTracker>().try_into().map_err(|_err| {
-                    solana_program::msg!("unexpected u64 overflow in struct size");
-                    ProgramError::ArithmeticOverflow
-                })?,
-                &[
-                    seed_prefixes::VERIFIER_SET_TRACKER_SEED,
-                    verifier_set_hash.as_slice(),
-                    &[pda_bump],
-                ],
+                epoch,
+                verifier_set_hash,
             )?;
-
-            // store account data
-            let mut data = verifier_set_pda.try_borrow_mut_data()?;
-            let tracker = VerifierSetTracker::read_mut(&mut data)
-                .ok_or(GatewayError::BytemuckDataLenInvalid)?;
-            *tracker = VerifierSetTracker::new(pda_bump, epoch, *verifier_set_hash);
-
-            // check that everything has been derived correctly
-            assert_valid_verifier_set_tracker_pda(tracker, verifier_set_pda.key)?;
         }
 
         let (_, bump) = get_gateway_root_config_internal(program_id);

--- a/solana/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
@@ -1,12 +1,10 @@
 use core::convert::TryInto;
-use core::mem::size_of;
 
 use axelar_message_primitives::U256;
 use axelar_solana_encoding::hasher::SolanaSyscallHasher;
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
-use solana_program::log::sol_log_data;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::Sysvar;
@@ -19,8 +17,7 @@ use crate::state::verifier_set_tracker::VerifierSetTracker;
 use crate::state::GatewayConfig;
 use crate::{
     assert_valid_gateway_root_pda, assert_valid_signature_verification_pda,
-    assert_valid_verifier_set_tracker_pda, event_prefixes, get_verifier_set_tracker_pda,
-    seed_prefixes,
+    assert_valid_verifier_set_tracker_pda,
 };
 
 impl Processor {

--- a/solana/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
@@ -123,11 +123,6 @@ impl Processor {
         // Check: Current verifier set isn't expired
         gateway_config.assert_valid_epoch(verifier_set_tracker.epoch)?;
 
-        // Check: new new verifier set PDA must be uninitialised
-        new_empty_verifier_set
-            .check_uninitialized_pda()
-            .map_err(|_err| GatewayError::VerifierSetTrackerAlreadyInitialised)?;
-
         // we always enforce the delay unless unless the operator has been provided and
         // its also the Gateway opreator
         // reference: https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/c290c7337fd447ecbb7426e52ac381175e33f602/contracts/gateway/AxelarAmplifierGateway.sol#L98-L101
@@ -196,42 +191,14 @@ fn rotate_signers<'a>(
         .ok_or(ProgramError::ArithmeticOverflow)?;
 
     // Initialize thethe new verifier set tracker PDA account
-    let (_, new_verifier_set_bump) = get_verifier_set_tracker_pda(new_verifier_set_merkle_root);
-    program_utils::init_pda_raw(
+    VerifierSetTracker::create(
+        program_id,
         payer,
         new_empty_verifier_set,
-        program_id,
         system_account,
-        size_of::<VerifierSetTracker>()
-            .try_into()
-            .expect("unexpected u64 overflow in struct size"),
-        &[
-            seed_prefixes::VERIFIER_SET_TRACKER_SEED,
-            new_verifier_set_merkle_root.as_slice(),
-            &[new_verifier_set_bump],
-        ],
-    )?;
-
-    // Store the new verifier set data
-    let mut new_verifier_set_data = new_empty_verifier_set.try_borrow_mut_data()?;
-    let new_verifier_set_tracker = VerifierSetTracker::read_mut(&mut new_verifier_set_data)
-        .ok_or(GatewayError::BytemuckDataLenInvalid)?;
-    *new_verifier_set_tracker = VerifierSetTracker::new(
-        new_verifier_set_bump,
         gateway_config.current_epoch,
-        new_verifier_set_merkle_root,
-    );
-
-    // Check that everything has been derived correctly
-    assert_valid_verifier_set_tracker_pda(new_verifier_set_tracker, new_empty_verifier_set.key)?;
-
-    // Emit the rotation event
-    sol_log_data(&[
-        event_prefixes::SIGNERS_ROTATED,
-        &new_verifier_set_tracker.epoch.to_le_bytes(), // u256 as LE [u8; 32]
-        &new_verifier_set_tracker.verifier_set_hash,   // [u8; 32]
-    ]);
-    Ok(())
+        &new_verifier_set_merkle_root
+    )
 }
 
 fn enough_time_till_next_rotation(current_time: u64, config: &GatewayConfig) -> bool {

--- a/solana/programs/axelar-solana-gateway/src/state/signature_verification_pda.rs
+++ b/solana/programs/axelar-solana-gateway/src/state/signature_verification_pda.rs
@@ -1,7 +1,11 @@
 //! Module for the signature verification session PDA data layout type.
 
 use bytemuck::{Pod, Zeroable};
-use program_utils::BytemuckedPda;
+use program_utils::{BytemuckedPda, ValidPDA};
+use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+use core::mem::size_of;
+
+use crate::{error::GatewayError, seed_prefixes};
 
 use super::signature_verification::SignatureVerification;
 
@@ -23,6 +27,59 @@ pub struct SignatureVerificationSessionData {
 }
 
 impl BytemuckedPda for SignatureVerificationSessionData {}
+
+impl SignatureVerificationSessionData {
+    pub(crate) fn populate<'a>(
+        pda: &AccountInfo<'a>, 
+        gateway_root_pda: &AccountInfo<'a>, 
+        payer: &AccountInfo<'a>, 
+        system_program: &AccountInfo<'a>, 
+        program_id: &Pubkey, 
+        merkle_root:[u8; 32]
+    )-> Result<(), ProgramError>{
+        // Check: Verification PDA can be derived from provided seeds.
+        // using canonical bump for the session account
+        let (verification_session_pda, bump) =
+            crate::get_signature_verification_pda(gateway_root_pda.key, &merkle_root);
+        if verification_session_pda != *pda.key {
+            return Err(GatewayError::InvalidVerificationSessionPDA.into());
+        }
+
+        // Check: the verification session account has not been initialised already
+        pda
+            .check_uninitialized_pda()
+            .map_err(|_err| GatewayError::VerificationSessionPDAInitialised)?;
+
+        // Use the same seeds as `[crate::get_signature_verification_pda]`, plus the
+        // bump seed.
+        let signers_seeds = &[
+            seed_prefixes::SIGNATURE_VERIFICATION_SEED,
+            gateway_root_pda.key.as_ref(),
+            &merkle_root,
+            &[bump],
+        ];
+
+        // Prepare the `create_account` instruction
+        program_utils::init_pda_raw(
+            payer,
+            pda,
+            program_id,
+            system_program,
+            size_of::<SignatureVerificationSessionData>()
+                .try_into()
+                .map_err(|_err| {
+                    solana_program::msg!("Unexpected u64 overflow in struct size");
+                    ProgramError::ArithmeticOverflow
+                })?,
+            signers_seeds,
+        )?;
+        let mut data = pda.try_borrow_mut_data()?;
+        let session = SignatureVerificationSessionData::read_mut(&mut data)
+            .ok_or(GatewayError::BytemuckDataLenInvalid)?;
+        session.bump = bump;
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/solana/programs/axelar-solana-gateway/src/state/verifier_set_tracker.rs
+++ b/solana/programs/axelar-solana-gateway/src/state/verifier_set_tracker.rs
@@ -2,7 +2,11 @@
 
 use axelar_message_primitives::U256;
 use bytemuck::{Pod, Zeroable};
-use program_utils::BytemuckedPda;
+use program_utils::{BytemuckedPda, ValidPDA};
+pub use core::mem::size_of;
+use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+
+use crate::{assert_valid_verifier_set_tracker_pda, error::GatewayError, get_verifier_set_tracker_pda, seed_prefixes};
 
 /// Ever-incrementing counter for keeping track of the sequence of signer sets
 pub type Epoch = U256;
@@ -37,6 +41,50 @@ impl VerifierSetTracker {
             verifier_set_hash,
         }
     }
+
+    pub(crate) fn create<'a>(
+        program_id: &Pubkey,
+        payer: &AccountInfo<'a>,
+        verifier_set_pda: &AccountInfo<'a>,
+        system_account: &AccountInfo<'a>,
+        epoch: U256,
+        verifier_set_hash: &VerifierSetHash,
+    )-> Result<(), ProgramError> {
+
+        let (_, pda_bump) = get_verifier_set_tracker_pda(*verifier_set_hash);
+        
+        // Check: new new verifier set PDA must be uninitialised
+        verifier_set_pda
+            .check_uninitialized_pda()
+            .map_err(|_err| GatewayError::VerifierSetTrackerAlreadyInitialised)?;
+
+        // Initialize the tracker account
+        program_utils::init_pda_raw(
+            payer,
+            verifier_set_pda,
+            program_id,
+            system_account,
+            size_of::<VerifierSetTracker>().try_into()
+                .expect("unexpected u64 overflow in struct size"),
+            &[
+                seed_prefixes::VERIFIER_SET_TRACKER_SEED,
+                verifier_set_hash.as_slice(),
+                &[pda_bump],
+            ],
+        )?;
+
+        // store account data
+        let mut data = verifier_set_pda.try_borrow_mut_data()?;
+        let tracker = VerifierSetTracker::read_mut(&mut data)
+            .ok_or(GatewayError::BytemuckDataLenInvalid)?;
+        *tracker = VerifierSetTracker::new(pda_bump, epoch, *verifier_set_hash);
+
+        // check that everything has been derived correctly
+        assert_valid_verifier_set_tracker_pda(tracker, verifier_set_pda.key)?;
+
+        Ok(())
+    }
+
 }
 
 impl BytemuckedPda for VerifierSetTracker {}

--- a/solana/programs/axelar-solana-gateway/src/state/verifier_set_tracker.rs
+++ b/solana/programs/axelar-solana-gateway/src/state/verifier_set_tracker.rs
@@ -4,7 +4,6 @@ use axelar_message_primitives::U256;
 use bytemuck::{Pod, Zeroable};
 use program_utils::{BytemuckedPda, ValidPDA};
 pub use core::mem::size_of;
-use std::{cell::{Ref, RefMut}, rc::Rc};
 use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 
 use crate::{assert_valid_verifier_set_tracker_pda, error::GatewayError, get_verifier_set_tracker_pda, seed_prefixes};


### PR DESCRIPTION
**Referenced issue**

If applies, the issue this PR belongs to.

**Summary of changes**

A brief summary of the changes and motivations.

- [ ] Does this PR change behavior or adds a new feature ?
- [ ] docs updated
- [ ] tests updated
- [ x] code style matches guidelines

**Reviewer recommendations**

This is a draft PR meant to showcase how moving code to helper functions can clear up intent. The code does not need to be moved to the storage files like it is here, but lib.rs is getting rather big.

**Ready-ready checklist**

- [ ] Labels (ticket type and component) are set
- [ ] Project & Phase is assigned
- [ ] This checklist is removed
