### PR TITLE
fix: downgrade bytemuck derive

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Triggered by https://github.com/axelarnetwork/axelar-amplifier/pull/744#issuecomment-2741488412