### PR TITLE
feat: operator instruction bindings

### DIFF
--- a/solana/bindings/anchor_lib/axelar-solana-its.rs
+++ b/solana/bindings/anchor_lib/axelar-solana-its.rs
@@ -167,6 +167,13 @@ pub mod axelar_solana_its {
     pub fn set_flow_limit(ctx: Context<SetFlowLimit>, flow_limit: u64) -> Result<()> {
         Ok(())
     }
+
+    pub fn operator_transfer_operatorship(
+        ctx: Context<OperatorTransferOperatorship>,
+        inputs: RoleManagementInstructionInputs,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -490,6 +497,23 @@ pub struct SetFlowLimit<'info> {
     system_program: Program<'info, System>,
 }
 
+#[derive(Accounts)]
+pub struct OperatorTransferOperatorship<'info> {
+    gateway_root_pda: AccountInfo<'info>,
+    system_program: Program<'info, System>,
+    #[account(mut)]
+    payer: Signer<'info>,
+    payer_roles_account: AccountInfo<'info>,
+    resource: AccountInfo<'info>,
+    destination_user_account: AccountInfo<'info>,
+    destination_roles_account: AccountInfo<'info>,
+    #[account(mut)]
+    origin_user_account: AccountInfo<'info>,
+    origin_roles_account: AccountInfo<'info>,
+    #[account(mut)]
+    proposal_account: AccountInfo<'info>,
+}
+
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub enum Type {
     NativeInterchainToken,
@@ -497,4 +521,11 @@ pub enum Type {
     LockUnlock,
     LockUnlockFee,
     MintBurn,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct RoleManagementInstructionInputs {
+    pub roles: u8,
+    pub destination_roles_pda_bump: u8,
+    pub proposal_pda_bump: Option<u8>,
 }

--- a/solana/bindings/anchor_lib/axelar-solana-its.rs
+++ b/solana/bindings/anchor_lib/axelar-solana-its.rs
@@ -181,6 +181,13 @@ pub mod axelar_solana_its {
     ) -> Result<()> {
         Ok(())
     }
+
+    pub fn operator_accept_operatorship(
+        ctx: Context<Operator>,
+        inputs: RoleManagementInstructionInputs,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]

--- a/solana/bindings/anchor_lib/axelar-solana-its.rs
+++ b/solana/bindings/anchor_lib/axelar-solana-its.rs
@@ -539,7 +539,14 @@ pub enum Type {
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct RoleManagementInstructionInputs {
-    pub roles: u8,
+    pub roles: Roles,
     pub destination_roles_pda_bump: u8,
     pub proposal_pda_bump: Option<u8>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub enum Roles {
+    Minter = 1,
+    Operator = 2,
+    FlowLimiter = 4,
 }

--- a/solana/bindings/anchor_lib/axelar-solana-its.rs
+++ b/solana/bindings/anchor_lib/axelar-solana-its.rs
@@ -169,7 +169,14 @@ pub mod axelar_solana_its {
     }
 
     pub fn operator_transfer_operatorship(
-        ctx: Context<OperatorTransferOperatorship>,
+        ctx: Context<Operator>,
+        inputs: RoleManagementInstructionInputs,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn operator_propose_operatorship(
+        ctx: Context<Operator>,
         inputs: RoleManagementInstructionInputs,
     ) -> Result<()> {
         Ok(())
@@ -498,7 +505,7 @@ pub struct SetFlowLimit<'info> {
 }
 
 #[derive(Accounts)]
-pub struct OperatorTransferOperatorship<'info> {
+pub struct Operator<'info> {
     gateway_root_pda: AccountInfo<'info>,
     system_program: Program<'info, System>,
     #[account(mut)]

--- a/solana/bindings/generated/axelar-solana-its/idl.json
+++ b/solana/bindings/generated/axelar-solana-its/idl.json
@@ -1509,6 +1509,69 @@
           }
         }
       ]
+    },
+    {
+      "name": "operatorAcceptOperatorship",
+      "accounts": [
+        {
+          "name": "gatewayRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "payerRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "resource",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "destinationUserAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "destinationRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "originUserAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "originRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposalAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inputs",
+          "type": {
+            "defined": "RoleManagementInstructionInputs"
+          }
+        }
+      ]
     }
   ],
   "types": [

--- a/solana/bindings/generated/axelar-solana-its/idl.json
+++ b/solana/bindings/generated/axelar-solana-its/idl.json
@@ -1446,6 +1446,69 @@
           }
         }
       ]
