### PR TITLE
chore: removal of dalek curve patch

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -2022,8 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek?rev=8274d5cbb6fc3f38cdc742b4798173895cd2a290#8274d5cbb6fc3f38cdc742b4798173895cd2a290"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -2414,7 +2415,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.2.1",
+ "curve25519-dalek 3.2.0",
  "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -210,10 +210,3 @@ codegen-units = 1
 opt-level = 3
 incremental = false
 codegen-units = 1
-
-[patch.crates-io]
-# curve25519-dalek 3.x pin zeroize to <1.4
-# which conflicts with other dependencies requiring zeroize ^1.5.
-# We’re patching it here to unpin zeroize, using commit from a PR, see
-# https://github.com/dalek-cryptography/curve25519-dalek/pull/606
-curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "8274d5cbb6fc3f38cdc742b4798173895cd2a290" }

--- a/solana/programs/axelar-solana-governance/src/entrypoint.rs
+++ b/solana/programs/axelar-solana-governance/src/entrypoint.rs
@@ -1,6 +1,7 @@
 //! Program entrypoint
 
 #![allow(unexpected_cfgs)]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
@@ -8,7 +9,6 @@ use solana_program::pubkey::Pubkey;
 
 use crate::processor::Processor;
 
-#[cfg(not(feature = "no-entrypoint"))]
 solana_program::entrypoint!(process_instruction);
 
 fn process_instruction(


### PR DESCRIPTION
**Summary of changes**

Due to the updated solana dependencies, this patch is no longer needed.

