### PR TITLE
fix(its): fix LockUnlock token vulnerability (ACKEE-5)

### DIFF
--- a/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
+++ b/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
@@ -539,3 +539,76 @@ async fn transfer_fails_with_wrong_gas_service(ctx: &mut ItsTestContext) -> anyh
 
     Ok(())
 }
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_lock_unlock_transfer_fails_with_token_manager_as_authority(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (token_id, _, solana_token) = custom_token(ctx, TokenManagerType::LockUnlock).await?;
+
+    let token_account = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &solana_token,
+        &spl_token_2022::id(),
+    );
+
+    let create_ata_ix = create_associated_token_account(
+        &ctx.solana_wallet,
+        &ctx.solana_wallet,
+        &solana_token,
+        &spl_token_2022::id(),
+    );
+
+    let token_manager_pda = axelar_solana_its::find_token_manager_pda(
+        &axelar_solana_its::find_its_root_pda().0,
+        &token_id,
+    )
+    .0;
+    let token_manager_ata = get_associated_token_address_with_program_id(
+        &token_manager_pda,
+        &solana_token,
+        &spl_token_2022::id(),
+    );
+
+    // Pretent the TokenManager has tokens locked already
+    let initial_balance = 300;
+    let mint_ix = spl_token_2022::instruction::mint_to(
+        &spl_token_2022::id(),
+        &solana_token,
+        &token_manager_ata,
+        &ctx.solana_wallet,
+        &[&ctx.solana_wallet],
+        initial_balance,
+    )?;
+
+    ctx.send_solana_tx(&[create_ata_ix, mint_ix]).await.unwrap();
+
+    // Try to transfer from the TokenManager to payer. This should fail after the fix
+    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
+    let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
+        ctx.solana_chain.fixture.payer.pubkey(),
+        token_manager_ata,
+        Some(token_manager_pda),
+        token_id,
+        ctx.solana_chain_name.clone(),
+        token_account.to_bytes().to_vec(),
+        initial_balance,
+        solana_token,
+        spl_token_2022::id(),
+        0,
+        axelar_solana_gas_service::id(),
+        ctx.solana_gas_utils.config_pda,
+        clock_sysvar.unix_timestamp,
+    )
+    .unwrap();
+
+    assert!(ctx
+        .send_solana_tx(&[transfer_ix])
+        .await
+        .unwrap_err()
+        .find_log("Cross-program invocation with unauthorized signer or writable account")
+        .is_some());
+
+    Ok(())
+}


### PR DESCRIPTION
This issue was reported by Ackee (ACKEE-5):

There is a severe issue with the InterchainTransfer . It lacks validation of source/destination accounts. It is possible to execute the instruction with LockUnlock / LockUnlockFee token manager type in unintended way -> if the attacker uses source account as the Token Manager ATA and destination account as his ATA, it will drain the token manager. This likely applies also to the CallContractWithInterchainToken and CallContractWithInterchainTokenOffchainData as both uses process_outbound_transfer.