+    },
+    {
+      "name": "operatorProposeOperatorship",
+      "accounts": [
+        {
+          "name": "gatewayRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "payerRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "resource",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "destinationUserAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "destinationRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "originUserAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "originRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposalAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inputs",
+          "type": {
+            "defined": "RoleManagementInstructionInputs"
+          }
+        }
+      ]
     }
   ],
   "types": [

--- a/solana/bindings/generated/axelar-solana-its/idl.json
+++ b/solana/bindings/generated/axelar-solana-its/idl.json
@@ -1582,7 +1582,9 @@
         "fields": [
           {
             "name": "roles",
-            "type": "u8"
+            "type": {
+              "defined": "Roles"
+            }
           },
           {
             "name": "destinationRolesPdaBump",
@@ -1616,6 +1618,23 @@
           },
           {
             "name": "MintBurn"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Roles",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Minter"
+          },
+          {
+            "name": "Operator"
+          },
+          {
+            "name": "FlowLimiter"
           }
         ]
       }

--- a/solana/bindings/generated/axelar-solana-its/idl.json
+++ b/solana/bindings/generated/axelar-solana-its/idl.json
@@ -1383,9 +1383,94 @@
           "type": "u64"
         }
       ]
+    },
+    {
+      "name": "operatorTransferOperatorship",
+      "accounts": [
+        {
+          "name": "gatewayRootPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "payerRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "resource",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "destinationUserAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "destinationRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "originUserAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "originRolesAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposalAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inputs",
+          "type": {
+            "defined": "RoleManagementInstructionInputs"
+          }
+        }
+      ]
     }
   ],
   "types": [
+    {
+      "name": "RoleManagementInstructionInputs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "roles",
+            "type": "u8"
+          },
+          {
+            "name": "destinationRolesPdaBump",
+            "type": "u8"
+          },
+          {
+            "name": "proposalPdaBump",
+            "type": {
+              "option": "u8"
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "Type",
       "type": {

--- a/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
@@ -61,6 +61,9 @@ export class AxelarSolanaItsInstructionCoder implements InstructionCoder {
       case "setFlowLimit": {
         return encodeSetFlowLimit(ix);
       }
+      case "operatorTransferOperatorship": {
+        return encodeOperatorTransferOperatorship(ix);
+      }
 
       default: {
         throw new Error(`Invalid instruction: ${ixName}`);
@@ -398,6 +401,13 @@ function encodeSetFlowLimit({ flowLimit }: any): Buffer {
   return encodeData({ setFlowLimit: { flowLimit } }, 1 + 8);
 }
 
+function encodeOperatorTransferOperatorship({ inputs }: any): Buffer {
+  return encodeData(
+    { operatorTransferOperatorship: { inputs } },
+    1 + 1 + 1 + 1 + (inputs.proposalPdaBump === null ? 0 : 1)
+  );
+}
+
 const LAYOUT = B.union(B.u8("instruction"));
 LAYOUT.addVariant(
   0,
@@ -549,6 +559,20 @@ LAYOUT.addVariant(
   "callContractWithInterchainTokenOffchainData"
 );
 LAYOUT.addVariant(17, B.struct([B.u64("flowLimit")]), "setFlowLimit");
+LAYOUT.addVariant(
+  18,
+  B.struct([
+    B.struct(
+      [
+        B.u8("roles"),
+        B.u8("destinationRolesPdaBump"),
+        B.option(B.u8(), "proposalPdaBump"),
+      ],
+      "inputs"
+    ),
+  ]),
+  "operatorTransferOperatorship"
+);
 
 function encodeData(ix: any, span: number): Buffer {
   const b = Buffer.alloc(span);

--- a/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
@@ -410,21 +410,60 @@ function encodeSetFlowLimit({ flowLimit }: any): Buffer {
 function encodeOperatorTransferOperatorship({ inputs }: any): Buffer {
   return encodeData(
     { operatorTransferOperatorship: { inputs } },
-    1 + 1 + 1 + 1 + (inputs.proposalPdaBump === null ? 0 : 1)
+    1 +
+      (() => {
+        switch (Object.keys(inputs.roles)[0]) {
+          case "minter":
+            return 1;
+          case "operator":
+            return 1;
+          case "flowLimiter":
+            return 1;
+        }
+      })() +
+      1 +
+      1 +
+      (inputs.proposalPdaBump === null ? 0 : 1)
   );
 }
 
 function encodeOperatorProposeOperatorship({ inputs }: any): Buffer {
   return encodeData(
     { operatorProposeOperatorship: { inputs } },
-    1 + 1 + 1 + 1 + (inputs.proposalPdaBump === null ? 0 : 1)
+    1 +
+      (() => {
+        switch (Object.keys(inputs.roles)[0]) {
+          case "minter":
+            return 1;
+          case "operator":
+            return 1;
+          case "flowLimiter":
+            return 1;
+        }
+      })() +
+      1 +
+      1 +
+      (inputs.proposalPdaBump === null ? 0 : 1)
   );
 }
 
 function encodeOperatorAcceptOperatorship({ inputs }: any): Buffer {
   return encodeData(
     { operatorAcceptOperatorship: { inputs } },
-    1 + 1 + 1 + 1 + (inputs.proposalPdaBump === null ? 0 : 1)
+    1 +
+      (() => {
+        switch (Object.keys(inputs.roles)[0]) {
+          case "minter":
+            return 1;
+          case "operator":
+            return 1;
+          case "flowLimiter":
+            return 1;
+        }
+      })() +
+      1 +
+      1 +
+      (inputs.proposalPdaBump === null ? 0 : 1)
   );
 }
 
@@ -584,7 +623,13 @@ LAYOUT.addVariant(
   B.struct([
     B.struct(
       [
-        B.u8("roles"),
+        ((p: string) => {
+          const U = B.union(B.u8("discriminator"), null, p);
+          U.addVariant(1, B.struct([]), "minter");
+          U.addVariant(2, B.struct([]), "operator");
+          U.addVariant(4, B.struct([]), "flowLimiter");
+          return U;
+        })("roles"),
         B.u8("destinationRolesPdaBump"),
         B.option(B.u8(), "proposalPdaBump"),
       ],
@@ -598,7 +643,13 @@ LAYOUT.addVariant(
   B.struct([
     B.struct(
       [
-        B.u8("roles"),
+        ((p: string) => {
+          const U = B.union(B.u8("discriminator"), null, p);
+          U.addVariant(1, B.struct([]), "minter");
+          U.addVariant(2, B.struct([]), "operator");
+          U.addVariant(4, B.struct([]), "flowLimiter");
+          return U;
+        })("roles"),
         B.u8("destinationRolesPdaBump"),
         B.option(B.u8(), "proposalPdaBump"),
       ],
@@ -612,7 +663,13 @@ LAYOUT.addVariant(
   B.struct([
     B.struct(
       [
-        B.u8("roles"),
+        ((p: string) => {
+          const U = B.union(B.u8("discriminator"), null, p);
+          U.addVariant(1, B.struct([]), "minter");
+          U.addVariant(2, B.struct([]), "operator");
+          U.addVariant(4, B.struct([]), "flowLimiter");
+          return U;
+        })("roles"),
         B.u8("destinationRolesPdaBump"),
         B.option(B.u8(), "proposalPdaBump"),
       ],

--- a/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
@@ -64,6 +64,9 @@ export class AxelarSolanaItsInstructionCoder implements InstructionCoder {
       case "operatorTransferOperatorship": {
         return encodeOperatorTransferOperatorship(ix);
       }
+      case "operatorProposeOperatorship": {
+        return encodeOperatorProposeOperatorship(ix);
+      }
 
       default: {
         throw new Error(`Invalid instruction: ${ixName}`);
@@ -408,6 +411,13 @@ function encodeOperatorTransferOperatorship({ inputs }: any): Buffer {
   );
 }
 
+function encodeOperatorProposeOperatorship({ inputs }: any): Buffer {
+  return encodeData(
+    { operatorProposeOperatorship: { inputs } },
+    1 + 1 + 1 + 1 + (inputs.proposalPdaBump === null ? 0 : 1)
+  );
+}
+
 const LAYOUT = B.union(B.u8("instruction"));
 LAYOUT.addVariant(
   0,
@@ -572,6 +582,20 @@ LAYOUT.addVariant(
     ),
   ]),
   "operatorTransferOperatorship"
+);
+LAYOUT.addVariant(
+  19,
+  B.struct([
+    B.struct(
+      [
+        B.u8("roles"),
+        B.u8("destinationRolesPdaBump"),
+        B.option(B.u8(), "proposalPdaBump"),
+      ],
+      "inputs"
+    ),
+  ]),
+  "operatorProposeOperatorship"
 );
 
 function encodeData(ix: any, span: number): Buffer {

--- a/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/coder/instructions.ts
@@ -67,6 +67,9 @@ export class AxelarSolanaItsInstructionCoder implements InstructionCoder {
       case "operatorProposeOperatorship": {
         return encodeOperatorProposeOperatorship(ix);
       }
+      case "operatorAcceptOperatorship": {
+        return encodeOperatorAcceptOperatorship(ix);
+      }
 
       default: {
         throw new Error(`Invalid instruction: ${ixName}`);
@@ -418,6 +421,13 @@ function encodeOperatorProposeOperatorship({ inputs }: any): Buffer {
   );
 }
 
+function encodeOperatorAcceptOperatorship({ inputs }: any): Buffer {
+  return encodeData(
+    { operatorAcceptOperatorship: { inputs } },
+    1 + 1 + 1 + 1 + (inputs.proposalPdaBump === null ? 0 : 1)
+  );
+}
+
 const LAYOUT = B.union(B.u8("instruction"));
 LAYOUT.addVariant(
   0,
@@ -596,6 +606,20 @@ LAYOUT.addVariant(
     ),
   ]),
   "operatorProposeOperatorship"
+);
+LAYOUT.addVariant(
+  20,
+  B.struct([
+    B.struct(
+      [
+        B.u8("roles"),
+        B.u8("destinationRolesPdaBump"),
+        B.option(B.u8(), "proposalPdaBump"),
+      ],
+      "inputs"
+    ),
+  ]),
+  "operatorAcceptOperatorship"
 );
 
 function encodeData(ix: any, span: number): Buffer {

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -1375,9 +1375,94 @@ type AxelarSolanaIts = {
           type: "u64";
         }
       ];
+    },
+    {
+      name: "operatorTransferOperatorship";
+      accounts: [
+        {
+          name: "gatewayRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "payer";
+          isMut: true;
+          isSigner: true;
+        },
+        {
+          name: "payerRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "resource";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "destinationUserAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "destinationRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "originUserAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "originRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "proposalAccount";
+          isMut: true;
+          isSigner: false;
+        }
+      ];
+      args: [
+        {
+          name: "inputs";
+          type: {
+            defined: "RoleManagementInstructionInputs";
+          };
+        }
+      ];
     }
   ];
   types: [
+    {
+      name: "RoleManagementInstructionInputs";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "roles";
+            type: "u8";
+          },
+          {
+            name: "destinationRolesPdaBump";
+            type: "u8";
+          },
+          {
+            name: "proposalPdaBump";
+            type: {
+              option: "u8";
+            };
+          }
+        ];
+      };
+    },
     {
       name: "Type";
       type: {
@@ -2757,8 +2842,93 @@ const IDL: AxelarSolanaIts = {
         },
       ],
     },
+    {
+      name: "operatorTransferOperatorship",
+      accounts: [
+        {
+          name: "gatewayRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "payer",
+          isMut: true,
+          isSigner: true,
+        },
+        {
+          name: "payerRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "resource",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "destinationUserAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "destinationRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "originUserAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "originRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "proposalAccount",
+          isMut: true,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "inputs",
+          type: {
+            defined: "RoleManagementInstructionInputs",
+          },
+        },
+      ],
+    },
   ],
   types: [
+    {
+      name: "RoleManagementInstructionInputs",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "roles",
+            type: "u8",
+          },
+          {
+            name: "destinationRolesPdaBump",
+            type: "u8",
+          },
+          {
+            name: "proposalPdaBump",
+            type: {
+              option: "u8",
+            },
+          },
+        ],
+      },
+    },
     {
       name: "Type",
       type: {

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -1438,6 +1438,69 @@ type AxelarSolanaIts = {
           };
         }
       ];
+    },
+    {
+      name: "operatorProposeOperatorship";
+      accounts: [
+        {
+          name: "gatewayRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "payer";
+          isMut: true;
+          isSigner: true;
+        },
+        {
+          name: "payerRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "resource";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "destinationUserAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "destinationRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "originUserAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "originRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "proposalAccount";
+          isMut: true;
+          isSigner: false;
+        }
+      ];
+      args: [
+        {
+          name: "inputs";
+          type: {
+            defined: "RoleManagementInstructionInputs";
+          };
+        }
+      ];
     }
   ];
   types: [
@@ -2844,6 +2907,69 @@ const IDL: AxelarSolanaIts = {
     },
     {
       name: "operatorTransferOperatorship",
+      accounts: [
+        {
+          name: "gatewayRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "payer",
+          isMut: true,
+          isSigner: true,
+        },
+        {
+          name: "payerRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "resource",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "destinationUserAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "destinationRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "originUserAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "originRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "proposalAccount",
+          isMut: true,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "inputs",
+          type: {
+            defined: "RoleManagementInstructionInputs",
+          },
+        },
+      ],
+    },
+    {
+      name: "operatorProposeOperatorship",
       accounts: [
         {
           name: "gatewayRootPda",

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -4,7 +4,7 @@ import { Program, AnchorProvider } from "@coral-xyz/anchor";
 import { AxelarSolanaItsCoder } from "./coder";
 
 export const AXELAR_SOLANA_ITS_PROGRAM_ID = new PublicKey(
-  "its2RSrgfKfQDkuxFhov4nPRw4Wy9i6e757beHvUXZQ"
+  "itsbPmAntHfec9PpLDoh9y3UiAEPT7DnzSvoJzdzZqd"
 );
 
 interface GetProgramParams {

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -1501,6 +1501,69 @@ type AxelarSolanaIts = {
           };
         }
       ];
+    },
+    {
+      name: "operatorAcceptOperatorship";
+      accounts: [
+        {
+          name: "gatewayRootPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "payer";
+          isMut: true;
+          isSigner: true;
+        },
+        {
+          name: "payerRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "resource";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "destinationUserAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "destinationRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "originUserAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "originRolesAccount";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "proposalAccount";
+          isMut: true;
+          isSigner: false;
+        }
+      ];
+      args: [
+        {
+          name: "inputs";
+          type: {
+            defined: "RoleManagementInstructionInputs";
+          };
+        }
+      ];
     }
   ];
   types: [
@@ -2970,6 +3033,69 @@ const IDL: AxelarSolanaIts = {
     },
     {
       name: "operatorProposeOperatorship",
+      accounts: [
+        {
+          name: "gatewayRootPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "payer",
+          isMut: true,
+          isSigner: true,
+        },
+        {
+          name: "payerRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "resource",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "destinationUserAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "destinationRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "originUserAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "originRolesAccount",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "proposalAccount",
+          isMut: true,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "inputs",
+          type: {
+            defined: "RoleManagementInstructionInputs",
+          },
+        },
+      ],
+    },
+    {
+      name: "operatorAcceptOperatorship",
       accounts: [
         {
           name: "gatewayRootPda",

--- a/solana/bindings/generated/axelar-solana-its/src/program.ts
+++ b/solana/bindings/generated/axelar-solana-its/src/program.ts
@@ -1574,7 +1574,9 @@ type AxelarSolanaIts = {
         fields: [
           {
             name: "roles";
-            type: "u8";
+            type: {
+              defined: "Roles";
+            };
           },
           {
             name: "destinationRolesPdaBump";
@@ -1608,6 +1610,23 @@ type AxelarSolanaIts = {
           },
           {
             name: "MintBurn";
+          }
+        ];
+      };
+    },
+    {
+      name: "Roles";
+      type: {
+        kind: "enum";
+        variants: [
+          {
+            name: "Minter";
+          },
+          {
+            name: "Operator";
+          },
+          {
+            name: "FlowLimiter";
           }
         ];
       };
@@ -3166,7 +3185,9 @@ const IDL: AxelarSolanaIts = {
         fields: [
           {
             name: "roles",
-            type: "u8",
+            type: {
+              defined: "Roles",
+            },
           },
           {
             name: "destinationRolesPdaBump",
@@ -3200,6 +3221,23 @@ const IDL: AxelarSolanaIts = {
           },
           {
             name: "MintBurn",
+          },
+        ],
+      },
+    },
+    {
+      name: "Roles",
+      type: {
+        kind: "enum",
+        variants: [
+          {
+            name: "Minter",
+          },
+          {
+            name: "Operator",
+          },
+          {
+            name: "FlowLimiter",
           },
         ],
       },

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -412,4 +412,28 @@ describe("Ping ITS", () => {
       processError(error, "SetFlowLimit");
     }
   })
+
+  it("TransferOperatorship", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+      const tx = await program.methods.operatorTransferOperatorship({
+        roles: 1,
+        destinationRolesPdaBump: 2,
+        proposalPdaBump: null
+      }).accounts({
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+        payer: payer.publicKey,
+        payerRolesAccount: payer.publicKey,
+        resource: payer.publicKey,
+        destinationUserAccount: payer.publicKey,
+        destinationRolesAccount: payer.publicKey,
+        originUserAccount: payer.publicKey,
+        originRolesAccount: payer.publicKey,
+        proposalAccount: payer.publicKey,
+      }).rpc();
+    } catch (error) {
+      processError(error, "TransferOperatorship");
+    }
+  })
 });

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -460,4 +460,28 @@ describe("Ping ITS", () => {
       processError(error, "Operator");
     }
   })
+
+  it("AcceptOperatorship", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+      const tx = await program.methods.operatorAcceptOperatorship({
+        roles: 2,
+        destinationRolesPdaBump: 2,
+        proposalPdaBump: null
+      }).accounts({
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+        payer: payer.publicKey,
+        payerRolesAccount: payer.publicKey,
+        resource: payer.publicKey,
+        destinationUserAccount: payer.publicKey,
+        destinationRolesAccount: payer.publicKey,
+        originUserAccount: payer.publicKey,
+        originRolesAccount: payer.publicKey,
+        proposalAccount: payer.publicKey,
+      }).rpc();
+    } catch (error) {
+      processError(error, "Operator");
+    }
+  })
 });

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -417,7 +417,7 @@ describe("Ping ITS", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods.operatorTransferOperatorship({
-        roles: 1,
+        roles: 2,
         destinationRolesPdaBump: 2,
         proposalPdaBump: null
       }).accounts({
@@ -433,7 +433,31 @@ describe("Ping ITS", () => {
         proposalAccount: payer.publicKey,
       }).rpc();
     } catch (error) {
-      processError(error, "TransferOperatorship");
+      processError(error, "Operator");
+    }
+  })
+
+  it("ProposeOperatorship", async () => {
+    const payer = await getKeypairFromFile();
+    try {
+      const tx = await program.methods.operatorProposeOperatorship({
+        roles: 2,
+        destinationRolesPdaBump: 2,
+        proposalPdaBump: null
+      }).accounts({
+        gatewayRootPda: payer.publicKey,
+        systemProgram: payer.publicKey,
+        payer: payer.publicKey,
+        payerRolesAccount: payer.publicKey,
+        resource: payer.publicKey,
+        destinationUserAccount: payer.publicKey,
+        destinationRolesAccount: payer.publicKey,
+        originUserAccount: payer.publicKey,
+        originRolesAccount: payer.publicKey,
+        proposalAccount: payer.publicKey,
+      }).rpc();
+    } catch (error) {
+      processError(error, "Operator");
     }
   })
 });

--- a/solana/bindings/generated/tests/its.ts
+++ b/solana/bindings/generated/tests/its.ts
@@ -417,7 +417,7 @@ describe("Ping ITS", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods.operatorTransferOperatorship({
-        roles: 2,
+        roles: { minter: {}},
         destinationRolesPdaBump: 2,
         proposalPdaBump: null
       }).accounts({
@@ -441,7 +441,7 @@ describe("Ping ITS", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods.operatorProposeOperatorship({
-        roles: 2,
+        roles: { operator: {}},
         destinationRolesPdaBump: 2,
         proposalPdaBump: null
       }).accounts({
@@ -465,7 +465,7 @@ describe("Ping ITS", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods.operatorAcceptOperatorship({
-        roles: 2,
+        roles: { flowLimiter: {}},
         destinationRolesPdaBump: 2,
         proposalPdaBump: null
       }).accounts({


### PR DESCRIPTION
**Summary of changes**

Underlying enum `OperatorInstruction` has been separated into multiple instructions. 

**Reviewer recommendations**

- [ ] All enum values are properly refactored
- [ ] Underlying new layer of checks in `processor/mod.rs` due to refactor
- [ ] `Roles` struct has been properly migrated as `enum` in bindings
- [ ] Tests are properly done
