### PR TITLE
feat: its events

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
 name = "axelar-solana-gas-service-events"
 version = "0.1.0"
 dependencies = [
+ "event-utils",
  "solana-program",
  "thiserror 1.0.69",
 ]
@@ -798,6 +799,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "ed25519-dalek 2.1.1",
+ "event-utils",
  "hex",
  "itertools 0.12.1",
  "lazy_static",
@@ -2809,6 +2811,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-utils"
+version = "0.1.0"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "evm-contracts-rs"
 version = "0.1.0"
 dependencies = [
@@ -3133,6 +3142,7 @@ dependencies = [
  "axelar-solana-gas-service-events",
  "axelar-solana-gateway",
  "base64 0.21.7",
+ "event-utils",
  "pretty_assertions",
  "solana-sdk",
  "test-log",

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -783,7 +783,6 @@ version = "0.1.0"
 dependencies = [
  "event-utils",
  "solana-program",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -893,7 +892,6 @@ dependencies = [
  "evm-contracts-test-suite",
  "interchain-token-transfer-gmp",
  "itertools 0.12.1",
- "keccak-const",
  "mpl-token-metadata",
  "program-utils",
  "role-management",
@@ -2817,7 +2815,6 @@ name = "event-macros"
 version = "0.1.0"
 dependencies = [
  "keccak-const",
- "proc-macro2",
  "quote",
  "syn 2.0.90",
 ]
@@ -2829,7 +2826,6 @@ dependencies = [
  "axelar-message-primitives",
  "base64 0.21.7",
  "event-macros",
- "keccak-const",
  "solana-program",
  "thiserror 1.0.69",
 ]

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -889,9 +889,11 @@ dependencies = [
  "axelar-solana-memo-program",
  "bitflags 2.6.0",
  "borsh 1.5.3",
+ "event-utils",
  "evm-contracts-test-suite",
  "interchain-token-transfer-gmp",
  "itertools 0.12.1",
+ "keccak-const",
  "mpl-token-metadata",
  "program-utils",
  "role-management",
@@ -2811,9 +2813,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-macros"
+version = "0.1.0"
+dependencies = [
+ "keccak-const",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "event-utils"
 version = "0.1.0"
 dependencies = [
+ "axelar-message-primitives",
+ "base64 0.21.7",
+ "event-macros",
+ "keccak-const",
+ "solana-program",
  "thiserror 1.0.69",
 ]
 
@@ -4159,6 +4176,12 @@ dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
+
+[[package]]
+name = "keccak-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
 
 [[package]]
 name = "kernel32-sys"

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -141,17 +141,18 @@ dummy-axelar-solana-gateway = { path = "programs/dummy-axelar-solana-gateway" }
 axelar-solana-governance = { path = "programs/axelar-solana-governance" }
 
 # helper crates
-gateway-event-stack = { path = "crates/gateway-event-stack" }
-axelar-solana-gas-service-events = { path = "crates/axelar-solana-gas-service-events" }
-axelar-solana-encoding = { path = "crates/axelar-solana-encoding" }
 axelar-executable = { path = "crates/axelar-executable" }
 axelar-message-primitives = { path = "helpers/axelar-message-primitives" }
+axelar-solana-encoding = { path = "crates/axelar-solana-encoding" }
+axelar-solana-gas-service-events = { path = "crates/axelar-solana-gas-service-events" }
 axelar-solana-gateway-test-fixtures = { path = "crates/axelar-solana-gateway-test-fixtures" }
+event-utils = { path = "crates/event-utils" }
 evm-contracts-rs = { path = "helpers/evm-contracts-rs" }
 evm-contracts-test-suite = { path = "helpers/evm-contracts-test-suite" }
+gateway-event-stack = { path = "crates/gateway-event-stack" }
+governance-gmp = { path = "helpers/governance-gmp" }
 interchain-token-transfer-gmp = { path = "helpers/interchain-token-transfer-gmp" }
 its-instruction-builder = { path = "helpers/its-instruction-builder" }
-governance-gmp = { path = "helpers/governance-gmp" }
 program-utils = { path = "helpers/program-utils" }
 role-management = { path = "helpers/role-management" }
 

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -130,6 +130,10 @@ xshell = "0.2"
 pretty_assertions = "1"
 udigest = { version = "0.2", features = ["derive"] }
 async-recursion = "1"
+keccak-const = "0.2.0"
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
 
 # solana programs
 axelar-solana-its = { path = "programs/axelar-solana-its" }
@@ -147,6 +151,7 @@ axelar-solana-encoding = { path = "crates/axelar-solana-encoding" }
 axelar-solana-gas-service-events = { path = "crates/axelar-solana-gas-service-events" }
 axelar-solana-gateway-test-fixtures = { path = "crates/axelar-solana-gateway-test-fixtures" }
 event-utils = { path = "crates/event-utils" }
+event-macros = { path = "crates/event-macros" }
 evm-contracts-rs = { path = "helpers/evm-contracts-rs" }
 evm-contracts-test-suite = { path = "helpers/evm-contracts-test-suite" }
 gateway-event-stack = { path = "crates/gateway-event-stack" }

--- a/solana/crates/axelar-solana-gas-service-events/Cargo.toml
+++ b/solana/crates/axelar-solana-gas-service-events/Cargo.toml
@@ -10,7 +10,6 @@ edition.workspace = true
 [dependencies]
 event-utils.workspace = true
 solana-program.workspace = true
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/solana/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/solana/crates/axelar-solana-gas-service-events/src/events.rs
@@ -2,7 +2,7 @@
 
 use solana_program::pubkey::Pubkey;
 
-use event_utils::{parse_u64_le, read_array, read_string, EventParseError};
+use event_utils::{read_array, read_string, read_u64, EventParseError};
 
 /// Even emitted by the Axelar Solana Gas service
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -77,7 +77,7 @@ impl NativeGasPaidForContractCallEvent {
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
-        let gas_fee_amount = parse_u64_le("gas_fee_amount", &gas_fee_amount_data)?;
+        let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
             config_pda,
@@ -123,7 +123,7 @@ impl NativeGasAddedEvent {
         let log_index_data = data
             .next()
             .ok_or(EventParseError::MissingData("log_index"))?;
-        let log_index = parse_u64_le("log_index", &log_index_data)?;
+        let log_index = read_u64("log_index", &log_index_data)?;
 
         let refund_address_data = data
             .next()
@@ -134,7 +134,7 @@ impl NativeGasAddedEvent {
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
-        let gas_fee_amount = parse_u64_le("gas_fee_amount", &gas_fee_amount_data)?;
+        let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
             config_pda,
@@ -178,7 +178,7 @@ impl NativeGasRefundedEvent {
         let log_index_data = data
             .next()
             .ok_or(EventParseError::MissingData("log_index"))?;
-        let log_index = parse_u64_le("log_index", &log_index_data)?;
+        let log_index = read_u64("log_index", &log_index_data)?;
 
         let receiver_data = data
             .next()
@@ -186,7 +186,7 @@ impl NativeGasRefundedEvent {
         let receiver = Pubkey::new_from_array(read_array::<32>("receiver", &receiver_data)?);
 
         let fees_data = data.next().ok_or(EventParseError::MissingData("fees"))?;
-        let fees = parse_u64_le("fees", &fees_data)?;
+        let fees = read_u64("fees", &fees_data)?;
 
         Ok(Self {
             tx_hash,
@@ -275,7 +275,7 @@ impl SplGasPaidForContractCallEvent {
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
-        let gas_fee_amount = parse_u64_le("gas_fee_amount", &gas_fee_amount_data)?;
+        let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
             config_pda,
@@ -345,7 +345,7 @@ impl SplGasAddedEvent {
         let log_index_data = data
             .next()
             .ok_or(EventParseError::MissingData("log_index"))?;
-        let log_index = parse_u64_le("log_index", &log_index_data)?;
+        let log_index = read_u64("log_index", &log_index_data)?;
 
         let refund_address_data = data
             .next()
@@ -356,7 +356,7 @@ impl SplGasAddedEvent {
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
-        let gas_fee_amount = parse_u64_le("gas_fee_amount", &gas_fee_amount_data)?;
+        let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
             config_pda,
@@ -424,7 +424,7 @@ impl SplGasRefundedEvent {
         let log_index_data = data
             .next()
             .ok_or(EventParseError::MissingData("log_index"))?;
-        let log_index = parse_u64_le("log_index", &log_index_data)?;
+        let log_index = read_u64("log_index", &log_index_data)?;
 
         let receiver_data = data
             .next()
@@ -432,7 +432,7 @@ impl SplGasRefundedEvent {
         let receiver = Pubkey::new_from_array(read_array::<32>("receiver", &receiver_data)?);
 
         let fees_data = data.next().ok_or(EventParseError::MissingData("fees"))?;
-        let fees = parse_u64_le("fees", &fees_data)?;
+        let fees = read_u64("fees", &fees_data)?;
 
         Ok(Self {
             config_pda_ata,

--- a/solana/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/solana/crates/axelar-solana-gas-service-events/src/events.rs
@@ -2,7 +2,7 @@
 
 use solana_program::pubkey::Pubkey;
 
-use crate::event_utils::{parse_u64_le, read_array, read_string, EventParseError};
+use event_utils::{parse_u64_le, read_array, read_string, EventParseError};
 
 /// Even emitted by the Axelar Solana Gas service
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/solana/crates/axelar-solana-gas-service-events/src/lib.rs
+++ b/solana/crates/axelar-solana-gas-service-events/src/lib.rs
@@ -1,5 +1,4 @@
 //! Axelar Solana Gas Service Events
 
 pub mod event_prefixes;
-pub mod event_utils;
 pub mod events;

--- a/solana/crates/event-macros/Cargo.toml
+++ b/solana/crates/event-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "event-utils"
+name = "event-macros"
 version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -7,13 +7,14 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[lib]
+proc-macro = true
+
 [dependencies]
-thiserror.workspace = true
-event-macros.workspace = true
+syn.workspace = true
+quote.workspace = true
+proc-macro2.workspace = true
 keccak-const.workspace = true
-solana-program.workspace = true
-base64.workspace = true
-axelar-message-primitives.workspace = true
 
 [lints]
 workspace = true

--- a/solana/crates/event-macros/Cargo.toml
+++ b/solana/crates/event-macros/Cargo.toml
@@ -13,5 +13,4 @@ proc-macro = true
 [dependencies]
 syn.workspace = true
 quote.workspace = true
-proc-macro2.workspace = true
 keccak-const.workspace = true

--- a/solana/crates/event-macros/Cargo.toml
+++ b/solana/crates/event-macros/Cargo.toml
@@ -15,6 +15,3 @@ syn.workspace = true
 quote.workspace = true
 proc-macro2.workspace = true
 keccak-const.workspace = true
-
-[lints]
-workspace = true

--- a/solana/crates/event-macros/src/lib.rs
+++ b/solana/crates/event-macros/src/lib.rs
@@ -201,17 +201,17 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
     });
 
     let deserialize_impl = quote! {
-        fn deserialize<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Box<Self>, ::event_utils::EventParseError> {
+        fn deserialize<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Self, ::event_utils::EventParseError> {
              #(#deserialize_steps)*
 
-             Ok(Box::new(Self {
+             Ok(Self {
                  #(#field_idents_for_struct),*
-             }))
+             })
         }
     };
 
     let try_from_log_impl = quote! {
-         fn try_from_log(log: &str) -> Result<Box<Self>, ::event_utils::EventParseError> {
+         fn try_from_log(log: &str) -> Result<Self, ::event_utils::EventParseError> {
              use ::std::convert::TryInto;
              use ::event_utils::base64::engine::Engine as _;
 

--- a/solana/crates/event-macros/src/lib.rs
+++ b/solana/crates/event-macros/src/lib.rs
@@ -96,13 +96,11 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
     let mut emit_slices = Vec::new();
     emit_slices.push(quote! { Self::DISC });
 
-    for field in fields.iter() {
+    for field in fields {
         let field_ident = field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        let slice_expr = if get_u8_array_size(ty).is_some() {
-            quote! { &self.#field_ident[..] }
-        } else if is_vec_u8(ty) {
+        let slice_expr = if get_u8_array_size(ty).is_some() || is_vec_u8(ty) {
             quote! { &self.#field_ident[..] }
         } else if let Some(type_name) = get_simple_type_ident_str(ty) {
             match type_name.as_str() {
@@ -115,7 +113,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
                 _ => {
                     return Error::new_spanned(
                         ty,
-                        format!("Unsupported simple type '{}' for emit.", type_name),
+                        format!("Unsupported simple type '{type_name}' for emit."),
                     )
                     .to_compile_error()
                     .into()
@@ -177,7 +175,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
                 _ => {
                     return Error::new_spanned(
                         ty,
-                        format!("Unsupported simple type '{}' for deserialize.", type_name),
+                        format!("Unsupported simple type '{type_name}' for deserialize."),
                     )
                     .to_compile_error()
                     .into()

--- a/solana/crates/event-macros/src/lib.rs
+++ b/solana/crates/event-macros/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(missing_docs)]
+//! This crate provides a procedural macro for deriving the [`event_utils::Event`] trait for structs.
+//!
+//! The `Event` is emitted and parsed differently compared to how Anchor does it, where the
+//! structures are serialized and deserialized with `Borsh`. Here we simply use `sol_log_data` to
+//! log each field as bytes.
 use keccak_const::Shake128;
 use proc_macro::TokenStream;
 use quote::quote;

--- a/solana/crates/event-macros/src/lib.rs
+++ b/solana/crates/event-macros/src/lib.rs
@@ -1,0 +1,269 @@
+#![allow(missing_docs)]
+use keccak_const::Shake128;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, Data, DeriveInput, Error, Fields, GenericArgument, PathArguments, Type,
+    TypeArray,
+};
+
+fn get_u8_array_size(ty: &Type) -> Option<usize> {
+    let Type::Array(TypeArray { elem, len, .. }) = ty else {
+        return None;
+    };
+    let Type::Path(type_path) = elem.as_ref() else {
+        return None;
+    };
+
+    if type_path.path.segments.len() == 1 && type_path.path.segments[0].ident == "u8" {
+        if let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(lit_int),
+            ..
+        }) = len
+        {
+            lit_int.base10_parse::<usize>().ok()
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+fn is_vec_u8(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        return false;
+    };
+    if segment.ident != "Vec" {
+        return false;
+    }
+    let PathArguments::AngleBracketed(ref args) = segment.arguments else {
+        return false;
+    };
+    if args.args.len() != 1 {
+        return false;
+    }
+    let GenericArgument::Type(ref inner_ty) = args.args[0] else {
+        return false;
+    };
+    let Type::Path(ref inner_path) = inner_ty else {
+        return false;
+    };
+    let segments = &inner_path.path.segments;
+    segments.len() == 1 && segments[0].ident == "u8"
+}
+
+fn get_simple_type_ident_str(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(ref type_path) if !type_path.path.segments.is_empty() => {
+            Some(type_path.path.segments.last().unwrap().ident.to_string())
+        }
+        _ => None,
+    }
+}
+
+#[proc_macro_derive(Event)]
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_ident = &input.ident;
+
+    let fields = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Named(f) => &f.named,
+            _ => {
+                return Error::new_spanned(
+                    &input.ident,
+                    "Event requires a struct with named fields",
+                )
+                .to_compile_error()
+                .into()
+            }
+        },
+        _ => {
+            return Error::new_spanned(&input.ident, "Event can only be derived for structs")
+                .to_compile_error()
+                .into()
+        }
+    };
+
+    let type_name_str = struct_ident.to_string();
+    let discriminant: [u8; 16] = Shake128::new().update(type_name_str.as_bytes()).finalize();
+    let discriminant_tokens = quote! { &[ #(#discriminant),* ] };
+
+    let mut emit_slices = Vec::new();
+    emit_slices.push(quote! { Self::DISC });
+
+    for field in fields.iter() {
+        let field_ident = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+
+        let slice_expr = if get_u8_array_size(ty).is_some() {
+            quote! { &self.#field_ident[..] }
+        } else if is_vec_u8(ty) {
+            quote! { &self.#field_ident[..] }
+        } else if let Some(type_name) = get_simple_type_ident_str(ty) {
+            match type_name.as_str() {
+                "Pubkey" => quote! { self.#field_ident.as_ref() },
+                "String" => quote! { self.#field_ident.as_bytes() },
+                "u8" | "u16" | "u32" | "u64" | "u128" | "i8" | "i16" | "i32" | "i64" | "i128"
+                | "bool" | "f32" | "f64" | "U256" => {
+                    quote! { &(self.#field_ident.to_le_bytes()[..]) }
+                }
+                _ => {
+                    return Error::new_spanned(
+                        ty,
+                        format!("Unsupported simple type '{}' for emit.", type_name),
+                    )
+                    .to_compile_error()
+                    .into()
+                }
+            }
+        } else {
+            return Error::new_spanned(ty, "Unsupported field type for emit.")
+                .to_compile_error()
+                .into();
+        };
+        emit_slices.push(slice_expr);
+    }
+
+    let emit_impl = quote! {
+        fn emit(&self) {
+            ::solana_program::log::sol_log_data(&[
+                #(#emit_slices),*
+            ]);
+        }
+    };
+
+    let mut deserialize_steps = Vec::new();
+    let mut field_idents_for_struct = Vec::new();
+
+    for field in fields.iter() {
+        let field_ident = field.ident.as_ref().unwrap();
+        field_idents_for_struct.push(field_ident.clone());
+        let field_name_str = field_ident.to_string();
+        let ty = &field.ty;
+
+        deserialize_steps.push(quote! {
+            let segment_data = data.next()
+                .ok_or(::event_utils::EventParseError::MissingData(#field_name_str))?;
+        });
+
+        // Call the appropriate `read_*` utility function from `event_utils`.
+        let parse_expr = if let Some(size) = get_u8_array_size(ty) {
+            quote! { ::event_utils::read_array::<#size>(#field_name_str, &segment_data)? }
+        } else if is_vec_u8(ty) {
+            quote! { segment_data }
+        } else if let Some(type_name) = get_simple_type_ident_str(ty) {
+            match type_name.as_str() {
+                "String" => quote! { ::event_utils::read_string(#field_name_str, segment_data)? },
+                "Pubkey" => quote! { ::event_utils::read_pubkey(#field_name_str, &segment_data)? },
+                "u8" => quote! { ::event_utils::read_u8(#field_name_str, &segment_data)? },
+                "u16" => quote! { ::event_utils::read_u16(#field_name_str, &segment_data)? },
+                "u32" => quote! { ::event_utils::read_u32(#field_name_str, &segment_data)? },
+                "u64" => quote! { ::event_utils::read_u64(#field_name_str, &segment_data)? },
+                "u128" => quote! { ::event_utils::read_u128(#field_name_str, &segment_data)? },
+                "i8" => quote! { ::event_utils::read_i8(#field_name_str, &segment_data)? },
+                "i16" => quote! { ::event_utils::read_i16(#field_name_str, &segment_data)? },
+                "i32" => quote! { ::event_utils::read_i32(#field_name_str, &segment_data)? },
+                "i64" => quote! { ::event_utils::read_i64(#field_name_str, &segment_data)? },
+                "i128" => quote! { ::event_utils::read_i128(#field_name_str, &segment_data)? },
+                "bool" => quote! { ::event_utils::read_bool(#field_name_str, &segment_data)? },
+                "f32" => quote! { ::event_utils::read_f32(#field_name_str, &segment_data)? },
+                "f64" => quote! { ::event_utils::read_f64(#field_name_str, &segment_data)? },
+                "U256" => quote! { ::event_utils::read_u256(#field_name_str, &segment_data)? },
+                _ => {
+                    return Error::new_spanned(
+                        ty,
+                        format!("Unsupported simple type '{}' for deserialize.", type_name),
+                    )
+                    .to_compile_error()
+                    .into()
+                }
+            }
+        } else {
+            return Error::new_spanned(ty, "Unsupported field type for deserialize.")
+                .to_compile_error()
+                .into();
+        };
+
+        deserialize_steps.push(quote! {
+            let #field_ident = #parse_expr;
+        });
+    }
+
+    deserialize_steps.push(quote! {
+        if data.next().is_some() {
+            return Err(::event_utils::EventParseError::Other("Trailing segments found after parsing"));
+        }
+    });
+
+    let deserialize_impl = quote! {
+        fn deserialize<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Box<Self>, ::event_utils::EventParseError> {
+             #(#deserialize_steps)*
+
+             Ok(Box::new(Self {
+                 #(#field_idents_for_struct),*
+             }))
+        }
+    };
+
+    let try_from_log_impl = quote! {
+         fn try_from_log(log: &str) -> Result<Box<Self>, ::event_utils::EventParseError> {
+             use ::std::convert::TryInto;
+             use ::event_utils::base64::engine::Engine as _;
+
+             const LOG_PREFIX_PROGRAM_DATA: &str = "Program data: ";
+
+             let data_part = if let Some(part) = log.strip_prefix(LOG_PREFIX_PROGRAM_DATA) {
+                 part
+             } else {
+                 return Err(::event_utils::EventParseError::Other("Log prefix mismatch"));
+             };
+
+             let segments: Result<Vec<Vec<u8>>, _> = data_part
+                 .split(' ')
+                 .filter(|s| !s.is_empty())
+                 .map(|s| ::event_utils::base64::engine::general_purpose::STANDARD.decode(s))
+                 .collect();
+
+             let mut decoded_segments = segments.map_err(|e| {
+                 ::event_utils::EventParseError::Other("Base64 decode error")
+             })?;
+
+             if decoded_segments.is_empty() {
+                 return Err(::event_utils::EventParseError::MissingData("discriminant"));
+             }
+
+             let discriminant_segment = decoded_segments.remove(0); // Take ownership
+             let discriminant_bytes: &[u8; 16] = discriminant_segment
+                 .as_slice()
+                 .try_into()
+                 .map_err(|_| ::event_utils::EventParseError::InvalidLength {
+                     field: "discriminant",
+                     expected: 16,
+                     actual: discriminant_segment.len(),
+                 })?;
+
+             if discriminant_bytes != Self::DISC {
+                 return Err(::event_utils::EventParseError::Other("Discriminant mismatch"));
+             }
+
+             Self::deserialize(decoded_segments.into_iter())
+         }
+    };
+
+    let expanded = quote! {
+        impl ::event_utils::Event for #struct_ident {
+            const DISC: &'static [u8; 16] = #discriminant_tokens;
+
+            #emit_impl
+            #try_from_log_impl
+            #deserialize_impl
+        }
+    };
+
+    expanded.into()
+}

--- a/solana/crates/event-utils/Cargo.toml
+++ b/solana/crates/event-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "axelar-solana-gas-service-events"
+name = "event-utils"
 version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -8,8 +8,6 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-event-utils.workspace = true
-solana-program.workspace = true
 thiserror.workspace = true
 
 [lints]

--- a/solana/crates/event-utils/Cargo.toml
+++ b/solana/crates/event-utils/Cargo.toml
@@ -10,7 +10,6 @@ edition.workspace = true
 [dependencies]
 thiserror.workspace = true
 event-macros.workspace = true
-keccak-const.workspace = true
 solana-program.workspace = true
 base64.workspace = true
 axelar-message-primitives.workspace = true

--- a/solana/crates/event-utils/src/lib.rs
+++ b/solana/crates/event-utils/src/lib.rs
@@ -1,4 +1,15 @@
-//! Utilities for parsing events emitted by axelar-solana programs
+//! This crate provides the `Event` trait to be used by Solana programs.
+//! It also provides utility functions to read data from the decoded logs emitted by the program.
+//!
+//! This crate should be used together with the `event-macros` crate, which provides a derive macro
+//! to implement the [`Event`] trait for compoatible structs.
+//!
+//! The `Event` is emitted and parsed differently compared to how Anchor does it, where the
+//! structures are serialized and deserialized with `Borsh`. Here we simply use `sol_log_data` to
+//! log each field as bytes, `sol_log_data` then logs these bytes as base64 encoded strings.
+//!
+//! All programs within the `solana-axelar` integration are encourage to use this crate to emit
+//! events as JavaScript utilities are also provided to parse them from logs.
 use axelar_message_primitives::U256;
 use solana_program::pubkey::Pubkey;
 

--- a/solana/crates/event-utils/src/lib.rs
+++ b/solana/crates/event-utils/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(missing_docs)]
 //! Utilities for parsing events emitted by axelar-solana programs
 use axelar_message_primitives::U256;
 use solana_program::pubkey::Pubkey;
@@ -6,20 +5,31 @@ use solana_program::pubkey::Pubkey;
 pub use base64;
 pub use event_macros::*;
 
-type Disc = [u8; 16];
+/// Trait for structs that represent events which can be emitted and deserialized from Solana logs.
 pub trait Event {
-    const DISC: &'static Disc;
+    /// Discriminator associated with this event type.
+    const DISC: &'static [u8; 16];
 
     /// Emits the event data using `sol_log_data`
     fn emit(&self);
 
     /// Tries to parses an event of this type from a log message string.
+    ///
+    /// # Errors
+    ///
+    /// In case the event could not be parsed from the log message.
     fn try_from_log(log: &str) -> Result<Self, EventParseError>
     where
         Self: Sized;
 
     /// Parses an event of this type from combined, decoded log data bytes.
     /// Assumes the discriminant has *already been checked* by the caller.
+    ///
+    ///
+    /// # Errors
+    ///
+    /// In case the iterator doesn't yield the expected fields or the data present cannot be
+    /// deserialized into the expected fields.
     fn deserialize<I: Iterator<Item = Vec<u8>>>(data: I) -> Result<Self, EventParseError>
     where
         Self: Sized;
@@ -63,17 +73,14 @@ pub enum EventParseError {
 }
 
 /// Tries to read a fixed-size array from the provided data slice.
+///
+/// # Errors
+///
+/// In case the size of `data` doesn't match the expected array size.
 pub fn read_array<const N: usize>(
     field: &'static str,
     data: &[u8],
 ) -> Result<[u8; N], EventParseError> {
-    if data.len() != N {
-        return Err(EventParseError::InvalidLength {
-            field,
-            expected: N,
-            actual: data.len(),
-        });
-    }
     let array = data
         .try_into()
         .map_err(|_err| EventParseError::InvalidLength {
@@ -81,127 +88,93 @@ pub fn read_array<const N: usize>(
             expected: N,
             actual: data.len(),
         })?;
+
     Ok(array)
 }
 
-/// Tries to read a string from the provided data vector.
+/// Tries to read a [`String`] from the provided data vector.
+///
+/// # Errors
+///
+/// In case the data cannot be converted into a valid UTF-8 string.
 pub fn read_string(field: &'static str, data: Vec<u8>) -> Result<String, EventParseError> {
     String::from_utf8(data).map_err(|err| EventParseError::InvalidUtf8 { field, source: err })
 }
 
-pub fn read_u8(field: &'static str, data: &[u8]) -> Result<u8, EventParseError> {
-    if data.len() != 1 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(data[0])
-}
-
-pub fn read_u16(field: &'static str, data: &[u8]) -> Result<u16, EventParseError> {
-    if data.len() != 2 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(u16::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_u32(field: &'static str, data: &[u8]) -> Result<u32, EventParseError> {
-    if data.len() != 4 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(u32::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-/// Tries to read a u64 from the provided data slice.
-#[allow(clippy::little_endian_bytes)]
-pub fn read_u64(field: &'static str, data: &[u8]) -> Result<u64, EventParseError> {
-    if data.len() != 8 {
-        return Err(EventParseError::InvalidData(field));
-    }
-
-    Ok(u64::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_u128(field: &'static str, data: &[u8]) -> Result<u128, EventParseError> {
-    if data.len() != 16 {
-        return Err(EventParseError::InvalidData(field));
-    }
-
-    Ok(u128::from_le_bytes(
-        data.try_into().expect("length checked"),
-    ))
-}
-
-pub fn read_i8(field: &'static str, data: &[u8]) -> Result<i8, EventParseError> {
-    if data.len() != 1 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(i8::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_i16(field: &'static str, data: &[u8]) -> Result<i16, EventParseError> {
-    if data.len() != 2 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(i16::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_i32(field: &'static str, data: &[u8]) -> Result<i32, EventParseError> {
-    if data.len() != 4 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(i32::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_i64(field: &'static str, data: &[u8]) -> Result<i64, EventParseError> {
-    if data.len() != 8 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(i64::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_i128(field: &'static str, data: &[u8]) -> Result<i128, EventParseError> {
-    if data.len() != 16 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(i128::from_le_bytes(
-        data.try_into().expect("length checked"),
-    ))
-}
-
+/// Tries to read a [`Pubkey`] from the provided data slice.
+///
+/// # Errors
+///
+/// In case the size of `data` doesn't match the expected length of a [`Pubkey`].
 pub fn read_pubkey(field: &'static str, data: &[u8]) -> Result<Pubkey, EventParseError> {
-    if data.len() != 32 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(Pubkey::new_from_array(
-        data.try_into().expect("length checked"),
-    ))
+    let bytes = data
+        .try_into()
+        .map_err(|_err| EventParseError::InvalidLength {
+            field,
+            expected: 32,
+            actual: data.len(),
+        })?;
+
+    Ok(Pubkey::new_from_array(bytes))
 }
 
+/// Tries to read a [`Vec<u8>`] from the provided data slice.
+///
+/// # Errors
+///
+/// In case the size of `data` doesn't match the expected length of a [`bool`].
 pub fn read_bool(field: &'static str, data: &[u8]) -> Result<bool, EventParseError> {
     if data.len() != 1 {
         return Err(EventParseError::InvalidData(field));
     }
-    Ok(data[0] != 0)
+
+    let byte = *data.first().ok_or(EventParseError::InvalidLength {
+        field,
+        expected: 1,
+        actual: data.len(),
+    })?;
+
+    Ok(byte != 0)
 }
 
-pub fn read_f32(field: &'static str, data: &[u8]) -> Result<f32, EventParseError> {
-    if data.len() != 4 {
-        return Err(EventParseError::InvalidData(field));
+macro_rules! make_read_functions {
+    ( $( ($fn_name:ident, $ty:ty) ),* $(,)? ) => {
+        $(
+            /// Tries to read a fixed-size value from the provided data slice.
+            ///
+            /// # Errors
+            ///
+            /// In case the data cannot be converted into the specified type.
+            #[allow(clippy::little_endian_bytes)]
+            pub fn $fn_name(field: &'static str, data: &[u8]) -> Result<$ty, EventParseError> {
+                const SIZE: usize = core::mem::size_of::<$ty>();
+
+                let bytes: [u8; SIZE] = data.try_into().map_err(|_err| {
+                    EventParseError::InvalidLength {
+                        field,
+                        expected: SIZE,
+                        actual: data.len(),
+                    }
+                })?;
+
+                Ok(<$ty>::from_le_bytes(bytes))
+            }
+        )*
     }
-    Ok(f32::from_le_bytes(data.try_into().expect("length checked")))
 }
 
-pub fn read_f64(field: &'static str, data: &[u8]) -> Result<f64, EventParseError> {
-    if data.len() != 8 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(f64::from_le_bytes(data.try_into().expect("length checked")))
-}
-
-pub fn read_u256(field: &'static str, data: &[u8]) -> Result<U256, EventParseError> {
-    if data.len() != 32 {
-        return Err(EventParseError::InvalidData(field));
-    }
-    Ok(U256::from_le_bytes(
-        data.try_into().expect("length checked"),
-    ))
+make_read_functions! {
+    (read_u8, u8),
+    (read_u16, u16),
+    (read_u32, u32),
+    (read_u64, u64),
+    (read_u128, u128),
+    (read_i8, i8),
+    (read_i16, i16),
+    (read_i32, i32),
+    (read_i64, i64),
+    (read_i128, i128),
+    (read_f32, f32),
+    (read_f64, f64),
+    (read_u256, U256),
 }

--- a/solana/crates/event-utils/src/lib.rs
+++ b/solana/crates/event-utils/src/lib.rs
@@ -1,4 +1,4 @@
-//! Utilities for parsing events emitted by the `GasService` program.
+//! Utilities for parsing events emitted by axelar-solana programs
 
 /// Errors that may occur while parsing a `MessageEvent`.
 #[derive(Debug, thiserror::Error)]
@@ -37,7 +37,8 @@ pub enum EventParseError {
     Other(&'static str),
 }
 
-pub(crate) fn read_array<const N: usize>(
+/// Tries to read a fixed-size array from the provided data slice.
+pub fn read_array<const N: usize>(
     field: &'static str,
     data: &[u8],
 ) -> Result<[u8; N], EventParseError> {
@@ -58,12 +59,14 @@ pub(crate) fn read_array<const N: usize>(
     Ok(array)
 }
 
-pub(crate) fn read_string(field: &'static str, data: Vec<u8>) -> Result<String, EventParseError> {
+/// Tries to read a string from the provided data vector.
+pub fn read_string(field: &'static str, data: Vec<u8>) -> Result<String, EventParseError> {
     String::from_utf8(data).map_err(|err| EventParseError::InvalidUtf8 { field, source: err })
 }
 
+/// Tries to read a u64 from the provided data slice.
 #[allow(clippy::little_endian_bytes)]
-pub(crate) fn parse_u64_le(field: &'static str, data: &[u8]) -> Result<u64, EventParseError> {
+pub fn parse_u64_le(field: &'static str, data: &[u8]) -> Result<u64, EventParseError> {
     if data.len() != 8 {
         return Err(EventParseError::InvalidData(field));
     }

--- a/solana/crates/event-utils/src/lib.rs
+++ b/solana/crates/event-utils/src/lib.rs
@@ -14,11 +14,15 @@ pub trait Event {
     fn emit(&self);
 
     /// Tries to parses an event of this type from a log message string.
-    fn try_from_log(log: &str) -> Result<Box<Self>, EventParseError>;
+    fn try_from_log(log: &str) -> Result<Self, EventParseError>
+    where
+        Self: Sized;
 
     /// Parses an event of this type from combined, decoded log data bytes.
     /// Assumes the discriminant has *already been checked* by the caller.
-    fn deserialize<I: Iterator<Item = Vec<u8>>>(data: I) -> Result<Box<Self>, EventParseError>;
+    fn deserialize<I: Iterator<Item = Vec<u8>>>(data: I) -> Result<Self, EventParseError>
+    where
+        Self: Sized;
 }
 
 /// Errors that may occur while parsing a `MessageEvent`.

--- a/solana/crates/gateway-event-stack/Cargo.toml
+++ b/solana/crates/gateway-event-stack/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 [dependencies]
 axelar-solana-gateway.workspace = true
 axelar-solana-gas-service-events.workspace = true
+event-utils.workspace = true
 tracing.workspace = true
 solana-sdk.workspace = true
 base64.workspace = true

--- a/solana/crates/gateway-event-stack/src/lib.rs
+++ b/solana/crates/gateway-event-stack/src/lib.rs
@@ -115,14 +115,12 @@ pub fn decode_base64(input: &str) -> Option<Vec<u8>> {
 ///
 /// - if the discrimintant for the event is not present
 /// - if the event was detected via the discriminant but the data does not match the discriminant type
-pub fn parse_gateway_logs<T>(
-    log: &T,
-) -> Result<GatewayEvent, axelar_solana_gateway::processor::EventParseError>
+pub fn parse_gateway_logs<T>(log: &T) -> Result<GatewayEvent, event_utils::EventParseError>
 where
     T: AsRef<str>,
 {
     use axelar_solana_gateway::event_prefixes::*;
-    use axelar_solana_gateway::processor::EventParseError;
+    use event_utils::EventParseError;
 
     let mut logs = log
         .as_ref()
@@ -180,18 +178,16 @@ where
 ///
 /// - if the discrimintant for the event is not present
 /// - if the event was detected via the discriminant but the data does not match the discriminant type
-pub fn parse_gas_service_log<T>(
-    log: &T,
-) -> Result<GasServiceEvent, axelar_solana_gas_service_events::event_utils::EventParseError>
+pub fn parse_gas_service_log<T>(log: &T) -> Result<GasServiceEvent, event_utils::EventParseError>
 where
     T: AsRef<str>,
 {
     use axelar_solana_gas_service_events::event_prefixes::*;
-    use axelar_solana_gas_service_events::event_utils::EventParseError;
     use axelar_solana_gas_service_events::events::{
         NativeGasAddedEvent, NativeGasPaidForContractCallEvent, NativeGasRefundedEvent,
         SplGasAddedEvent, SplGasPaidForContractCallEvent, SplGasRefundedEvent,
     };
+    use event_utils::EventParseError;
 
     let mut logs = log
         .as_ref()

--- a/solana/programs/axelar-solana-gateway/Cargo.toml
+++ b/solana/programs/axelar-solana-gateway/Cargo.toml
@@ -23,15 +23,16 @@ borsh.workspace = true
 bytemuck.workspace = true
 bytemuck_derive.workspace = true
 ed25519-dalek.workspace = true
+event-utils.workspace = true
 hex.workspace = true
 itertools.workspace = true
 libsecp256k1.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
 program-utils.workspace = true
+role-management.workspace = true
 solana-program.workspace = true
 thiserror.workspace = true
-role-management.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/solana/programs/axelar-solana-gateway/src/processor/call_contract.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/call_contract.rs
@@ -1,3 +1,4 @@
+use event_utils::{read_array, read_string, EventParseError};
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
@@ -6,7 +7,6 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::{bpf_loader, bpf_loader_upgradeable};
 
-use super::event_utils::{read_array, read_string, EventParseError};
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::GatewayConfig;

--- a/solana/programs/axelar-solana-gateway/src/processor/call_contract_offchain_data.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/call_contract_offchain_data.rs
@@ -1,3 +1,4 @@
+use event_utils::{read_array, read_string, EventParseError};
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
@@ -6,7 +7,6 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::{bpf_loader, bpf_loader_upgradeable};
 
-use super::event_utils::{read_array, read_string, EventParseError};
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::GatewayConfig;

--- a/solana/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
@@ -3,6 +3,7 @@ use core::mem::size_of;
 
 use axelar_message_primitives::U256;
 use axelar_solana_encoding::hasher::SolanaSyscallHasher;
+use event_utils::{read_array, EventParseError};
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
@@ -11,7 +12,6 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::Sysvar;
 
-use super::event_utils::{read_array, EventParseError};
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::signature_verification_pda::SignatureVerificationSessionData;

--- a/solana/programs/axelar-solana-gateway/src/processor/transfer_operatorship.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/transfer_operatorship.rs
@@ -1,3 +1,4 @@
+use event_utils::{read_array, EventParseError};
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
@@ -5,7 +6,6 @@ use solana_program::entrypoint::ProgramResult;
 use solana_program::log::sol_log_data;
 use solana_program::pubkey::Pubkey;
 
-use super::event_utils::{read_array, EventParseError};
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::GatewayConfig;

--- a/solana/programs/axelar-solana-gateway/src/processor/validate_message.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/validate_message.rs
@@ -3,6 +3,7 @@ use core::str::FromStr;
 use axelar_solana_encoding::hasher::SolanaSyscallHasher;
 use axelar_solana_encoding::types::messages::Message;
 use axelar_solana_encoding::LeafHash;
+use event_utils::{read_array, read_string, EventParseError};
 use program_utils::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::log::sol_log_data;
@@ -10,7 +11,6 @@ use solana_program::msg;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 
-use super::event_utils::{read_array, read_string, EventParseError};
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::incoming_message::{command_id, IncomingMessage, MessageStatus};

--- a/solana/programs/axelar-solana-its/Cargo.toml
+++ b/solana/programs/axelar-solana-its/Cargo.toml
@@ -32,7 +32,6 @@ solana-program.workspace = true
 spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint", "serde-traits"] }
 typed-builder.workspace = true
-keccak-const.workspace = true
 event-utils.workspace = true
 
 [dev-dependencies]

--- a/solana/programs/axelar-solana-its/Cargo.toml
+++ b/solana/programs/axelar-solana-its/Cargo.toml
@@ -32,6 +32,8 @@ solana-program.workspace = true
 spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint", "serde-traits"] }
 typed-builder.workspace = true
+keccak-const.workspace = true
+event-utils.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/solana/programs/axelar-solana-its/src/event.rs
+++ b/solana/programs/axelar-solana-its/src/event.rs
@@ -1,0 +1,126 @@
+#![allow(missing_docs)]
+use event_utils::*;
+use solana_program::pubkey::Pubkey;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct InterchainTransfer {
+    pub token_id: [u8; 32],
+    pub source_address: Pubkey,
+    pub destination_chain: String,
+    pub destination_address: Vec<u8>,
+    pub amount: u64,
+    pub data_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct InterchainTransferReceived {
+    pub command_id: [u8; 32],
+    pub token_id: [u8; 32],
+    pub source_chain: String,
+    pub source_address: Vec<u8>,
+    pub destination_address: Pubkey,
+    pub amount: u64,
+    pub data_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct TokenMetadataRegistered {
+    pub token_address: Pubkey,
+    pub decimals: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct LinkTokenStarted {
+    pub token_id: [u8; 32],
+    pub destination_chain: String,
+    pub source_token_address: Pubkey,
+    pub destination_token_address: Vec<u8>,
+    pub token_manager_type: u8,
+    pub params: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct InterchainTokenDeploymentStarted {
+    pub token_id: [u8; 32],
+    pub token_name: String,
+    pub token_symbol: String,
+    pub token_decimals: u8,
+    pub minter: Vec<u8>,
+    pub destination_chain: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct TokenManagerDeployed {
+    pub token_id: [u8; 32],
+    pub token_manager: Pubkey,
+    pub token_manager_type: u8,
+    pub params: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct InterchainTokenDeployed {
+    pub token_id: [u8; 32],
+    pub token_address: Pubkey,
+    pub minter: Pubkey,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct InterchainTokenIdClaimed {
+    pub token_id: [u8; 32],
+    pub deployer: Pubkey,
+    pub salt: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct DeployRemoteInterchainTokenApproval {
+    pub minter: Pubkey,
+    pub deployer: Pubkey,
+    pub token_id: [u8; 32],
+    pub destination_chain: String,
+    pub destination_minter: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct RevokeRemoteInterchainTokenApproval {
+    pub minter: Pubkey,
+    pub deployer: Pubkey,
+    pub token_id: [u8; 32],
+    pub destination_chain: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct FlowLimitSet {
+    pub token_id: [u8; 32],
+    pub operator: Pubkey,
+    pub flow_limit: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct TrustedChainSet {
+    pub chain_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Event)]
+pub struct TrustedChainRemoved {
+    pub chain_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum InterchainTokenServiceEvent {
+    InterchainTransfer(InterchainTransfer),
+    InterchainTransferReceived(InterchainTransferReceived),
+    TokenMetadataRegistered(TokenMetadataRegistered),
+    LinkTokenStarted(LinkTokenStarted),
+    InterchainTokenDeploymentStarted(InterchainTokenDeploymentStarted),
+    TokenManagerDeployed(TokenManagerDeployed),
+    InterchainTokenDeployed(InterchainTokenDeployed),
+    InterchainTokenIdClaimed(InterchainTokenIdClaimed),
+    DeployRemoteInterchainTokenApproval(DeployRemoteInterchainTokenApproval),
+    RevokeRemoteInterchainTokenApproval(RevokeRemoteInterchainTokenApproval),
+    FlowLimitSet(FlowLimitSet),
+    TrustedChainSet(TrustedChainSet),
+    TrustedChainRemoved(TrustedChainRemoved),
+}

--- a/solana/programs/axelar-solana-its/src/lib.rs
+++ b/solana/programs/axelar-solana-its/src/lib.rs
@@ -10,6 +10,7 @@ use solana_program::pubkey::Pubkey;
 use state::InterchainTokenService;
 
 mod entrypoint;
+pub mod event;
 pub mod executable;
 pub mod instruction;
 pub mod processor;

--- a/solana/programs/axelar-solana-its/src/processor/gmp.rs
+++ b/solana/programs/axelar-solana-its/src/processor/gmp.rs
@@ -83,6 +83,7 @@ pub(crate) fn process_inbound<'a>(
             payload_account,
             instruction_accounts,
             &transfer,
+            inner.source_chain,
         ),
         GMPPayload::DeployInterchainToken(deploy) => {
             let parsed_accounts =

--- a/solana/programs/axelar-solana-its/src/processor/link_token.rs
+++ b/solana/programs/axelar-solana-its/src/processor/link_token.rs
@@ -1,5 +1,6 @@
 //! This module is responsible for functions related to custom token linking
 
+use event_utils::Event as _;
 use interchain_token_transfer_gmp::{GMPPayload, LinkToken, RegisterTokenMetadata};
 use mpl_token_metadata::accounts::Metadata;
 use program_utils::BorshPda;
@@ -15,7 +16,10 @@ use spl_token_2022::state::Mint;
 use crate::processor::gmp::GmpAccounts;
 use crate::state::token_manager::TokenManager;
 use crate::state::{token_manager, InterchainTokenService};
-use crate::{assert_valid_its_root_pda, assert_valid_token_manager_pda, FromAccountInfoSlice};
+use crate::{
+    assert_its_not_paused, assert_valid_its_root_pda, assert_valid_token_manager_pda, event,
+    FromAccountInfoSlice,
+};
 
 use super::gmp;
 use super::token_manager::{DeployTokenManagerAccounts, DeployTokenManagerInternal};
@@ -91,7 +95,16 @@ pub(crate) fn process_outbound<'a>(
     let token_manager_account = next_account_info(accounts_iter)?;
 
     msg!("Instruction: ProcessOutbound");
-    let token_id = crate::linked_token_id(payer.key, &salt);
+    let deploy_salt = crate::linked_token_deployer_salt(payer.key, &salt);
+    let token_id = crate::interchain_token_id_internal(&deploy_salt);
+
+    event::InterchainTokenIdClaimed {
+        token_id,
+        deployer: *payer.key,
+        salt: deploy_salt,
+    }
+    .emit();
+
     let token_manager = TokenManager::load(token_manager_account)?;
 
     assert_valid_token_manager_pda(
@@ -101,6 +114,16 @@ pub(crate) fn process_outbound<'a>(
         token_manager.bump,
     )?;
 
+    let link_started_event = event::LinkTokenStarted {
+        token_id,
+        destination_chain,
+        source_token_address: token_manager.token_address,
+        destination_token_address,
+        token_manager_type: token_manager_type as u8,
+        params: link_params,
+    };
+    link_started_event.emit();
+
     let message = GMPPayload::LinkToken(LinkToken {
         selector: LinkToken::MESSAGE_TYPE_ID
             .try_into()
@@ -108,15 +131,15 @@ pub(crate) fn process_outbound<'a>(
         token_id: token_id.into(),
         token_manager_type: token_manager_type.into(),
         source_token_address: token_manager.token_address.to_bytes().into(),
-        destination_token_address: destination_token_address.into(),
-        link_params: link_params.into(),
+        destination_token_address: link_started_event.destination_token_address.into(),
+        link_params: link_started_event.params.into(),
     });
 
     gmp::process_outbound(
         payer,
         &gmp_accounts,
         &message,
-        destination_chain,
+        link_started_event.destination_chain,
         gas_value,
         signing_pda_bump,
         None,
@@ -152,6 +175,12 @@ pub(crate) fn register_token_metadata<'a>(
         token_address: mint_account.key.to_bytes().into(),
         decimals: mint.decimals,
     });
+
+    event::TokenMetadataRegistered {
+        token_address: *mint_account.key,
+        decimals: mint.decimals,
+    }
+    .emit();
 
     gmp::process_outbound(
         payer,
@@ -215,6 +244,10 @@ fn register_token<'a>(
         .ok_or(ProgramError::NotEnoughAccountKeys)?;
 
     msg!("Instruction: RegisterToken");
+
+    let its_config = InterchainTokenService::load(parsed_accounts.its_root_pda)?;
+    assert_its_not_paused(&its_config)?;
+
     match Metadata::from_bytes(&metadata_account.try_borrow_data()?) {
         Ok(metadata) => {
             if metadata.mint.ne(parsed_accounts.token_mint.key) {
@@ -229,25 +262,33 @@ fn register_token<'a>(
         }
     };
 
-    let (token_id, token_manager_type, operator) = match *registration {
+    let (token_manager_type, operator, deploy_salt) = match *registration {
         TokenRegistration::Canonical => (
-            crate::canonical_interchain_token_id(parsed_accounts.token_mint.key),
             token_manager::Type::LockUnlock,
             None,
+            crate::canonical_interchain_token_deploy_salt(parsed_accounts.token_mint.key),
         ),
         TokenRegistration::Custom {
             salt,
             token_manager_type,
             operator,
         } => (
-            crate::linked_token_id(payer.key, &salt),
             token_manager_type,
             operator,
+            crate::linked_token_deployer_salt(payer.key, &salt),
         ),
     };
 
+    let token_id = crate::interchain_token_id_internal(&deploy_salt);
     let (_, token_manager_pda_bump) =
         crate::find_token_manager_pda(parsed_accounts.its_root_pda.key, &token_id);
+
+    event::InterchainTokenIdClaimed {
+        token_id,
+        deployer: *payer.key,
+        salt: deploy_salt,
+    }
+    .emit();
 
     let deploy_token_manager = DeployTokenManagerInternal::new(
         token_manager_type,

--- a/solana/programs/axelar-solana-its/src/processor/link_token.rs
+++ b/solana/programs/axelar-solana-its/src/processor/link_token.rs
@@ -119,7 +119,7 @@ pub(crate) fn process_outbound<'a>(
         destination_chain,
         source_token_address: token_manager.token_address,
         destination_token_address,
-        token_manager_type: token_manager_type as u8,
+        token_manager_type: token_manager_type.into(),
         params: link_params,
     };
     link_started_event.emit();

--- a/solana/programs/axelar-solana-its/src/processor/mod.rs
+++ b/solana/programs/axelar-solana-its/src/processor/mod.rs
@@ -620,7 +620,7 @@ fn process_remove_trusted_chain(accounts: &[AccountInfo<'_>], chain_name: &str) 
     )?;
 
     event::TrustedChainRemoved {
-        chain_name: chain_name.to_string(),
+        chain_name: chain_name.to_owned(),
     }
     .emit();
 

--- a/solana/programs/axelar-solana-its/src/processor/mod.rs
+++ b/solana/programs/axelar-solana-its/src/processor/mod.rs
@@ -3,6 +3,7 @@
 use axelar_solana_gateway::error::GatewayError;
 use axelar_solana_gateway::state::GatewayConfig;
 use borsh::BorshDeserialize;
+use event_utils::Event as _;
 use interchain_token::process_mint;
 use program_utils::{BorshPda, BytemuckedPda, ValidPDA};
 use role_management::instructions::RoleManagementInstructionInputs;
@@ -22,7 +23,7 @@ use crate::instruction::InterchainTokenServiceInstruction;
 use crate::state::token_manager::TokenManager;
 use crate::state::InterchainTokenService;
 use crate::{
-    assert_valid_its_root_pda, assert_valid_token_manager_pda, check_program_account, Roles,
+    assert_valid_its_root_pda, assert_valid_token_manager_pda, check_program_account, event, Roles,
 };
 
 pub(crate) mod gmp;
@@ -78,8 +79,8 @@ pub fn process_instruction<'a>(
             accounts,
             deployer,
             salt,
-            &destination_chain,
-            &destination_minter,
+            destination_chain,
+            destination_minter,
         ),
         InterchainTokenServiceInstruction::RevokeDeployRemoteInterchainToken {
             deployer,
@@ -89,7 +90,7 @@ pub fn process_instruction<'a>(
             accounts,
             deployer,
             salt,
-            &destination_chain,
+            destination_chain,
         ),
         InterchainTokenServiceInstruction::RegisterCanonicalInterchainToken => {
             link_token::register_canonical_interchain_token(accounts)
@@ -593,7 +594,9 @@ fn process_set_trusted_chain(accounts: &[AccountInfo<'_>], chain_name: String) -
         its_root_config.bump,
     )?;
 
-    its_root_config.add_trusted_chain(chain_name);
+    let trusted_chain_event = event::TrustedChainSet { chain_name };
+    trusted_chain_event.emit();
+    its_root_config.add_trusted_chain(trusted_chain_event.chain_name);
     its_root_config.store(payer, its_root_pda, system_account)?;
 
     Ok(())
@@ -615,6 +618,11 @@ fn process_remove_trusted_chain(accounts: &[AccountInfo<'_>], chain_name: &str) 
         gateway_root_pda_account.key,
         its_root_config.bump,
     )?;
+
+    event::TrustedChainRemoved {
+        chain_name: chain_name.to_string(),
+    }
+    .emit();
 
     its_root_config.remove_trusted_chain(chain_name);
     its_root_config.store(payer, its_root_pda, system_account)?;

--- a/solana/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/solana/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -1,5 +1,6 @@
 //! Processor for [`TokenManager`] related requests.
 
+use event_utils::Event as _;
 use program_utils::{BorshPda, ValidPDA};
 use role_management::processor::ensure_roles;
 use role_management::state::UserRoles;
@@ -14,9 +15,9 @@ use spl_token_2022::extension::{BaseStateWithExtensions, ExtensionType, StateWit
 use spl_token_2022::instruction::AuthorityType;
 use spl_token_2022::state::Mint;
 
-use crate::assert_valid_its_root_pda;
 use crate::state::token_manager::{self, TokenManager};
 use crate::state::InterchainTokenService;
+use crate::{assert_valid_its_root_pda, event};
 use crate::{assert_valid_token_manager_pda, seed_prefixes, FromAccountInfoSlice, Roles};
 
 pub(crate) fn set_flow_limit(
@@ -155,6 +156,17 @@ pub(crate) fn deploy<'a>(
             &[token_manager.bump],
         ],
     )?;
+
+    event::TokenManagerDeployed {
+        token_id: deploy_token_manager.token_id,
+        token_manager: *accounts.token_manager_pda.key,
+        token_manager_type: deploy_token_manager.manager_type as u8,
+        params: deploy_token_manager
+            .operator
+            .map(|op| op.to_bytes().to_vec())
+            .unwrap_or_default(),
+    }
+    .emit();
 
     Ok(())
 }

--- a/solana/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/solana/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -160,7 +160,7 @@ pub(crate) fn deploy<'a>(
     event::TokenManagerDeployed {
         token_id: deploy_token_manager.token_id,
         token_manager: *accounts.token_manager_pda.key,
-        token_manager_type: deploy_token_manager.manager_type as u8,
+        token_manager_type: deploy_token_manager.manager_type.into(),
         params: deploy_token_manager
             .operator
             .map(|op| op.to_bytes().to_vec())

--- a/solana/programs/axelar-solana-its/src/state/token_manager.rs
+++ b/solana/programs/axelar-solana-its/src/state/token_manager.rs
@@ -108,6 +108,35 @@ impl From<Type> for U256 {
     }
 }
 
+impl From<Type> for u8 {
+    fn from(value: Type) -> Self {
+        match value {
+            Type::NativeInterchainToken => 0,
+            Type::MintBurnFrom => 1,
+            Type::LockUnlock => 2,
+            Type::LockUnlockFee => 3,
+            Type::MintBurn => 4,
+        }
+    }
+}
+
+impl TryFrom<u8> for Type {
+    type Error = ProgramError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        let converted = match value {
+            0 => Self::NativeInterchainToken,
+            1 => Self::MintBurnFrom,
+            2 => Self::LockUnlock,
+            3 => Self::LockUnlockFee,
+            4 => Self::MintBurn,
+            _ => return Err(ProgramError::InvalidInstructionData),
+        };
+
+        Ok(converted)
+    }
+}
+
 /// Struct containing state of a `TokenManager`
 #[derive(Debug, Eq, PartialEq, Clone, BorshSerialize, BorshDeserialize)]
 pub struct TokenManager {

--- a/solana/xtask/src/main.rs
+++ b/solana/xtask/src/main.rs
@@ -175,13 +175,14 @@ fn workspace_crates_by_category(
         .leak(); // fine to leak as xtask is short lived
     let all_crate_data = crates_in_repo.split_whitespace();
     let all_crate_data = all_crate_data
-        .filter(|item| !item.starts_with('[')) // filters "[dev-dependencies]"
+        .filter(|item| !item.starts_with('[') && !item.contains("proc-macro")) // filters "[dev-dependencies]"
         .tuples()
         .group_by(|(_, _, path)| path.contains("solana/programs"));
     let mut solana_programs = vec![];
     let mut auxiliary_crates = vec![];
     for (is_solana_program, group) in &all_crate_data {
         for (crate_name, _crate_version, crate_path) in group {
+            dbg!(crate_name, _crate_version, crate_path);
             let crate_path = crate_path
                 .strip_prefix('(')
                 .ok_or_eyre("expected prefix not there")?;

--- a/solana/xtask/src/main.rs
+++ b/solana/xtask/src/main.rs
@@ -175,14 +175,13 @@ fn workspace_crates_by_category(
         .leak(); // fine to leak as xtask is short lived
     let all_crate_data = crates_in_repo.split_whitespace();
     let all_crate_data = all_crate_data
-        .filter(|item| !item.starts_with('[') && !item.contains("proc-macro")) // filters "[dev-dependencies]"
+        .filter(|item| !item.starts_with('[') && !item.contains("proc-macro")) // filters "[dev-dependencies]" and "(proc-macro)"
         .tuples()
         .group_by(|(_, _, path)| path.contains("solana/programs"));
     let mut solana_programs = vec![];
     let mut auxiliary_crates = vec![];
     for (is_solana_program, group) in &all_crate_data {
         for (crate_name, _crate_version, crate_path) in group {
-            dbg!(crate_name, _crate_version, crate_path);
             let crate_path = crate_path
                 .strip_prefix('(')
                 .ok_or_eyre("expected prefix not there")?;


### PR DESCRIPTION
Since there's a lot of events emitted by ITS, implementing serialization and deserialization of each event was just too time consuming, and thus, a proc-macro was introduced to makes things easier.

We should probably update the GasService and Gateway events to remove the manually implemented deserialization and use the newly added macro. I think that should be done on a separate PR though.