### PR TITLE
fix(its): allow operator to set/remove trusted chain (ACKEE-L1)

### DIFF
--- a/bindings/anchor_lib/axelar-solana-its.rs
+++ b/bindings/anchor_lib/axelar-solana-its.rs
@@ -273,6 +273,7 @@ pub struct SetPauseStatus<'info> {
 pub struct SetTrustedChain<'info> {
     #[account(mut)]
     payer: Signer<'info>,
+    payer_roles_pda: AccountInfo<'info>,
     program_data_address: AccountInfo<'info>,
     #[account(mut)]
     its_root_pda: AccountInfo<'info>,
@@ -283,6 +284,7 @@ pub struct SetTrustedChain<'info> {
 pub struct RemoveTrustedChain<'info> {
     #[account(mut)]
     payer: Signer<'info>,
+    payer_roles_pda: AccountInfo<'info>,
     program_data_address: AccountInfo<'info>,
     #[account(mut)]
     its_root_pda: AccountInfo<'info>,

--- a/bindings/axelar-solana-its/src/instructions.ts
+++ b/bindings/axelar-solana-its/src/instructions.ts
@@ -130,8 +130,11 @@ export class ItsInstructions {
     payer: PublicKey;
     chainName: string;
   }): ReturnType<Program["methods"]["setTrustedChain"]> {
+    const [payerRolesPda] = findUserRolesPda(this.itsRootPda, params.payer);
+
     return this.program.methods.setTrustedChain(params.chainName).accounts({
       payer: params.payer,
+      payerRolesPda,
       programDataAddress: this.programDataAddress,
       itsRootPda: this.itsRootPda,
       systemProgram: SystemProgram.programId,
@@ -142,8 +145,10 @@ export class ItsInstructions {
     payer: PublicKey;
     chainName: string;
   }): ReturnType<Program["methods"]["removeTrustedChain"]> {
+    const [payerRolesPda] = findUserRolesPda(this.itsRootPda, params.payer);
     return this.program.methods.removeTrustedChain(params.chainName).accounts({
       payer: params.payer,
+      payerRolesPda,
       programDataAddress: this.programDataAddress,
       itsRootPda: this.itsRootPda,
       systemProgram: SystemProgram.programId,

--- a/bindings/generated/axelar-solana-its/idl.json
+++ b/bindings/generated/axelar-solana-its/idl.json
@@ -87,6 +87,11 @@
           "isSigner": true
         },
         {
+          "name": "payerRolesPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "programDataAddress",
           "isMut": false,
           "isSigner": false
@@ -116,6 +121,11 @@
           "name": "payer",
           "isMut": true,
           "isSigner": true
+        },
+        {
+          "name": "payerRolesPda",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "programDataAddress",

--- a/bindings/generated/axelar-solana-its/src/program.ts
+++ b/bindings/generated/axelar-solana-its/src/program.ts
@@ -112,6 +112,11 @@ type AxelarSolanaIts = {
           isSigner: true;
         },
         {
+          name: "payerRolesPda";
+          isMut: false;
+          isSigner: false;
+        },
+        {
           name: "programDataAddress";
           isMut: false;
           isSigner: false;
@@ -141,6 +146,11 @@ type AxelarSolanaIts = {
           name: "payer";
           isMut: true;
           isSigner: true;
+        },
+        {
+          name: "payerRolesPda";
+          isMut: false;
+          isSigner: false;
         },
         {
           name: "programDataAddress";
@@ -2026,6 +2036,11 @@ const IDL: AxelarSolanaIts = {
           isSigner: true,
         },
         {
+          name: "payerRolesPda",
+          isMut: false,
+          isSigner: false,
+        },
+        {
           name: "programDataAddress",
           isMut: false,
           isSigner: false,
@@ -2055,6 +2070,11 @@ const IDL: AxelarSolanaIts = {
           name: "payer",
           isMut: true,
           isSigner: true,
+        },
+        {
+          name: "payerRolesPda",
+          isMut: false,
+          isSigner: false,
         },
         {
           name: "programDataAddress",

--- a/bindings/tests/its.ts
+++ b/bindings/tests/its.ts
@@ -70,6 +70,7 @@ describe("Ping ITS", () => {
         .setTrustedChain("chain")
         .accounts({
           payer: payer.publicKey,
+          payerRolesPda: payer.publicKey,
           programDataAddress: payer.publicKey,
           itsRootPda: payer.publicKey,
           systemProgram: systemAccount,
@@ -87,6 +88,7 @@ describe("Ping ITS", () => {
         .removeTrustedChain("chain")
         .accounts({
           payer: payer.publicKey,
+          payerRolesPda: payer.publicKey,
           programDataAddress: payer.publicKey,
           itsRootPda: payer.publicKey,
           systemProgram: systemAccount,

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -809,11 +809,14 @@ pub fn set_trusted_chain(payer: Pubkey, chain_name: String) -> Result<Instructio
         Pubkey::find_program_address(&[crate::ID.as_ref()], &bpf_loader_upgradeable::ID);
 
     let (its_root_pda, _) = crate::find_its_root_pda();
+    let (payer_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::ID, &its_root_pda, &payer);
 
     let data = to_vec(&InterchainTokenServiceInstruction::SetTrustedChain { chain_name })?;
 
     let accounts = vec![
         AccountMeta::new(payer, true),
+        AccountMeta::new_readonly(payer_roles_pda, false),
         AccountMeta::new_readonly(program_data_address, false),
         AccountMeta::new(its_root_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),
@@ -838,11 +841,14 @@ pub fn remove_trusted_chain(
     let (program_data_address, _) =
         Pubkey::find_program_address(&[crate::ID.as_ref()], &bpf_loader_upgradeable::ID);
     let (its_root_pda, _) = crate::find_its_root_pda();
+    let (payer_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::ID, &its_root_pda, &payer);
 
     let data = to_vec(&InterchainTokenServiceInstruction::RemoveTrustedChain { chain_name })?;
 
     let accounts = vec![
         AccountMeta::new(payer, true),
+        AccountMeta::new_readonly(payer_roles_pda, false),
         AccountMeta::new_readonly(program_data_address, false),
         AccountMeta::new(its_root_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),


### PR DESCRIPTION
This was reported by Ackee in their audit report (ACKEE-L1).