### PR TITLE
feat(bindings): additional its bindings

### DIFF
--- a/solana/bindings/anchor_lib/axelar-solana-its.rs
+++ b/solana/bindings/anchor_lib/axelar-solana-its.rs
@@ -65,6 +65,18 @@ pub mod axelar_solana_its {
         Ok(())
     }
 
+    pub fn interchain_transfer(
+        ctx: Context<InterchainTransfer>,
+        token_id: [u8; 32],
+        destination_chain: String,
+        destination_address: Vec<u8>,
+        amount: u64,
+        gas_value: u64,
+        signing_pda_bump: u8,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     pub fn deploy_interchain_token(
         ctx: Context<DeployInterchainToken>,
         salt: [u8; 32],
@@ -120,6 +132,32 @@ pub mod axelar_solana_its {
         destination_token_address: Vec<u8>,
         token_manager_type: Type,
         link_params: Vec<u8>,
+        gas_value: u64,
+        signing_pda_bump: u8,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn call_contract_with_interchain_token(
+        ctx: Context<CallContractWithInterchainToken>,
+        token_id: [u8; 32],
+        destination_chain: String,
+        destination_address: Vec<u8>,
+        amount: u64,
+        data: Vec<u8>,
+        gas_value: u64,
+        signing_pda_bump: u8,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn call_contract_with_interchain_token_offchain_data(
+        ctx: Context<CallContractWithInterchainTokenOffchainData>,
+        token_id: [u8; 32],
+        destination_chain: String,
+        destination_address: Vec<u8>,
+        amount: u64,
+        payload_hash: [u8; 32],
         gas_value: u64,
         signing_pda_bump: u8,
     ) -> Result<()> {
@@ -229,6 +267,31 @@ pub struct DeployRemoteCanonicalInterchainToken<'info> {
     metadata_account: AccountInfo<'info>,
     sysvar_instructions: AccountInfo<'info>,
     mpl_token_metadata: AccountInfo<'info>,
+    gateway_root_pda: AccountInfo<'info>,
+    axelar_solana_gateway: AccountInfo<'info>,
+    #[account(mut)]
+    gas_config_pda: AccountInfo<'info>,
+    gas_service: AccountInfo<'info>,
+    system_program: Program<'info, System>,
+    its_root_pda: AccountInfo<'info>,
+    call_contract_signing_pda: AccountInfo<'info>,
+    ID: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct InterchainTransfer<'info> {
+    payer: Signer<'info>,
+    authority: Signer<'info>,
+    #[account(mut)]
+    source_account: AccountInfo<'info>,
+    #[account(mut)]
+    mint: AccountInfo<'info>,
+    token_manager_pda: AccountInfo<'info>,
+    #[account(mut)]
+    token_manager_ata: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+    #[account(mut)]
+    flow_slot_pda: AccountInfo<'info>,
     gateway_root_pda: AccountInfo<'info>,
     axelar_solana_gateway: AccountInfo<'info>,
     #[account(mut)]
@@ -357,6 +420,56 @@ pub struct LinkToken<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     token_manager_pda: AccountInfo<'info>,
+    gateway_root_pda: AccountInfo<'info>,
+    axelar_solana_gateway: AccountInfo<'info>,
+    #[account(mut)]
+    gas_config_pda: AccountInfo<'info>,
+    gas_service: AccountInfo<'info>,
+    system_program: Program<'info, System>,
+    its_root_pda: AccountInfo<'info>,
+    call_contract_signing_pda: AccountInfo<'info>,
+    ID: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CallContractWithInterchainToken<'info> {
+    payer: Signer<'info>,
+    authority: Signer<'info>,
+    #[account(mut)]
+    source_account: AccountInfo<'info>,
+    #[account(mut)]
+    mint: AccountInfo<'info>,
+    token_manager_pda: AccountInfo<'info>,
+    #[account(mut)]
+    token_manager_ata: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+    #[account(mut)]
+    flow_slot_pda: AccountInfo<'info>,
+    gateway_root_pda: AccountInfo<'info>,
+    axelar_solana_gateway: AccountInfo<'info>,
+    #[account(mut)]
+    gas_config_pda: AccountInfo<'info>,
+    gas_service: AccountInfo<'info>,
+    system_program: Program<'info, System>,
+    its_root_pda: AccountInfo<'info>,
+    call_contract_signing_pda: AccountInfo<'info>,
+    ID: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CallContractWithInterchainTokenOffchainData<'info> {
+    payer: Signer<'info>,
+    authority: Signer<'info>,
+    #[account(mut)]
+    source_account: AccountInfo<'info>,
+    #[account(mut)]
+    mint: AccountInfo<'info>,
+    token_manager_pda: AccountInfo<'info>,
+    #[account(mut)]
+    token_manager_ata: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+    #[account(mut)]
+    flow_slot_pda: AccountInfo<'info>,
     gateway_root_pda: AccountInfo<'info>,
     axelar_solana_gateway: AccountInfo<'info>,
     #[account(mut)]

--- a/solana/bindings/anchor_lib/axelar-solana-its.rs
+++ b/solana/bindings/anchor_lib/axelar-solana-its.rs
@@ -231,8 +231,6 @@ pub struct ApproveDeployRemoteInterchainToken<'info> {
 pub struct RevokeDeployRemoteInterchainToken<'info> {
     #[account(mut)]
     payer: Signer<'info>,
-    token_manager_pda: AccountInfo<'info>,
-    roles_pda: AccountInfo<'info>,
     #[account(mut)]
     deploy_approval_pda: AccountInfo<'info>,
     system_program: Program<'info, System>,

--- a/solana/bindings/generated/axelar-solana-its/idl.json
+++ b/solana/bindings/generated/axelar-solana-its/idl.json
@@ -222,16 +222,6 @@
           "isSigner": true
         },
         {
-          "name": "tokenManagerPda",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rolesPda",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "deployApprovalPda",
           "isMut": true,
           "isSigner": false

--- a/solana/bindings/generated/axelar-solana-its/idl.json
+++ b/solana/bindings/generated/axelar-solana-its/idl.json
@@ -413,6 +413,122 @@
       ]
     },
     {
+      "name": "interchainTransfer",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "sourceAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenManagerPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenManagerAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "flowSlotPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "gatewayRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "axelarSolanaGateway",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "gasConfigPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "gasService",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itsRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "callContractSigningPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "id",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "tokenId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "destinationChain",
+          "type": "string"
+        },
+        {
+          "name": "destinationAddress",
+          "type": "bytes"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "gasValue",
+          "type": "u64"
+        },
+        {
+          "name": "signingPdaBump",
+          "type": "u8"
+        }
+      ]
+    },
+    {
       "name": "deployInterchainToken",
       "accounts": [
         {
@@ -981,6 +1097,251 @@
         {
           "name": "linkParams",
           "type": "bytes"
+        },
+        {
+          "name": "gasValue",
+          "type": "u64"
+        },
+        {
+          "name": "signingPdaBump",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "callContractWithInterchainToken",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "sourceAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenManagerPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenManagerAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "flowSlotPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "gatewayRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "axelarSolanaGateway",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "gasConfigPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "gasService",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itsRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "callContractSigningPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "id",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "tokenId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "destinationChain",
+          "type": "string"
+        },
+        {
+          "name": "destinationAddress",
+          "type": "bytes"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        },
+        {
+          "name": "gasValue",
+          "type": "u64"
+        },
+        {
+          "name": "signingPdaBump",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "callContractWithInterchainTokenOffchainData",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "sourceAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenManagerPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenManagerAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "flowSlotPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "gatewayRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "axelarSolanaGateway",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "gasConfigPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "gasService",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "itsRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "callContractSigningPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "id",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "tokenId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "destinationChain",
+          "type": "string"
+        },
+        {
+          "name": "destinationAddress",
+          "type": "bytes"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "payloadHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
         },
         {
           "name": "gasValue",

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -432,6 +432,119 @@ type AxelarSolanaIts = {
       ];
     },
     {
+      name: "interchainTransfer";
+      accounts: [
+        {
+          name: "payer";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "authority";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "sourceAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "mint";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenManagerPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "tokenManagerAta";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "flowSlotPda";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "gatewayRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "axelarSolanaGateway";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "gasConfigPda";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "gasService";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "itsRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "callContractSigningPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "id";
+          isMut: false;
+          isSigner: false;
+        }
+      ];
+      args: [
+        {
+          name: "tokenId";
+          type: {
+            array: ["u8", 32];
+          };
+        },
+        {
+          name: "destinationChain";
+          type: "string";
+        },
+        {
+          name: "destinationAddress";
+          type: "bytes";
+        },
+        {
+          name: "amount";
+          type: "u64";
+        },
+        {
+          name: "gasValue";
+          type: "u64";
+        },
+        {
+          name: "signingPdaBump";
+          type: "u8";
+        }
+      ];
+    },
+    {
       name: "deployInterchainToken";
       accounts: [
         {
@@ -997,6 +1110,242 @@ type AxelarSolanaIts = {
       ];
     },
     {
+      name: "callContractWithInterchainToken";
+      accounts: [
+        {
+          name: "payer";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "authority";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "sourceAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "mint";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenManagerPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "tokenManagerAta";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "flowSlotPda";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "gatewayRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "axelarSolanaGateway";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "gasConfigPda";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "gasService";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "itsRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "callContractSigningPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "id";
+          isMut: false;
+          isSigner: false;
+        }
+      ];
+      args: [
+        {
+          name: "tokenId";
+          type: {
+            array: ["u8", 32];
+          };
+        },
+        {
+          name: "destinationChain";
+          type: "string";
+        },
+        {
+          name: "destinationAddress";
+          type: "bytes";
+        },
+        {
+          name: "amount";
+          type: "u64";
+        },
+        {
+          name: "data";
+          type: "bytes";
+        },
+        {
+          name: "gasValue";
+          type: "u64";
+        },
+        {
+          name: "signingPdaBump";
+          type: "u8";
+        }
+      ];
+    },
+    {
+      name: "callContractWithInterchainTokenOffchainData";
+      accounts: [
+        {
+          name: "payer";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "authority";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "sourceAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "mint";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenManagerPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "tokenManagerAta";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "flowSlotPda";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "gatewayRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "axelarSolanaGateway";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "gasConfigPda";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "gasService";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "itsRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "callContractSigningPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "id";
+          isMut: false;
+          isSigner: false;
+        }
+      ];
+      args: [
+        {
+          name: "tokenId";
+          type: {
+            array: ["u8", 32];
+          };
+        },
+        {
+          name: "destinationChain";
+          type: "string";
+        },
+        {
+          name: "destinationAddress";
+          type: "bytes";
+        },
+        {
+          name: "amount";
+          type: "u64";
+        },
+        {
+          name: "payloadHash";
+          type: {
+            array: ["u8", 32];
+          };
+        },
+        {
+          name: "gasValue";
+          type: "u64";
+        },
+        {
+          name: "signingPdaBump";
+          type: "u8";
+        }
+      ];
+    },
+    {
       name: "setFlowLimit";
       accounts: [
         {
@@ -1462,6 +1811,119 @@ const IDL: AxelarSolanaIts = {
         {
           name: "destinationChain",
           type: "string",
+        },
+        {
+          name: "gasValue",
+          type: "u64",
+        },
+        {
+          name: "signingPdaBump",
+          type: "u8",
+        },
+      ],
+    },
+    {
+      name: "interchainTransfer",
+      accounts: [
+        {
+          name: "payer",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "authority",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "sourceAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "mint",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenManagerPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "tokenManagerAta",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "flowSlotPda",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "gatewayRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "axelarSolanaGateway",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "gasConfigPda",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "gasService",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "itsRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "callContractSigningPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "id",
+          isMut: false,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "tokenId",
+          type: {
+            array: ["u8", 32],
+          },
+        },
+        {
+          name: "destinationChain",
+          type: "string",
+        },
+        {
+          name: "destinationAddress",
+          type: "bytes",
+        },
+        {
+          name: "amount",
+          type: "u64",
         },
         {
           name: "gasValue",
@@ -2027,6 +2489,242 @@ const IDL: AxelarSolanaIts = {
         {
           name: "linkParams",
           type: "bytes",
+        },
+        {
+          name: "gasValue",
+          type: "u64",
+        },
+        {
+          name: "signingPdaBump",
+          type: "u8",
+        },
+      ],
+    },
+    {
+      name: "callContractWithInterchainToken",
+      accounts: [
+        {
+          name: "payer",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "authority",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "sourceAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "mint",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenManagerPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "tokenManagerAta",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "flowSlotPda",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "gatewayRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "axelarSolanaGateway",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "gasConfigPda",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "gasService",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "itsRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "callContractSigningPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "id",
+          isMut: false,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "tokenId",
+          type: {
+            array: ["u8", 32],
+          },
+        },
+        {
+          name: "destinationChain",
+          type: "string",
+        },
+        {
+          name: "destinationAddress",
+          type: "bytes",
+        },
+        {
+          name: "amount",
+          type: "u64",
+        },
+        {
+          name: "data",
+          type: "bytes",
+        },
+        {
+          name: "gasValue",
+          type: "u64",
+        },
+        {
+          name: "signingPdaBump",
+          type: "u8",
+        },
+      ],
+    },
+    {
+      name: "callContractWithInterchainTokenOffchainData",
+      accounts: [
+        {
+          name: "payer",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "authority",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "sourceAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "mint",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenManagerPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "tokenManagerAta",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "flowSlotPda",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "gatewayRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "axelarSolanaGateway",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "gasConfigPda",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "gasService",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "itsRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "callContractSigningPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "id",
+          isMut: false,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "tokenId",
+          type: {
+            array: ["u8", 32],
+          },
+        },
+        {
+          name: "destinationChain",
+          type: "string",
+        },
+        {
+          name: "destinationAddress",
+          type: "bytes",
+        },
+        {
+          name: "amount",
+          type: "u64",
+        },
+        {
+          name: "payloadHash",
+          type: {
+            array: ["u8", 32],
+          },
         },
         {
           name: "gasValue",

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -244,16 +244,6 @@ type AxelarSolanaIts = {
           isSigner: true;
         },
         {
-          name: "tokenManagerPda";
-          isMut: false;
-          isSigner: false;
-        },
-        {
-          name: "rolesPda";
-          isMut: false;
-          isSigner: false;
-        },
-        {
           name: "deployApprovalPda";
           isMut: true;
           isSigner: false;
@@ -1633,16 +1623,6 @@ const IDL: AxelarSolanaIts = {
           name: "payer",
           isMut: true,
           isSigner: true,
-        },
-        {
-          name: "tokenManagerPda",
-          isMut: false,
-          isSigner: false,
-        },
-        {
-          name: "rolesPda",
-          isMut: false,
-          isSigner: false,
         },
         {
           name: "deployApprovalPda",

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -4,397 +4,414 @@ import { BN } from "@coral-xyz/anchor";
 
 describe("Ping ITS", () => {
   const program = axelarSolanaItsProgram();
+  const processError = (error: any, functionName: string) => {
+    const errorMessage = "Program log: Instruction: " + functionName;
+    if (error.logs.includes(errorMessage)) {
+        console.log("Test OK: Program throws error, but data is properly sent through bindings.");
+    } else {
+        console.log("Test FAIL: Program throws error and data is not properly sent. Check bindings.")
+    }
+  };
 
   it("Initialize", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.initialize("1", "2").accounts({
-            payer: payer.publicKey,
-            programDataAddress: payer.publicKey,
-            itsRootPda: payer.publicKey,
-            operator: payer.publicKey,
-            userRolesPda: payer.publicKey,
-            gatewayRootPda: payer.publicKey,
-            systemProgram: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.initialize(
+        "1", "2"
+      ).accounts({
+        payer: payer.publicKey,
+        programDataAddress: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        operator: payer.publicKey,
+        userRolesPda: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from Initialize");
+      processError(error, "Initialize");
     }
   })
 
   it("SetPauseStatus", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.setPauseStatus(true).accounts({
-          payer: payer.publicKey,
-          programDataAddress: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          itsRootPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.setPauseStatus(
+        true
+      ).accounts({
+        payer: payer.publicKey,
+        programDataAddress: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        itsRootPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from SetPauseStatus");
+      processError(error, "SetPauseStatus");
     }
   })
 
   it("SetTrustedChain", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.setTrustedChain("chain").accounts({
-          payer: payer.publicKey,
-          programDataAddress: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          itsRootPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.setTrustedChain(
+        "chain"
+      ).accounts({
+        payer: payer.publicKey,
+        programDataAddress: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from SetTrustedChain");
+      processError(error, "SetTrustedChain");
     }
   })
 
   it("RemoveTrustedChain", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.removeTrustedChain("chain").accounts({
-          payer: payer.publicKey,
-          programDataAddress: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          itsRootPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.removeTrustedChain(
+        "chain"
+      ).accounts({
+        payer: payer.publicKey,
+        programDataAddress: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        itsRootPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from RemoveTrustedChain");
+      processError(error, "RemoveTrustedChain");
     }
   })
 
   it("ApproveDeployRemoteInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.approveDeployRemoteInterchainToken(
-          payer.publicKey, [1, 2], "chain", Buffer.from(new Uint8Array(2))
-        ).accounts({
-          payer: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          rolesPda: payer.publicKey,
-          deployApprovalPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.approveDeployRemoteInterchainToken(
+        payer.publicKey, [1, 2], "chain", Buffer.from(new Uint8Array(2))
+      ).accounts({
+        payer: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        rolesPda: payer.publicKey,
+        deployApprovalPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from ApproveDeployRemoteInterchainToken");
+      processError(error, "ApproveDeployRemoteInterchainToken");
     }
   })
 
   it("RevokeDeployRemoteInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.revokeDeployRemoteInterchainToken(
-          payer.publicKey, [1, 2], "chain"
-        ).accounts({
-          payer: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          rolesPda: payer.publicKey,
-          deployApprovalPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.revokeDeployRemoteInterchainToken(
+        payer.publicKey, [1, 2], "chain"
+      ).accounts({
+        payer: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        rolesPda: payer.publicKey,
+        deployApprovalPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from RevokeDeployRemoteInterchainToken");
+      processError(error, "RevokeDeployRemoteInterchainToken");
     }
   })
 
   it("RegisterCanonicalInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.registerCanonicalInterchainToken().accounts({
-          payer: payer.publicKey,
-          tokenMetadataAccount: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          mint: payer.publicKey,
-          tokenManagerAta: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          splAssociatedTokenAccount: payer.publicKey,
-          itsUserRolesPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.registerCanonicalInterchainToken().accounts({
+        payer: payer.publicKey,
+        tokenMetadataAccount: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        mint: payer.publicKey,
+        tokenManagerAta: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        splAssociatedTokenAccount: payer.publicKey,
+        itsUserRolesPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from RegisterCanonicalInterchainToken");
+      processError(error, "RegisterCanonicalInterchainToken");
     }
   })
 
   it("DeployRemoteCanonicalInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.deployRemoteCanonicalInterchainToken(
-          "chain", new BN(1), 2
-        ).accounts({
-          payer: payer.publicKey,
-          mint: payer.publicKey,
-          metadataAccount: payer.publicKey,
-          sysvarInstructions: payer.publicKey,
-          mplTokenMetadata: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.deployRemoteCanonicalInterchainToken(
+        "chain", new BN(1), 2
+      ).accounts({
+        payer: payer.publicKey,
+        mint: payer.publicKey,
+        metadataAccount: payer.publicKey,
+        sysvarInstructions: payer.publicKey,
+        mplTokenMetadata: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from DeployRemoteCanonicalInterchainToken");
+      processError(error, "OutboundDeploy")
     }
   })
 
   it("InterchainTransfer", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.interchainTransfer(
-          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(2), new BN(3), 4
-        ).accounts({
-          payer: payer.publicKey,
-          authority: payer.publicKey,
-          sourceAccount: payer.publicKey,
-          mint: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          tokenManagerAta: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          flowSlotPda: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.interchainTransfer(
+        [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(2), new BN(3), 4
+      ).accounts({
+        payer: payer.publicKey,
+        authority: payer.publicKey,
+        sourceAccount: payer.publicKey,
+        mint: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        tokenManagerAta: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        flowSlotPda: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from InterchainTransfer");
+      processError(error, "OutboundTransfer");
     }
   })
 
   it("DeployInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.deployInterchainToken(
-          [1, 2], "name", "symbol", 2
-        ).accounts({
-          payer: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          mint: payer.publicKey,
-          tokenManagerAta: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          splAssociatedTokenAccount: payer.publicKey,
-          itsUserRolesPda: payer.publicKey,
-          rent: payer.publicKey,
-          sysvarInstructions: payer.publicKey,
-          mplTokenMetadata: payer.publicKey,
-          metadataAccount: payer.publicKey,
-          minter: payer.publicKey,
-          minterRolesPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.deployInterchainToken(
+        [1, 2], "name", "symbol", 2
+      ).accounts({
+        payer: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        mint: payer.publicKey,
+        tokenManagerAta: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        splAssociatedTokenAccount: payer.publicKey,
+        itsUserRolesPda: payer.publicKey,
+        rent: payer.publicKey,
+        sysvarInstructions: payer.publicKey,
+        mplTokenMetadata: payer.publicKey,
+        metadataAccount: payer.publicKey,
+        minter: payer.publicKey,
+        minterRolesPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from DeployInterchainToken");
+      processError(error, "InboundDeploy");
     }
   })
 
   it("DeployRemoteInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.deployRemoteInterchainToken(
-          [1, 2], "chain", new BN(1), 2
-        ).accounts({
-          payer: payer.publicKey,
-          mint: payer.publicKey,
-          metadataAccount: payer.publicKey,
-          sysvarInstructions: payer.publicKey,
-          mplTokenMetadata: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey
-        }).rpc();
+      const tx = await program.methods.deployRemoteInterchainToken(
+        [1, 2], "chain", new BN(1), 2
+      ).accounts({
+        payer: payer.publicKey,
+        mint: payer.publicKey,
+        metadataAccount: payer.publicKey,
+        sysvarInstructions: payer.publicKey,
+        mplTokenMetadata: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey
+      }).rpc();
     } catch (error) {
-        console.log("Error from DeployRemoteInterchainToken");
+      processError(error, "OutboundDeploy");
     }
   })
 
   it("DeployRemoteInterchainTokenWithMinter", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.deployRemoteInterchainTokenWithMinter(
-          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(4), 5
-        ).accounts({
-          payer: payer.publicKey,
-          mint: payer.publicKey,
-          metadataAccount: payer.publicKey,
-          minter: payer.publicKey,
-          deployApproval: payer.publicKey,
-          minterRolesPda: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          sysvarInstructions: payer.publicKey,
-          mplTokenMetadata: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey
-        }).rpc();
+      const tx = await program.methods.deployRemoteInterchainTokenWithMinter(
+        [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(4), 5
+      ).accounts({
+        payer: payer.publicKey,
+        mint: payer.publicKey,
+        metadataAccount: payer.publicKey,
+        minter: payer.publicKey,
+        deployApproval: payer.publicKey,
+        minterRolesPda: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        sysvarInstructions: payer.publicKey,
+        mplTokenMetadata: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey
+      }).rpc();
     } catch (error) {
-        console.log("Error from DeployRemoteInterchainTokenWithMinter");
+      processError(error, "OutboundDeployMinter");
     }
   })
 
   it("RegisterTokenMetadata", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.registerTokenMetadata(
-          new BN(1), 2
-        ).accounts({
-          payer: payer.publicKey,
-          mint: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.registerTokenMetadata(
+        new BN(1), 2
+      ).accounts({
+        payer: payer.publicKey,
+        mint: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from RegisterTokenMetadata");
+      processError(error, "RegisterTokenMetadata");
     }
   })
 
   it("RegisterCustomToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.registerCustomToken(
-          [1, 2], {nativeInterchainToken: 1}, payer.publicKey
-        ).accounts({
-          payer: payer.publicKey,
-          tokenMetadataAccount: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          mint: payer.publicKey,
-          tokenManagerAta: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          splAssociatedTokenAccount: payer.publicKey,
-          itsUserRolesPda: payer.publicKey,
-          rent: payer.publicKey,
-          operator: payer.publicKey,
-          operatorRolesPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.registerCustomToken(
+        [1, 2], {nativeInterchainToken: 1}, payer.publicKey
+      ).accounts({
+        payer: payer.publicKey,
+        tokenMetadataAccount: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        mint: payer.publicKey,
+        tokenManagerAta: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        splAssociatedTokenAccount: payer.publicKey,
+        itsUserRolesPda: payer.publicKey,
+        rent: payer.publicKey,
+        operator: payer.publicKey,
+        operatorRolesPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from RegisterCustomToken");
+      processError(error, "RegisterToken");
     }
   })
 
   it("LinkToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.linkToken(
-           [1, 2], "chain", Buffer.from(new Uint8Array(2)), { mintBurn: 1 }, Buffer.from(new Uint8Array(3)), new BN(1), 2
-        ).accounts({
-          payer: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.linkToken(
+          [1, 2], "chain", Buffer.from(new Uint8Array(2)), { mintBurn: 1 }, Buffer.from(new Uint8Array(3)), new BN(1), 2
+      ).accounts({
+        payer: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from LinkToken");
+      processError(error, "ProcessOutbound");
     }
   })
 
   it("CallContractWithInterchainToken", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.callContractWithInterchainToken(
-          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(1),
-          Buffer.from(new Uint8Array(3)), new BN(4), 2
-        ).accounts({
-          payer: payer.publicKey,
-          authority: payer.publicKey,
-          sourceAccount: payer.publicKey,
-          mint: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          tokenManagerAta: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          flowSlotPda: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.callContractWithInterchainToken(
+        [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(1),
+        Buffer.from(new Uint8Array(3)), new BN(4), 2
+      ).accounts({
+        payer: payer.publicKey,
+        authority: payer.publicKey,
+        sourceAccount: payer.publicKey,
+        mint: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        tokenManagerAta: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        flowSlotPda: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from CallContractWithInterchainToken");
+      processError(error, "OutboundTransfer");
     }
   })
 
   it("CallContractWithInterchainTokenOffchainData", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.callContractWithInterchainTokenOffchainData(
-          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(1),
-          [3, 4], new BN(4), 2
-        ).accounts({
-          payer: payer.publicKey,
-          authority: payer.publicKey,
-          sourceAccount: payer.publicKey,
-          mint: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          tokenManagerAta: payer.publicKey,
-          tokenProgram: payer.publicKey,
-          flowSlotPda: payer.publicKey,
-          gatewayRootPda: payer.publicKey,
-          axelarSolanaGateway: payer.publicKey,
-          gasConfigPda: payer.publicKey,
-          gasService: payer.publicKey,
-          systemProgram: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          callContractSigningPda: payer.publicKey,
-          id: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.callContractWithInterchainTokenOffchainData(
+        [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(1),
+        [3, 4], new BN(4), 2
+      ).accounts({
+        payer: payer.publicKey,
+        authority: payer.publicKey,
+        sourceAccount: payer.publicKey,
+        mint: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        tokenManagerAta: payer.publicKey,
+        tokenProgram: payer.publicKey,
+        flowSlotPda: payer.publicKey,
+        gatewayRootPda: payer.publicKey,
+        axelarSolanaGateway: payer.publicKey,
+        gasConfigPda: payer.publicKey,
+        gasService: payer.publicKey,
+        systemProgram: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        callContractSigningPda: payer.publicKey,
+        id: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from CallContractWithInterchainTokenOffchainData");
+      processError(error, "OutboundTransfer");
     }
   })
 
   it("SetFlowLimit", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.setFlowLimit(
-          new BN(1)
-        ).accounts({
-          payer: payer.publicKey,
-          itsRootPda: payer.publicKey,
-          tokenManagerPda: payer.publicKey,
-          itsUserRolesPda: payer.publicKey,
-          tokenManagerUserRolesPda: payer.publicKey,
-        }).rpc();
+      const tx = await program.methods.setFlowLimit(
+        new BN(1)
+      ).accounts({
+        payer: payer.publicKey,
+        itsRootPda: payer.publicKey,
+        tokenManagerPda: payer.publicKey,
+        itsUserRolesPda: payer.publicKey,
+        tokenManagerUserRolesPda: payer.publicKey,
+      }).rpc();
     } catch (error) {
-        console.log("Error from SetFlowLimit");
+      processError(error, "SetFlowLimit");
     }
   })
 });

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -104,8 +104,6 @@ describe("Ping ITS", () => {
         payer.publicKey, [1, 2], "chain"
       ).accounts({
         payer: payer.publicKey,
-        tokenManagerPda: payer.publicKey,
-        rolesPda: payer.publicKey,
         deployApprovalPda: payer.publicKey,
       }).rpc();
     } catch (error) {

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -141,4 +141,260 @@ describe("Ping ITS", () => {
         console.log("Error from DeployRemoteCanonicalInterchainToken");
     }
   })
+
+  it("InterchainTransfer", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.interchainTransfer(
+          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(2), new BN(3), 4
+        ).accounts({
+          payer: payer.publicKey,
+          authority: payer.publicKey,
+          sourceAccount: payer.publicKey,
+          mint: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          tokenManagerAta: payer.publicKey,
+          tokenProgram: payer.publicKey,
+          flowSlotPda: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from InterchainTransfer");
+    }
+  })
+
+  it("DeployInterchainToken", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.deployInterchainToken(
+          [1, 2], "name", "symbol", 2
+        ).accounts({
+          payer: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          mint: payer.publicKey,
+          tokenManagerAta: payer.publicKey,
+          tokenProgram: payer.publicKey,
+          splAssociatedTokenAccount: payer.publicKey,
+          itsUserRolesPda: payer.publicKey,
+          rent: payer.publicKey,
+          sysvarInstructions: payer.publicKey,
+          mplTokenMetadata: payer.publicKey,
+          metadataAccount: payer.publicKey,
+          minter: payer.publicKey,
+          minterRolesPda: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from DeployInterchainToken");
+    }
+  })
+
+  it("DeployRemoteInterchainToken", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.deployRemoteInterchainToken(
+          [1, 2], "chain", new BN(1), 2
+        ).accounts({
+          payer: payer.publicKey,
+          mint: payer.publicKey,
+          metadataAccount: payer.publicKey,
+          sysvarInstructions: payer.publicKey,
+          mplTokenMetadata: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey
+        }).rpc();
+    } catch (error) {
+        console.log("Error from DeployRemoteInterchainToken");
+    }
+  })
+
+  it("DeployRemoteInterchainTokenWithMinter", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.deployRemoteInterchainTokenWithMinter(
+          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(4), 5
+        ).accounts({
+          payer: payer.publicKey,
+          mint: payer.publicKey,
+          metadataAccount: payer.publicKey,
+          minter: payer.publicKey,
+          deployApproval: payer.publicKey,
+          minterRolesPda: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          sysvarInstructions: payer.publicKey,
+          mplTokenMetadata: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey
+        }).rpc();
+    } catch (error) {
+        console.log("Error from DeployRemoteInterchainTokenWithMinter");
+    }
+  })
+
+  it("RegisterTokenMetadata", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.registerTokenMetadata(
+          new BN(1), 2
+        ).accounts({
+          payer: payer.publicKey,
+          mint: payer.publicKey,
+          tokenProgram: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from RegisterTokenMetadata");
+    }
+  })
+
+  it("RegisterCustomToken", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.registerCustomToken(
+          [1, 2], {nativeInterchainToken: 1}, payer.publicKey
+        ).accounts({
+          payer: payer.publicKey,
+          tokenMetadataAccount: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          mint: payer.publicKey,
+          tokenManagerAta: payer.publicKey,
+          tokenProgram: payer.publicKey,
+          splAssociatedTokenAccount: payer.publicKey,
+          itsUserRolesPda: payer.publicKey,
+          rent: payer.publicKey,
+          operator: payer.publicKey,
+          operatorRolesPda: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from RegisterCustomToken");
+    }
+  })
+
+  it("LinkToken", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.linkToken(
+           [1, 2], "chain", Buffer.from(new Uint8Array(2)), { mintBurn: 1 }, Buffer.from(new Uint8Array(3)), new BN(1), 2
+        ).accounts({
+          payer: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from LinkToken");
+    }
+  })
+
+  it("CallContractWithInterchainToken", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.callContractWithInterchainToken(
+          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(1),
+          Buffer.from(new Uint8Array(3)), new BN(4), 2
+        ).accounts({
+          payer: payer.publicKey,
+          authority: payer.publicKey,
+          sourceAccount: payer.publicKey,
+          mint: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          tokenManagerAta: payer.publicKey,
+          tokenProgram: payer.publicKey,
+          flowSlotPda: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from CallContractWithInterchainToken");
+    }
+  })
+
+  it("CallContractWithInterchainTokenOffchainData", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.callContractWithInterchainTokenOffchainData(
+          [1, 2], "chain", Buffer.from(new Uint8Array(1)), new BN(1),
+          [3, 4], new BN(4), 2
+        ).accounts({
+          payer: payer.publicKey,
+          authority: payer.publicKey,
+          sourceAccount: payer.publicKey,
+          mint: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          tokenManagerAta: payer.publicKey,
+          tokenProgram: payer.publicKey,
+          flowSlotPda: payer.publicKey,
+          gatewayRootPda: payer.publicKey,
+          axelarSolanaGateway: payer.publicKey,
+          gasConfigPda: payer.publicKey,
+          gasService: payer.publicKey,
+          systemProgram: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          callContractSigningPda: payer.publicKey,
+          id: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from CallContractWithInterchainTokenOffchainData");
+    }
+  })
+
+  it("SetFlowLimit", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+        const tx = await program.methods.setFlowLimit(
+          new BN(1)
+        ).accounts({
+          payer: payer.publicKey,
+          itsRootPda: payer.publicKey,
+          tokenManagerPda: payer.publicKey,
+          itsUserRolesPda: payer.publicKey,
+          tokenManagerUserRolesPda: payer.publicKey,
+        }).rpc();
+    } catch (error) {
+        console.log("Error from SetFlowLimit");
+    }
+  })
 });

--- a/solana/programs/axelar-solana-its/src/instruction.rs
+++ b/solana/programs/axelar-solana-its/src/instruction.rs
@@ -469,18 +469,6 @@ pub enum InterchainTokenServiceInstruction {
         signing_pda_bump: u8,
     },
 
-    /// A GMP Interchain Token Service instruction.
-    ///
-    /// 0. [writable,signer] The address of payer / sender
-    /// 1. [] gateway root pda
-    /// 2. [] ITS root pda
-    ///
-    /// 3..N Accounts depend on the inner ITS instruction.
-    ItsGmpPayload {
-        /// The GMP metadata
-        message: Message,
-    },
-
     /// Sets the flow limit for an interchain token.
     ///
     /// 0. [writable,signer] The address of the payer
@@ -505,6 +493,18 @@ pub enum InterchainTokenServiceInstruction {
 
     /// Instructions operating in Interchain Tokens.
     InterchainTokenInstruction(interchain_token::Instruction),
+
+    /// A GMP Interchain Token Service instruction.
+    ///
+    /// 0. [writable,signer] The address of payer / sender
+    /// 1. [] gateway root pda
+    /// 2. [] ITS root pda
+    ///
+    /// 3..N Accounts depend on the inner ITS instruction.
+    ItsGmpPayload {
+        /// The GMP metadata
+        message: Message,
+    },
 }
 
 /// Inputs for the [`its_gmp_payload`] function.

--- a/solana/programs/axelar-solana-its/src/instruction.rs
+++ b/solana/programs/axelar-solana-its/src/instruction.rs
@@ -1255,7 +1255,7 @@ pub fn interchain_transfer(
         get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(ID);
-    
+
     let accounts = vec![
         AccountMeta::new_readonly(payer, true),
         AccountMeta::new_readonly(authority, signer),
@@ -1323,7 +1323,7 @@ pub fn call_contract_with_interchain_token(
         get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(ID);
-    
+
     let accounts = vec![
         AccountMeta::new_readonly(payer, true),
         AccountMeta::new_readonly(authority, signer),
@@ -1394,7 +1394,7 @@ pub fn call_contract_with_interchain_token_offchain_data(
         get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(ID);
-    
+
     let accounts = vec![
         AccountMeta::new_readonly(payer, true),
         AccountMeta::new_readonly(authority, signer),

--- a/solana/programs/axelar-solana-its/src/instruction.rs
+++ b/solana/programs/axelar-solana-its/src/instruction.rs
@@ -764,19 +764,12 @@ pub fn revoke_deploy_remote_interchain_token(
     salt: [u8; 32],
     destination_chain: String,
 ) -> Result<Instruction, ProgramError> {
-    let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
-    let (its_root_pda, _) = crate::find_its_root_pda(&gateway_root_pda);
     let token_id = crate::interchain_token_id(&deployer, &salt);
-    let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::ID, &token_manager_pda, &payer);
     let (deploy_approval_pda, _) =
         crate::find_deployment_approval_pda(&payer, &token_id, &destination_chain);
 
     let accounts = vec![
         AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(token_manager_pda, false),
-        AccountMeta::new_readonly(roles_pda, false),
         AccountMeta::new(deploy_approval_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),
     ];

--- a/solana/programs/axelar-solana-its/src/instruction.rs
+++ b/solana/programs/axelar-solana-its/src/instruction.rs
@@ -1252,17 +1252,35 @@ pub fn interchain_transfer(
     gas_config_pda: Pubkey,
     timestamp: i64,
 ) -> Result<Instruction, ProgramError> {
-    let (accounts, signing_pda_bump) = interchain_transfer_accounts(
-        payer,
-        source_account,
-        authority,
-        token_id,
-        mint,
-        token_program,
-        gas_service,
-        gas_config_pda,
-        timestamp,
-    )?;
+    let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
+    let (its_root_pda, _) = crate::find_its_root_pda(&gateway_root_pda);
+    let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
+    let flow_epoch = flow_limit::flow_epoch_with_timestamp(timestamp)?;
+    let (flow_slot_pda, _) = crate::find_flow_slot_pda(&token_manager_pda, flow_epoch);
+    let (authority, signer) = authority.map_or((token_manager_pda, false), |key| (key, true));
+    let token_manager_ata =
+        get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
+    let (call_contract_signing_pda, signing_pda_bump) =
+        axelar_solana_gateway::get_call_contract_signing_pda(ID);
+    
+    let accounts = vec![
+        AccountMeta::new_readonly(payer, true),
+        AccountMeta::new_readonly(authority, signer),
+        AccountMeta::new(source_account, false),
+        AccountMeta::new(mint, false),
+        AccountMeta::new_readonly(token_manager_pda, false),
+        AccountMeta::new(token_manager_ata, false),
+        AccountMeta::new_readonly(token_program, false),
+        AccountMeta::new(flow_slot_pda, false),
+        AccountMeta::new_readonly(gateway_root_pda, false),
+        AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
+        AccountMeta::new(gas_config_pda, false),
+        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(system_program::ID, false),
+        AccountMeta::new_readonly(its_root_pda, false),
+        AccountMeta::new_readonly(call_contract_signing_pda, false),
+        AccountMeta::new_readonly(ID, false),
+    ];
 
     let data = to_vec(&InterchainTokenServiceInstruction::InterchainTransfer {
         token_id,
@@ -1302,17 +1320,35 @@ pub fn call_contract_with_interchain_token(
     gas_config_pda: Pubkey,
     timestamp: i64,
 ) -> Result<Instruction, ProgramError> {
-    let (accounts, signing_pda_bump) = interchain_transfer_accounts(
-        payer,
-        source_account,
-        authority,
-        token_id,
-        mint,
-        token_program,
-        gas_service,
-        gas_config_pda,
-        timestamp,
-    )?;
+    let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
+    let (its_root_pda, _) = crate::find_its_root_pda(&gateway_root_pda);
+    let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
+    let flow_epoch = flow_limit::flow_epoch_with_timestamp(timestamp)?;
+    let (flow_slot_pda, _) = crate::find_flow_slot_pda(&token_manager_pda, flow_epoch);
+    let (authority, signer) = authority.map_or((token_manager_pda, false), |key| (key, true));
+    let token_manager_ata =
+        get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
+    let (call_contract_signing_pda, signing_pda_bump) =
+        axelar_solana_gateway::get_call_contract_signing_pda(ID);
+    
+    let accounts = vec![
+        AccountMeta::new_readonly(payer, true),
+        AccountMeta::new_readonly(authority, signer),
+        AccountMeta::new(source_account, false),
+        AccountMeta::new(mint, false),
+        AccountMeta::new_readonly(token_manager_pda, false),
+        AccountMeta::new(token_manager_ata, false),
+        AccountMeta::new_readonly(token_program, false),
+        AccountMeta::new(flow_slot_pda, false),
+        AccountMeta::new_readonly(gateway_root_pda, false),
+        AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
+        AccountMeta::new(gas_config_pda, false),
+        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(system_program::ID, false),
+        AccountMeta::new_readonly(its_root_pda, false),
+        AccountMeta::new_readonly(call_contract_signing_pda, false),
+        AccountMeta::new_readonly(ID, false),
+    ];
 
     let data = to_vec(
         &InterchainTokenServiceInstruction::CallContractWithInterchainToken {
@@ -1355,17 +1391,35 @@ pub fn call_contract_with_interchain_token_offchain_data(
     gas_config_pda: Pubkey,
     timestamp: i64,
 ) -> Result<(Instruction, Vec<u8>), ProgramError> {
-    let (accounts, signing_pda_bump) = interchain_transfer_accounts(
-        payer,
-        source_account,
-        authority,
-        token_id,
-        mint,
-        token_program,
-        gas_service,
-        gas_config_pda,
-        timestamp,
-    )?;
+    let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
+    let (its_root_pda, _) = crate::find_its_root_pda(&gateway_root_pda);
+    let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
+    let flow_epoch = flow_limit::flow_epoch_with_timestamp(timestamp)?;
+    let (flow_slot_pda, _) = crate::find_flow_slot_pda(&token_manager_pda, flow_epoch);
+    let (authority, signer) = authority.map_or((token_manager_pda, false), |key| (key, true));
+    let token_manager_ata =
+        get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
+    let (call_contract_signing_pda, signing_pda_bump) =
+        axelar_solana_gateway::get_call_contract_signing_pda(ID);
+    
+    let accounts = vec![
+        AccountMeta::new_readonly(payer, true),
+        AccountMeta::new_readonly(authority, signer),
+        AccountMeta::new(source_account, false),
+        AccountMeta::new(mint, false),
+        AccountMeta::new_readonly(token_manager_pda, false),
+        AccountMeta::new(token_manager_ata, false),
+        AccountMeta::new_readonly(token_program, false),
+        AccountMeta::new(flow_slot_pda, false),
+        AccountMeta::new_readonly(gateway_root_pda, false),
+        AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
+        AccountMeta::new(gas_config_pda, false),
+        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(system_program::ID, false),
+        AccountMeta::new_readonly(its_root_pda, false),
+        AccountMeta::new_readonly(call_contract_signing_pda, false),
+        AccountMeta::new_readonly(ID, false),
+    ];
 
     let payload = GMPPayload::SendToHub(SendToHub {
         payload: GMPPayload::InterchainTransfer(InterchainTransfer {
@@ -1406,51 +1460,6 @@ pub fn call_contract_with_interchain_token_offchain_data(
             data,
         },
         payload,
-    ))
-}
-
-fn interchain_transfer_accounts(
-    payer: Pubkey,
-    source_account: Pubkey,
-    authority: Option<Pubkey>,
-    token_id: [u8; 32],
-    mint: Pubkey,
-    token_program: Pubkey,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
-    timestamp: i64,
-) -> Result<(Vec<AccountMeta>, u8), ProgramError> {
-    let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
-    let (its_root_pda, _) = crate::find_its_root_pda(&gateway_root_pda);
-    let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let flow_epoch = flow_limit::flow_epoch_with_timestamp(timestamp)?;
-    let (flow_slot_pda, _) = crate::find_flow_slot_pda(&token_manager_pda, flow_epoch);
-    let (authority, signer) = authority.map_or((token_manager_pda, false), |key| (key, true));
-    let token_manager_ata =
-        get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
-    let (call_contract_signing_pda, signing_pda_bump) =
-        axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
-
-    Ok((
-        vec![
-            AccountMeta::new_readonly(payer, true),
-            AccountMeta::new_readonly(authority, signer),
-            AccountMeta::new(source_account, false),
-            AccountMeta::new(mint, false),
-            AccountMeta::new_readonly(token_manager_pda, false),
-            AccountMeta::new(token_manager_ata, false),
-            AccountMeta::new_readonly(token_program, false),
-            AccountMeta::new(flow_slot_pda, false),
-            AccountMeta::new_readonly(gateway_root_pda, false),
-            AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
-            AccountMeta::new(gas_config_pda, false),
-            AccountMeta::new_readonly(gas_service, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-            AccountMeta::new_readonly(its_root_pda, false),
-            AccountMeta::new_readonly(call_contract_signing_pda, false),
-            AccountMeta::new_readonly(crate::ID, false),
-        ],
-        signing_pda_bump,
     ))
 }
 

--- a/solana/programs/axelar-solana-its/src/processor/interchain_token.rs
+++ b/solana/programs/axelar-solana-its/src/processor/interchain_token.rs
@@ -140,6 +140,7 @@ pub(crate) fn process_inbound_deploy<'a>(
     decimals: u8,
 ) -> ProgramResult {
     let parsed_accounts = DeployInterchainTokenAccounts::from_account_info_slice(accounts, &())?;
+    msg!("Instruction: InboundDeploy");
     let its_root_pda_bump = InterchainTokenService::load(parsed_accounts.its_root_pda)?.bump;
     assert_valid_its_root_pda(
         parsed_accounts.its_root_pda,
@@ -216,6 +217,7 @@ pub(crate) fn process_outbound_deploy<'a>(
     let token_id = crate::interchain_token_id_internal(&salt);
     let mut outbound_message_accounts_index = OUTBOUND_MESSAGE_ACCOUNTS_INDEX;
 
+    msg!("Instruction: OutboundDeploy");
     let destination_minter = if let Some(destination_minter) = maybe_destination_minter {
         let minter = next_account_info(accounts_iter)?;
         let deploy_approval = next_account_info(accounts_iter)?;
@@ -223,6 +225,7 @@ pub(crate) fn process_outbound_deploy<'a>(
         let token_manager_account = next_account_info(accounts_iter)?;
         outbound_message_accounts_index = outbound_message_accounts_index.saturating_add(4);
 
+        msg!("Instruction: OutboundDeployMinter");
         ensure_roles(
             &crate::id(),
             token_manager_account,
@@ -514,6 +517,7 @@ pub(crate) fn approve_deploy_remote_interchain_token(
     let deploy_approval_account = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
 
+    msg!("Instruction: ApproveDeployRemoteInterchainToken");
     ensure_signer_roles(
         &crate::id(),
         token_manager_account,
@@ -557,6 +561,7 @@ pub(crate) fn revoke_deploy_remote_interchain_token(
     let payer = next_account_info(accounts_iter)?;
     let deploy_approval_account = next_account_info(accounts_iter)?;
 
+    msg!("Instruction: RevokeDeployRemoteInterchainToken");
     if !payer.is_signer {
         return Err(ProgramError::MissingRequiredSignature);
     }

--- a/solana/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/solana/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -213,7 +213,7 @@ pub(crate) fn process_outbound_transfer<'a>(
     let take_token_accounts = TakeTokenAccounts::from_account_info_slice(accounts, &())?;
     let (_other, outbound_message_accounts) = accounts.split_at(8);
     let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
-    
+
     msg!("Instruction: OutboundTransfer");
     let token_manager = TokenManager::load(take_token_accounts.token_manager_pda)?;
     assert_valid_token_manager_pda(

--- a/solana/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/solana/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -211,6 +211,10 @@ pub(crate) fn process_outbound_transfer<'a>(
     payload_hash: Option<[u8; 32]>,
 ) -> ProgramResult {
     let take_token_accounts = TakeTokenAccounts::from_account_info_slice(accounts, &())?;
+    let (_other, outbound_message_accounts) = accounts.split_at(8);
+    let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
+    
+    msg!("Instruction: OutboundTransfer");
     let token_manager = TokenManager::load(take_token_accounts.token_manager_pda)?;
     assert_valid_token_manager_pda(
         take_token_accounts.token_manager_pda,
@@ -232,9 +236,6 @@ pub(crate) fn process_outbound_transfer<'a>(
         amount: alloy_primitives::U256::from(amount),
         data: data.unwrap_or_default().into(),
     });
-
-    let (_other, outbound_message_accounts) = accounts.split_at(8);
-    let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
 
     gmp::process_outbound(
         take_token_accounts.payer,

--- a/solana/programs/axelar-solana-its/src/processor/link_token.rs
+++ b/solana/programs/axelar-solana-its/src/processor/link_token.rs
@@ -152,7 +152,7 @@ pub(crate) fn register_token_metadata<'a>(
         token_address: mint_account.key.to_bytes().into(),
         decimals: mint.decimals,
     });
-    
+
     gmp::process_outbound(
         payer,
         &gmp_accounts,
@@ -213,7 +213,7 @@ fn register_token<'a>(
     let metadata_account = metadata_account
         .first()
         .ok_or(ProgramError::NotEnoughAccountKeys)?;
-    
+
     msg!("Instruction: RegisterToken");
     match Metadata::from_bytes(&metadata_account.try_borrow_data()?) {
         Ok(metadata) => {

--- a/solana/programs/axelar-solana-its/src/processor/mod.rs
+++ b/solana/programs/axelar-solana-its/src/processor/mod.rs
@@ -178,7 +178,8 @@ pub fn process_instruction<'a>(
         ),
         InterchainTokenServiceInstruction::SetFlowLimit { flow_limit } => {
             let mut instruction_accounts = SetFlowLimitAccounts::try_from(accounts)?;
-
+            
+            msg!("Instruction: SetFlowLimit");
             ensure_signer_roles(
                 &crate::id(),
                 instruction_accounts.its_root_pda,
@@ -255,6 +256,7 @@ fn process_initialize(
     let operator = next_account_info(account_info_iter)?;
     let user_roles_account = next_account_info(account_info_iter)?;
 
+    msg!("Instruction: Initialize");
     // Check: System Program Account
     if !system_program::check_id(system_account.key) {
         return Err(ProgramError::IncorrectProgramId);
@@ -374,6 +376,7 @@ fn process_set_pause_status(accounts: &[AccountInfo<'_>], paused: bool) -> Progr
     let its_root_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
 
+    msg!("Instruction: SetPauseStatus");
     ensure_upgrade_authority(&crate::id(), payer, program_data_account)?;
     let mut its_root_config = InterchainTokenService::load(its_root_pda)?;
     assert_valid_its_root_pda(
@@ -395,6 +398,7 @@ fn process_set_trusted_chain(accounts: &[AccountInfo<'_>], chain_name: String) -
     let its_root_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
 
+    msg!("Instruction: SetTrustedChain");
     ensure_upgrade_authority(&crate::id(), payer, program_data_account)?;
     let mut its_root_config = InterchainTokenService::load(its_root_pda)?;
     assert_valid_its_root_pda(
@@ -417,6 +421,7 @@ fn process_remove_trusted_chain(accounts: &[AccountInfo<'_>], chain_name: &str) 
     let its_root_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
 
+    msg!("Instruction: RemoveTrustedChain");
     ensure_upgrade_authority(&crate::id(), payer, program_data_account)?;
     let mut its_root_config = InterchainTokenService::load(its_root_pda)?;
     assert_valid_its_root_pda(

--- a/solana/programs/axelar-solana-its/src/processor/mod.rs
+++ b/solana/programs/axelar-solana-its/src/processor/mod.rs
@@ -178,7 +178,7 @@ pub fn process_instruction<'a>(
         ),
         InterchainTokenServiceInstruction::SetFlowLimit { flow_limit } => {
             let mut instruction_accounts = SetFlowLimitAccounts::try_from(accounts)?;
-            
+
             msg!("Instruction: SetFlowLimit");
             ensure_signer_roles(
                 &crate::id(),


### PR DESCRIPTION
**Summary of changes**

Additional bindings for `its` are added with this PR. Corresponding tests have been provided to verify that proper data types and accounts are propagated on the `solana` side.

**Reviewer recommendations**

Go through the `README.md` inside the `solana/bindings` to deploy the program locally and verify that the bindings work.

**Ready-ready checklist**

To check the necessary changes that have been added:

- [ ] Rearranged instructions inside `instruction.rs` so that the unhandled are at the end. This way, enumeration in bindings is the same as the one in `solana`
- [ ] Removed function `interchain_transfer_accounts()` and added accounts directly into instructions so that `native-to-anchor` bindings generator properly parses instructions
- [ ] Added messages inside  solana `its` program to verify that data and accounts are properly propagated from `typescript` to `solana`
- [ ] Removed redundant accounts from `RevokeDeployRemoteInterchainToken` instruction
