### PR TITLE
fix(its): token creation with initial supply

### DIFF
--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -22,6 +22,7 @@ style = { priority = -6, level = "deny" }
 suspicious = { priority = -7, level = "deny" }
 
 absolute_paths = "allow"
+arbitrary_source_item_ordering = "allow"
 assertions_on_result_states = "allow"
 blanket_clippy_restriction_lints = "allow"
 cargo_common_metadata = "allow"
@@ -84,10 +85,12 @@ precedence = "allow"
 redundant_clone = "allow"
 std_instead_of_core = "allow"
 renamed_function_params = "allow"
+too_long_first_doc_paragraph = "allow"
 transmute_ptr_to_ptr = "allow"
 undocumented_unsafe_blocks = "allow"
 unnecessary_wraps = "allow"
 unseparated_literal_suffix = "allow"
+unused_trait_names = "allow"
 unwrap_used = "allow"
 use_self = "allow"
 

--- a/solana/crates/axelar-executable/src/axelar_payload/encoding/borsh_encoding.rs
+++ b/solana/crates/axelar-executable/src/axelar_payload/encoding/borsh_encoding.rs
@@ -144,7 +144,9 @@ mod tests {
     #[test]
     fn test_decode_multiple_accounts() {
         let payload = random_payload_bytes(100);
-        let accounts: Vec<SolanaAccountRepr> = (0_u8..12).map(|_| create_test_account()).collect();
+        let accounts: Vec<SolanaAccountRepr> = std::iter::repeat_with(create_test_account)
+            .take(12)
+            .collect();
 
         let encoded = borsh::to_vec(&(payload.clone(), accounts.clone())).unwrap();
         let (payload_ref, decoded_accounts) = AxelarMessagePayload::decode_borsh(&encoded).unwrap();

--- a/solana/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/solana/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -682,7 +682,9 @@ pub fn make_verifiers_with_quorum(
 /// Make new random messages
 #[must_use]
 pub fn make_messages(num_messages: usize) -> Vec<Message> {
-    (0..num_messages).map(|_| random_message()).collect()
+    std::iter::repeat_with(random_message)
+        .take(num_messages)
+        .collect()
 }
 
 /// Random GMP Message

--- a/solana/programs/axelar-solana-gateway/src/processor/transfer_operatorship.rs
+++ b/solana/programs/axelar-solana-gateway/src/processor/transfer_operatorship.rs
@@ -82,7 +82,7 @@ impl Processor {
         // Check: the signer matches either the current operator or the upgrade
         // authority
         if !(gateway_config.operator == *operator_or_upgrade_authority.key
-            || upgrade_authority_address.map_or(false, |x| x == *operator_or_upgrade_authority.key))
+            || upgrade_authority_address == Some(*operator_or_upgrade_authority.key))
         {
             return Err(GatewayError::InvalidOperatorOrAuthorityAccount.into());
         }

--- a/solana/programs/axelar-solana-its/tests/module/deploy_interchain_token.rs
+++ b/solana/programs/axelar-solana-its/tests/module/deploy_interchain_token.rs
@@ -1,0 +1,291 @@
+use anyhow::anyhow;
+use event_utils::Event as _;
+use solana_program_test::tokio;
+use solana_sdk::program_pack::Pack as _;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use test_context::test_context;
+
+use crate::ItsTestContext;
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_deploy_interchain_token_with_no_minter_and_no_initial_supply(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let salt = solana_sdk::keccak::hash(b"NoMinterNoSupplyToken").0;
+    let initial_supply = 0u64;
+
+    let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
+        salt,
+        "No Supply No Minter Token".to_owned(),
+        "NSMT".to_owned(),
+        9,
+        initial_supply,
+        None,
+    )?;
+
+    let result = ctx.send_solana_tx(&[deploy_local_ix]).await;
+
+    assert!(result.is_err(), "Expected transaction to fail");
+    let err = result.unwrap_err();
+
+    let error_logs = err.metadata.unwrap().log_messages;
+    let has_invalid_arg_error = error_logs
+        .iter()
+        .any(|log| log.contains("invalid program argument"));
+
+    assert!(
+        has_invalid_arg_error,
+        "Expected InvalidArgument error when deploying with no minter and no initial supply"
+    );
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_deploy_interchain_token_with_minter_but_no_initial_supply(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let salt = solana_sdk::keccak::hash(b"MinterNoSupplyToken").0;
+    let initial_supply = 0u64;
+
+    let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
+        salt,
+        "Zero Supply Token".to_owned(),
+        "ZST".to_owned(),
+        9,
+        initial_supply,
+        Some(ctx.solana_wallet),
+    )?;
+
+    let tx = ctx
+        .send_solana_tx(&[deploy_local_ix])
+        .await
+        .expect("InterchainToken deployment failed");
+
+    let deploy_event = tx
+        .metadata
+        .unwrap()
+        .log_messages
+        .iter()
+        .find_map(|log| axelar_solana_its::event::InterchainTokenDeployed::try_from_log(log).ok())
+        .unwrap();
+
+    assert_eq!(
+        deploy_event.name, "Zero Supply Token",
+        "token name does not match"
+    );
+    assert_eq!(deploy_event.symbol, "ZST", "token symbol does not match");
+
+    let token_id = axelar_solana_its::interchain_token_id(&ctx.solana_wallet, &salt);
+    let (interchain_token_pda, _) =
+        axelar_solana_its::find_interchain_token_pda(&its_root_pda, &token_id);
+
+    let payer_ata = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &interchain_token_pda,
+        &spl_token_2022::id(),
+    );
+
+    let token_account_opt = ctx
+        .solana_chain
+        .try_get_account_no_checks(&payer_ata)
+        .await?;
+
+    if let Some(token_account) = token_account_opt {
+        let account = spl_token_2022::state::Account::unpack_from_slice(&token_account.data)?;
+        assert_eq!(account.amount, 0, "Initial supply should be zero");
+    }
+
+    let create_token_account_ix =
+        spl_associated_token_account::instruction::create_associated_token_account(
+            &ctx.solana_wallet,
+            &ctx.solana_wallet,
+            &interchain_token_pda,
+            &spl_token_2022::id(),
+        );
+
+    ctx.send_solana_tx(&[create_token_account_ix])
+        .await
+        .expect("Failed to create token account");
+
+    let mint_amount = 500u64;
+    let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        token_id,
+        interchain_token_pda,
+        payer_ata,
+        ctx.solana_wallet,
+        spl_token_2022::id(),
+        mint_amount,
+    )?;
+
+    ctx.send_solana_tx(&[mint_ix])
+        .await
+        .expect("Minting tokens failed");
+
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&payer_ata)
+        .await?
+        .ok_or_else(|| anyhow!("token account not found"))?
+        .data;
+
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+
+    assert_eq!(
+        account.amount, mint_amount,
+        "Minted amount doesn't match expected amount"
+    );
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_deploy_interchain_token_with_large_initial_supply(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let salt = solana_sdk::keccak::hash(b"LargeSupplyTestToken").0;
+    let initial_supply = u64::MAX;
+
+    let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
+        salt,
+        "Large Supply Token".to_owned(),
+        "LST".to_owned(),
+        9,
+        initial_supply,
+        Some(ctx.solana_wallet),
+    )?;
+
+    let tx = ctx
+        .send_solana_tx(&[deploy_local_ix])
+        .await
+        .expect("InterchainToken deployment failed");
+
+    let deploy_event = tx
+        .metadata
+        .unwrap()
+        .log_messages
+        .iter()
+        .find_map(|log| axelar_solana_its::event::InterchainTokenDeployed::try_from_log(log).ok())
+        .unwrap();
+
+    assert_eq!(
+        deploy_event.name, "Large Supply Token",
+        "token name does not match"
+    );
+    assert_eq!(deploy_event.symbol, "LST", "token symbol does not match");
+
+    let token_id = axelar_solana_its::interchain_token_id(&ctx.solana_wallet, &salt);
+    let (interchain_token_pda, _) =
+        axelar_solana_its::find_interchain_token_pda(&its_root_pda, &token_id);
+
+    let payer_ata = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &interchain_token_pda,
+        &spl_token_2022::id(),
+    );
+
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&payer_ata)
+        .await?
+        .ok_or_else(|| anyhow!("token account not found"))?
+        .data;
+
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+
+    assert_eq!(
+        account.amount, initial_supply,
+        "Initial supply doesn't match expected amount"
+    );
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_deploy_interchain_token_with_no_minter_but_initial_supply(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let salt = solana_sdk::keccak::hash(b"NoMinterWithSupplyToken").0;
+    let initial_supply = 1000u64;
+
+    let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
+        salt,
+        "Fixed Supply Token".to_owned(),
+        "FST".to_owned(),
+        9,
+        initial_supply,
+        None,
+    )?;
+
+    let tx = ctx
+        .send_solana_tx(&[deploy_local_ix])
+        .await
+        .expect("InterchainToken deployment failed");
+
+    let deploy_event = tx
+        .metadata
+        .unwrap()
+        .log_messages
+        .iter()
+        .find_map(|log| axelar_solana_its::event::InterchainTokenDeployed::try_from_log(log).ok())
+        .unwrap();
+
+    assert_eq!(
+        deploy_event.name, "Fixed Supply Token",
+        "token name does not match"
+    );
+    assert_eq!(deploy_event.symbol, "FST", "token symbol does not match");
+
+    let token_id = axelar_solana_its::interchain_token_id(&ctx.solana_wallet, &salt);
+    let (interchain_token_pda, _) =
+        axelar_solana_its::find_interchain_token_pda(&its_root_pda, &token_id);
+
+    let payer_ata = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &interchain_token_pda,
+        &spl_token_2022::id(),
+    );
+
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&payer_ata)
+        .await?
+        .ok_or_else(|| anyhow!("token account not found"))?
+        .data;
+
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+
+    assert_eq!(
+        account.amount, initial_supply,
+        "Initial supply doesn't match expected amount"
+    );
+
+    let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        token_id,
+        interchain_token_pda,
+        payer_ata,
+        ctx.solana_wallet,
+        spl_token_2022::id(),
+        100,
+    )?;
+
+    let result = ctx.send_solana_tx(&[mint_ix]).await;
+
+    assert!(
+        result.is_err(),
+        "Expected minting to fail for fixed supply token"
+    );
+
+    Ok(())
+}

--- a/solana/programs/axelar-solana-its/tests/module/main.rs
+++ b/solana/programs/axelar-solana-its/tests/module/main.rs
@@ -19,6 +19,7 @@
     unused_must_use
 )]
 
+mod deploy_interchain_token;
 mod flow_limits;
 mod from_evm_to_solana;
 mod from_solana_to_evm;

--- a/solana/rust-toolchain.toml
+++ b/solana/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-# Same one that is used on the Solana repo
-channel = "1.81.0"
+channel = "1.85.1"


### PR DESCRIPTION
- When no minter and no initial_supply is passed, the deployment should
  fail.
- When no minter is passed but an initial_supply is, we should mint the
  initial_supply to the payer(sender). We SHOULD STILL have the
  TokenManager as mint authority as it needs to mint tokens on incoming
  interchain transfers.
- If a minter is given, it's tracked through role management within ITS
  and not set as mint authority, as the mint authority must be the
  TokenManager and SPL tokens can have only one mint authority.