### PR TITLE
feat: removal of operator from the config PDA

### DIFF
--- a/crates/axelar-solana-gateway-test-fixtures/src/gas_service.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gas_service.rs
@@ -49,11 +49,8 @@ impl TestFixture {
     pub fn setup_default_gas_config(&mut self, upgrade_authority: Keypair) -> GasServiceUtils {
         let operator = Keypair::new();
         let salt = keccak::hash(b"my gas service").0;
-        let (config_pda, ..) = axelar_solana_gas_service::get_config_pda(
-            &axelar_solana_gas_service::ID,
-            &salt,
-            &operator.pubkey(),
-        );
+        let (config_pda, ..) =
+            axelar_solana_gas_service::get_config_pda(&axelar_solana_gas_service::ID, &salt);
 
         GasServiceUtils {
             upgrade_authority,

--- a/programs/axelar-solana-gas-service/src/lib.rs
+++ b/programs/axelar-solana-gas-service/src/lib.rs
@@ -39,11 +39,8 @@ pub fn check_program_account(program_id: Pubkey) -> Result<(), ProgramError> {
 /// uses [`Pubkey::find_program_address`] to return the derived PDA and its associated bump seed.
 #[inline]
 #[must_use]
-pub fn get_config_pda(program_id: &Pubkey, salt: &[u8; 32], operator: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(
-        &[seed_prefixes::CONFIG_SEED, salt, operator.as_ref()],
-        program_id,
-    )
+pub fn get_config_pda(program_id: &Pubkey, salt: &[u8; 32]) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[seed_prefixes::CONFIG_SEED, salt], program_id)
 }
 
 /// Checks that the given `expected_pubkey` matches the derived PDA for the provided parameters.
@@ -59,14 +56,11 @@ pub fn get_config_pda(program_id: &Pubkey, salt: &[u8; 32], operator: &Pubkey) -
 pub fn assert_valid_config_pda(
     bump: u8,
     salt: &[u8; 32],
-    operator: &Pubkey,
     expected_pubkey: &Pubkey,
 ) -> Result<(), ProgramError> {
-    let derived_pubkey = Pubkey::create_program_address(
-        &[seed_prefixes::CONFIG_SEED, salt, operator.as_ref(), &[bump]],
-        &crate::ID,
-    )
-    .expect("invalid bump for the config pda");
+    let derived_pubkey =
+        Pubkey::create_program_address(&[seed_prefixes::CONFIG_SEED, salt, &[bump]], &crate::ID)
+            .expect("invalid bump for the config pda");
 
     if &derived_pubkey == expected_pubkey {
         Ok(())

--- a/programs/axelar-solana-gas-service/src/processor/initialize.rs
+++ b/programs/axelar-solana-gas-service/src/processor/initialize.rs
@@ -31,10 +31,10 @@ pub(crate) fn process_initialize_config(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    let (_, bump) = get_config_pda(program_id, &salt, operator.key);
+    let (_, bump) = get_config_pda(program_id, &salt);
 
     // Check: Gateway Config account uses the canonical bump.
-    assert_valid_config_pda(bump, &salt, operator.key, config_pda.key)?;
+    assert_valid_config_pda(bump, &salt, config_pda.key)?;
 
     // Initialize the account
     program_utils::pda::init_pda_raw(

--- a/programs/axelar-solana-gas-service/src/processor/initialize.rs
+++ b/programs/axelar-solana-gas-service/src/processor/initialize.rs
@@ -43,12 +43,7 @@ pub(crate) fn process_initialize_config(
         program_id,
         system_account,
         size_of::<Config>().try_into().expect("must be valid u64"),
-        &[
-            seed_prefixes::CONFIG_SEED,
-            &salt,
-            operator.key.as_ref(),
-            &[bump],
-        ],
+        &[seed_prefixes::CONFIG_SEED, &salt, &[bump]],
     )?;
     let mut data = config_pda.try_borrow_mut_data()?;
     let gateway_config = Config::read_mut(&mut data).ok_or(ProgramError::InvalidAccountData)?;

--- a/programs/axelar-solana-gas-service/src/processor/native.rs
+++ b/programs/axelar-solana-gas-service/src/processor/native.rs
@@ -67,7 +67,7 @@ fn try_load_config(
     config_pda.check_initialized_pda_without_deserialization(program_id)?;
     let data = config_pda.try_borrow_data()?;
     let config = Config::read(&data).ok_or(ProgramError::InvalidAccountData)?;
-    assert_valid_config_pda(config.bump, &config.salt, &config.operator, config_pda.key)?;
+    assert_valid_config_pda(config.bump, &config.salt, config_pda.key)?;
     Ok(*config)
 }
 

--- a/programs/axelar-solana-gas-service/src/processor/spl.rs
+++ b/programs/axelar-solana-gas-service/src/processor/spl.rs
@@ -35,7 +35,7 @@ fn ensure_valid_config_pda(config_pda: &AccountInfo<'_>, program_id: &Pubkey) ->
     config_pda.check_initialized_pda_without_deserialization(program_id)?;
     let data = config_pda.try_borrow_data()?;
     let config = Config::read(&data).ok_or(ProgramError::InvalidAccountData)?;
-    assert_valid_config_pda(config.bump, &config.salt, &config.operator, config_pda.key)?;
+    assert_valid_config_pda(config.bump, &config.salt, config_pda.key)?;
     Ok(())
 }
 

--- a/programs/axelar-solana-gas-service/src/processor/spl.rs
+++ b/programs/axelar-solana-gas-service/src/processor/spl.rs
@@ -270,12 +270,7 @@ pub(crate) fn collect_fees_spl(
             receiver_account.clone(),
             token_program.clone(),
         ],
-        &[&[
-            seed_prefixes::CONFIG_SEED,
-            &config.salt,
-            config.operator.as_ref(),
-            &[config.bump],
-        ]],
+        &[&[seed_prefixes::CONFIG_SEED, &config.salt, &[config.bump]]],
     )?;
 
     Ok(())
@@ -342,12 +337,7 @@ pub(crate) fn refund_spl(
             receiver_account.clone(),
             token_program.clone(),
         ],
-        &[&[
-            seed_prefixes::CONFIG_SEED,
-            &config.salt,
-            config.operator.as_ref(),
-            &[config.bump],
-        ]],
+        &[&[seed_prefixes::CONFIG_SEED, &config.salt, &[config.bump]]],
     )?;
 
     // Emit an event

--- a/programs/axelar-solana-gas-service/tests/module/initialize.rs
+++ b/programs/axelar-solana-gas-service/tests/module/initialize.rs
@@ -38,11 +38,8 @@ async fn test_different_salts_give_new_configs() {
     let salt_seeds = b"abc";
     for salt_seed in salt_seeds {
         let salt = hashv(&[&[*salt_seed]]).0;
-        let (config_pda, bump) = axelar_solana_gas_service::get_config_pda(
-            &axelar_solana_gas_service::ID,
-            &salt,
-            &gas_utils.operator.pubkey(),
-        );
+        let (config_pda, bump) =
+            axelar_solana_gas_service::get_config_pda(&axelar_solana_gas_service::ID, &salt);
         let _res = test_fixture
             .init_gas_config_with_params(gas_utils.operator.insecure_clone(), config_pda, salt)
             .await
@@ -62,11 +59,8 @@ async fn test_different_salts_give_new_configs() {
     // assert -- subsequent initializations will revert the tx
     for salt_seed in salt_seeds {
         let salt = hashv(&[&[*salt_seed]]).0;
-        let (config_pda, _bump) = axelar_solana_gas_service::get_config_pda(
-            &axelar_solana_gas_service::ID,
-            &salt,
-            &gas_utils.operator.pubkey(),
-        );
+        let (config_pda, _bump) =
+            axelar_solana_gas_service::get_config_pda(&axelar_solana_gas_service::ID, &salt);
         let res = test_fixture
             .init_gas_config_with_params(gas_utils.operator.insecure_clone(), config_pda, salt)
             .await;


### PR DESCRIPTION
Removal `operator` from the config PDA, allowing the program to change the operator without losing track of refunds