### PR TITLE
chore: fix ci fail for rust check and docs

### DIFF
--- a/.github/actions/setup-repo/action.yaml
+++ b/.github/actions/setup-repo/action.yaml
@@ -47,3 +47,9 @@ runs:
       shell: bash
       run: |
         sudo apt-get install -y protobuf-compiler bzip2 clang
+
+    - name: Install deps for rust check and docs
+      shell: bash
+      run: |
+        sudo apt install -y pkg-config libusb-1.0-0-dev libftdi1-dev
+        sudo apt-get install libudev-dev


### PR DESCRIPTION
**Summary of changes**

Ci failed when merging of new solana dependencies to [main](https://github.com/eigerco/solana-axelar/actions/runs/14531397250/job/40771667666) was done and not during review. Added necessary deps for the ci

**Reviewer recommendations**

Check if actions pass green
