### PR TITLE
chore: update proper types in tests

### DIFF
--- a/solana/bindings/generated/axelar-solana-gateway/src/coder/instructions.ts
+++ b/solana/bindings/generated/axelar-solana-gateway/src/coder/instructions.ts
@@ -175,6 +175,14 @@ function encodeVerifySignature({
   payloadMerkleRoot,
   verifierInfo,
 }: any): Buffer {
+  const signatureKey = Object.keys(verifierInfo.signature)[0];
+  const signatureValue = verifierInfo.signature[signatureKey];
+  verifierInfo.signature[signatureKey] = signatureValue['0'];
+
+  const signerPubKey = Object.keys(verifierInfo.leaf.signerPubkey)[0];
+  const signerPubKeyValue = verifierInfo.leaf.signerPubkey[signerPubKey];
+  verifierInfo.leaf.signerPubkey[signerPubKey] = signerPubKeyValue['0'];
+
   return encodeData(
     { verifySignature: { payloadMerkleRoot, verifierInfo } },
     1 +

--- a/solana/bindings/generated/tests/gateway.ts
+++ b/solana/bindings/generated/tests/gateway.ts
@@ -34,7 +34,7 @@ describe("Ping Gateway", () => {
                     domainSeparator: [4],
                     signingVerifierSet: [6],
                 },
-                proof: new Uint8Array(1),
+                proof: Buffer.from(new Uint8Array(1)),
             }, [1]).accounts({
             gatewayRootPda: payer.publicKey,
             payer: payer.publicKey,
@@ -81,7 +81,7 @@ describe("Ping Gateway", () => {
   it("CallContract", async () => {
     const payer = await getKeypairFromFile();
     try {
-        const tx = await program.methods.callContract("1", "2", new Uint8Array(2), 1).accounts({
+        const tx = await program.methods.callContract("1", "2", Buffer.from(new Uint8Array(2)), 1).accounts({
             senderProgram: payer.publicKey,
             senderCallContractPda: payer.publicKey,
             gatewayRootPda: payer.publicKey,
@@ -142,20 +142,24 @@ describe("Ping Gateway", () => {
         // Using BN from u64 and bigger numbers
         const tx = await program.methods.verifySignature([1], {
             signature: {
-                ecdsaRecoverable: [1],
+                ecdsaRecoverable: {
+                    0: [1]
+                },
             },
             leaf: {
                 nonce: new BN(1),
                 quorum: new BN(2),
                 signerPubkey: {
-                    secp256k1: [2],
+                    secp256k1: {
+                        0: [2]
+                    },
                 },
                 signerWeight: new BN(3),
                 position: 2,
                 setSize: 3,
                 domainSeparator: [3],
             },
-            merkleProof: new Uint8Array(3),
+            merkleProof: Buffer.from(new Uint8Array(3)),
         }).accounts({
             gatewayConfigPda: payer.publicKey,
             verificationSessionPda: payer.publicKey,
@@ -185,7 +189,7 @@ describe("Ping Gateway", () => {
     const payer = await getKeypairFromFile();
     try {
         const tx = await program.methods.writeMessagePayload(
-            new BN(1), new Uint8Array(2), [1, 2]
+            new BN(1), Buffer.from(new Uint8Array(2)), [1, 2]
         ).accounts({
             authority: payer.publicKey,
             gatewayRootPda: payer.publicKey,

--- a/solana/bindings/generated/tests/gateway.ts
+++ b/solana/bindings/generated/tests/gateway.ts
@@ -16,7 +16,6 @@ describe("Ping Gateway", () => {
   it("ApproveMessage", async () => {
     const payer = await getKeypairFromFile();
     try {
-        // VSCode might underline complex types, but this structure works
         const tx = await program.methods.approveMessage({
             leaf: {
                     message: {
@@ -138,8 +137,6 @@ describe("Ping Gateway", () => {
   it("VerifySignature", async () => {
     const payer = await getKeypairFromFile();
     try {
-        // VSCode might underline complex types, but this structure works
-        // Using BN from u64 and bigger numbers
         const tx = await program.methods.verifySignature([1], {
             signature: {
                 ecdsaRecoverable: {

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -294,7 +294,7 @@ describe("Ping ITS", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods.registerCustomToken(
-        [1, 2], {nativeInterchainToken: 1}, payer.publicKey
+        [1, 2], { mintBurn: {} }, payer.publicKey
       ).accounts({
         payer: payer.publicKey,
         tokenMetadataAccount: payer.publicKey,
@@ -320,7 +320,7 @@ describe("Ping ITS", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods.linkToken(
-          [1, 2], "chain", Buffer.from(new Uint8Array(2)), { mintBurn: 1 }, Buffer.from(new Uint8Array(3)), new BN(1), 2
+          [1, 2], "chain", Buffer.from(new Uint8Array(2)), { nativeInterchainToken: {} }, Buffer.from(new Uint8Array(3)), new BN(1), 2
       ).accounts({
         payer: payer.publicKey,
         tokenManagerPda: payer.publicKey,

--- a/solana/bindings/generated/tsconfig.json
+++ b/solana/bindings/generated/tsconfig.json
@@ -7,8 +7,5 @@
     "target": "es6",
     "esModuleInterop": true,
     "outDir": "dist"
-  },
-  "exclude": [
-    "tests"
-  ]
+  }
 }


### PR DESCRIPTION
**Summary of changes**

Types in tests have been updated so that IDEs don't produce underline errors.
They have been properly parsed on solana side before, but now they also are properly parsed on Typescript side.
Meaning that `pnpm install` is properly executed and produces no errors.

**Reviewer recommendations**

Go through `solana/bindings/README.md` and execute tests on local node.

**Ready-ready checklist**

- [ ] `pnpm install` produces no error
- [ ] No more type underlines in IDE
- [ ] Tests are passing
