### PR TITLE
fix(its): token manager type validation (ACKEE-W3)

### DIFF
--- a/programs/axelar-solana-its/src/processor/link_token.rs
+++ b/programs/axelar-solana-its/src/processor/link_token.rs
@@ -196,6 +196,10 @@ pub(crate) fn register_custom_token<'a>(
     token_manager_type: token_manager::Type,
     operator: Option<Pubkey>,
 ) -> ProgramResult {
+    if token_manager_type == token_manager::Type::NativeInterchainToken {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
     register_token(
         accounts,
         &TokenRegistration::Custom {


### PR DESCRIPTION
Ackee report raises a concern that not all token manager types are validate within the validate_token_manager_type function. This is intended since the requirements are different for different token manager types. It's required that MintBurn and MintBurnFrom token managers get mint authority, but that only happens after the deployment, and thus cannot be validated during deployment. This check is now added, but only during transfers. During deployment, we only need to make sure LockUnlockFee token managers are deployed for mints with the appropriate extension.

A missing check was also added to register_custom_token as it should not be possible to register custom tokens using the NativeInterchainToken token manager type.