### PR TITLE
chore: remove rkyv dep from program-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,7 +5635,6 @@ dependencies = [
  "borsh 1.5.7",
  "bytemuck",
  "mpl-token-metadata",
- "rkyv",
  "solana-program",
  "spl-associated-token-account 6.0.0",
 ]

--- a/helpers/program-utils/Cargo.toml
+++ b/helpers/program-utils/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-rkyv = { workspace = true, features = ["validation"] }
 borsh.workspace = true
 bytemuck.workspace = true
 mpl-token-metadata.workspace = true


### PR DESCRIPTION
Little PR for removing rkyv from program utils. rkyv its still in the workspace, as there are other things still depend on it. This is a preparatory step for a new impl.