### PR TITLE
refactor(gas-service): simplify API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-associated-token-account 6.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 6.0.0",
 ]

--- a/crates/axelar-solana-gateway-test-fixtures/src/gas_service.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gas_service.rs
@@ -6,7 +6,7 @@ use axelar_solana_gateway::BytemuckedPda;
 use gateway_event_stack::{MatchContext, ProgramInvocationState};
 use solana_program_test::{tokio, BanksTransactionResultWithMetadata};
 use solana_sdk::{
-    account::ReadableAccount, keccak, program_pack::Pack, pubkey::Pubkey, signature::Keypair,
+    account::ReadableAccount, program_pack::Pack, pubkey::Pubkey, signature::Keypair,
     signer::Signer, system_instruction,
 };
 use spl_associated_token_account::get_associated_token_address_with_program_id;
@@ -20,8 +20,6 @@ pub struct GasServiceUtils {
     pub operator: Keypair,
     /// PDA of the gas service config
     pub config_pda: Pubkey,
-    /// salt to derive the config pda
-    pub salt: [u8; 32],
 }
 
 impl TestFixture {
@@ -48,15 +46,12 @@ impl TestFixture {
     /// Initialise a new gas config and return a utility tracker struct for it
     pub fn setup_default_gas_config(&mut self, upgrade_authority: Keypair) -> GasServiceUtils {
         let operator = Keypair::new();
-        let salt = keccak::hash(b"my gas service").0;
-        let (config_pda, ..) =
-            axelar_solana_gas_service::get_config_pda(&axelar_solana_gas_service::ID, &salt);
+        let (config_pda, ..) = axelar_solana_gas_service::get_config_pda();
 
         GasServiceUtils {
             upgrade_authority,
             operator,
             config_pda,
-            salt,
         }
     }
 
@@ -65,27 +60,18 @@ impl TestFixture {
         &mut self,
         utils: &GasServiceUtils,
     ) -> Result<BanksTransactionResultWithMetadata, BanksTransactionResultWithMetadata> {
-        self.init_gas_config_with_params(
-            utils.operator.insecure_clone(),
-            utils.config_pda,
-            utils.salt,
-        )
-        .await
+        self.init_gas_config_with_params(utils.operator.insecure_clone())
+            .await
     }
 
     /// init the gas service with raw params
     pub async fn init_gas_config_with_params(
         &mut self,
         operator: Keypair,
-        config_pda: Pubkey,
-        salt: [u8; 32],
     ) -> Result<BanksTransactionResultWithMetadata, BanksTransactionResultWithMetadata> {
         let ix = axelar_solana_gas_service::instructions::init_config(
-            &axelar_solana_gas_service::ID,
             &self.payer.pubkey(),
             &operator.pubkey(),
-            &config_pda,
-            salt,
         )
         .unwrap();
         self.send_tx_with_custom_signers(&[ix], &[operator, self.payer.insecure_clone()])

--- a/programs/axelar-solana-gas-service/Cargo.toml
+++ b/programs/axelar-solana-gas-service/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 solana-program.workspace = true
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
 axelar-solana-gas-service-events.workspace = true
 bytemuck.workspace = true
 borsh.workspace = true

--- a/programs/axelar-solana-gas-service/src/lib.rs
+++ b/programs/axelar-solana-gas-service/src/lib.rs
@@ -52,8 +52,8 @@ pub fn check_program_account(program_id: Pubkey) -> Result<(), ProgramError> {
 /// uses [`Pubkey::find_program_address`] to return the derived PDA and its associated bump seed.
 #[inline]
 #[must_use]
-pub fn get_config_pda(program_id: &Pubkey, salt: &[u8; 32]) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[seed_prefixes::CONFIG_SEED, salt], program_id)
+pub fn get_config_pda() -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[seed_prefixes::CONFIG_SEED], &crate::ID)
 }
 
 /// Checks that the given `expected_pubkey` matches the derived PDA for the provided parameters.
@@ -66,13 +66,9 @@ pub fn get_config_pda(program_id: &Pubkey, salt: &[u8; 32]) -> (Pubkey, u8) {
 /// - if the derived PDA does not match the `expected_pubkey`.
 #[inline]
 #[track_caller]
-pub fn assert_valid_config_pda(
-    bump: u8,
-    salt: &[u8; 32],
-    expected_pubkey: &Pubkey,
-) -> Result<(), ProgramError> {
+pub fn assert_valid_config_pda(bump: u8, expected_pubkey: &Pubkey) -> Result<(), ProgramError> {
     let derived_pubkey =
-        Pubkey::create_program_address(&[seed_prefixes::CONFIG_SEED, salt, &[bump]], &crate::ID)
+        Pubkey::create_program_address(&[seed_prefixes::CONFIG_SEED, &[bump]], &crate::ID)
             .expect("invalid bump for the config pda");
 
     if &derived_pubkey == expected_pubkey {

--- a/programs/axelar-solana-gas-service/src/processor.rs
+++ b/programs/axelar-solana-gas-service/src/processor.rs
@@ -34,9 +34,7 @@ pub fn process_instruction(
     check_program_account(*program_id)?;
 
     match instruction {
-        GasServiceInstruction::Initialize { salt } => {
-            process_initialize_config(program_id, accounts, salt)
-        }
+        GasServiceInstruction::Initialize => process_initialize_config(program_id, accounts),
         GasServiceInstruction::SplToken(ix) => match ix {
             PayWithSplToken::ForContractCall {
                 destination_chain,

--- a/programs/axelar-solana-gas-service/src/processor/native.rs
+++ b/programs/axelar-solana-gas-service/src/processor/native.rs
@@ -67,7 +67,7 @@ fn try_load_config(
     config_pda.check_initialized_pda_without_deserialization(program_id)?;
     let data = config_pda.try_borrow_data()?;
     let config = Config::read(&data).ok_or(ProgramError::InvalidAccountData)?;
-    assert_valid_config_pda(config.bump, &config.salt, config_pda.key)?;
+    assert_valid_config_pda(config.bump, config_pda.key)?;
     Ok(*config)
 }
 

--- a/programs/axelar-solana-gas-service/src/processor/spl.rs
+++ b/programs/axelar-solana-gas-service/src/processor/spl.rs
@@ -35,7 +35,7 @@ fn ensure_valid_config_pda(config_pda: &AccountInfo<'_>, program_id: &Pubkey) ->
     config_pda.check_initialized_pda_without_deserialization(program_id)?;
     let data = config_pda.try_borrow_data()?;
     let config = Config::read(&data).ok_or(ProgramError::InvalidAccountData)?;
-    assert_valid_config_pda(config.bump, &config.salt, config_pda.key)?;
+    assert_valid_config_pda(config.bump, config_pda.key)?;
     Ok(())
 }
 
@@ -270,7 +270,7 @@ pub(crate) fn collect_fees_spl(
             receiver_account.clone(),
             token_program.clone(),
         ],
-        &[&[seed_prefixes::CONFIG_SEED, &config.salt, &[config.bump]]],
+        &[&[seed_prefixes::CONFIG_SEED, &[config.bump]]],
     )?;
 
     Ok(())
@@ -337,7 +337,7 @@ pub(crate) fn refund_spl(
             receiver_account.clone(),
             token_program.clone(),
         ],
-        &[&[seed_prefixes::CONFIG_SEED, &config.salt, &[config.bump]]],
+        &[&[seed_prefixes::CONFIG_SEED, &[config.bump]]],
     )?;
 
     // Emit an event

--- a/programs/axelar-solana-gas-service/src/state.rs
+++ b/programs/axelar-solana-gas-service/src/state.rs
@@ -10,8 +10,6 @@ use solana_program::pubkey::Pubkey;
 pub struct Config {
     /// Operator with permission to give refunds & withdraw funds
     pub operator: Pubkey,
-    /// A 32-byte "salt" to ensure uniqueness in PDA derivation.
-    pub salt: [u8; 32],
     /// The bump seed used to derive the PDA, ensuring the address is valid.
     pub bump: u8,
 }

--- a/programs/axelar-solana-gas-service/tests/module/initialize.rs
+++ b/programs/axelar-solana-gas-service/tests/module/initialize.rs
@@ -1,7 +1,7 @@
 use axelar_solana_gas_service::state::Config;
 use axelar_solana_gateway_test_fixtures::base::TestFixture;
 use solana_program_test::{tokio, ProgramTest};
-use solana_sdk::{keccak::hashv, signer::Signer};
+use solana_sdk::signer::Signer;
 
 #[tokio::test]
 async fn test_successfully_initialize_config() {
@@ -21,49 +21,7 @@ async fn test_successfully_initialize_config() {
         config,
         Config {
             operator: gas_utils.operator.pubkey(),
-            salt: gas_utils.salt,
             bump: config.bump
         }
     );
-}
-
-#[tokio::test]
-async fn test_different_salts_give_new_configs() {
-    // Setup
-    let pt = ProgramTest::default();
-    let mut test_fixture = TestFixture::new(pt).await;
-    let gas_utils = test_fixture.deploy_gas_service().await;
-
-    // Action
-    let salt_seeds = b"abc";
-    for salt_seed in salt_seeds {
-        let salt = hashv(&[&[*salt_seed]]).0;
-        let (config_pda, bump) =
-            axelar_solana_gas_service::get_config_pda(&axelar_solana_gas_service::ID, &salt);
-        let _res = test_fixture
-            .init_gas_config_with_params(gas_utils.operator.insecure_clone(), config_pda, salt)
-            .await
-            .unwrap();
-        // Assert
-        let config = test_fixture.gas_service_config_state(config_pda).await;
-        assert_eq!(
-            config,
-            Config {
-                operator: gas_utils.operator.pubkey(),
-                salt,
-                bump
-            }
-        );
-    }
-
-    // assert -- subsequent initializations will revert the tx
-    for salt_seed in salt_seeds {
-        let salt = hashv(&[&[*salt_seed]]).0;
-        let (config_pda, _bump) =
-            axelar_solana_gas_service::get_config_pda(&axelar_solana_gas_service::ID, &salt);
-        let res = test_fixture
-            .init_gas_config_with_params(gas_utils.operator.insecure_clone(), config_pda, salt)
-            .await;
-        assert!(res.is_err());
-    }
 }

--- a/programs/axelar-solana-gas-service/tests/module/native/add_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/add_gas.rs
@@ -36,9 +36,7 @@ async fn test_add_native_gas() {
     let tx_hash = [42; 64];
     let log_index = 1232;
     let ix = axelar_solana_gas_service::instructions::add_native_gas_instruction(
-        &axelar_solana_gas_service::ID,
         &payer.pubkey(),
-        &gas_utils.config_pda,
         tx_hash,
         log_index,
         gas_amount,
@@ -119,9 +117,7 @@ async fn fails_if_payer_not_signer() {
     let tx_hash = [42; 64];
     let log_index = 1232;
     let mut ix = axelar_solana_gas_service::instructions::add_native_gas_instruction(
-        &axelar_solana_gas_service::ID,
         &payer.pubkey(),
-        &gas_utils.config_pda,
         tx_hash,
         log_index,
         gas_amount,

--- a/programs/axelar-solana-gas-service/tests/module/native/collect_fees.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/collect_fees.rs
@@ -26,9 +26,7 @@ async fn test_receive_funds() {
     // Action
     let sol_amount = 1_000_000;
     let ix = axelar_solana_gas_service::instructions::collect_native_fees_instruction(
-        &axelar_solana_gas_service::ID,
         &gas_utils.operator.pubkey(),
-        &gas_utils.config_pda,
         &receiver.pubkey(),
         sol_amount,
     )
@@ -83,9 +81,7 @@ async fn test_refund_native_fails_if_not_signed_by_authority() {
     let receiver = Keypair::new();
     let sol_amount = 1_000_000;
     let mut ix = axelar_solana_gas_service::instructions::collect_native_fees_instruction(
-        &axelar_solana_gas_service::ID,
         &gas_utils.operator.pubkey(),
-        &gas_utils.config_pda,
         &receiver.pubkey(),
         sol_amount,
     )

--- a/programs/axelar-solana-gas-service/tests/module/native/pay_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/pay_for_contract_call.rs
@@ -42,9 +42,7 @@ async fn test_pay_native_for_contract_call() {
         .to_string()
         .into_bytes();
     let ix = axelar_solana_gas_service::instructions::pay_native_for_contract_call_instruction(
-        &axelar_solana_gas_service::ID,
         &payer.pubkey(),
-        &gas_utils.config_pda,
         destination_chain.clone(),
         destination_addr.clone(),
         payload_hash,
@@ -134,9 +132,7 @@ async fn fails_if_payer_not_signer() {
         .to_string()
         .into_bytes();
     let mut ix = axelar_solana_gas_service::instructions::pay_native_for_contract_call_instruction(
-        &axelar_solana_gas_service::ID,
         &payer.pubkey(),
-        &gas_utils.config_pda,
         destination_chain.clone(),
         destination_addr.clone(),
         payload_hash,

--- a/programs/axelar-solana-gas-service/tests/module/native/refund_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/refund_gas.rs
@@ -30,10 +30,8 @@ async fn test_refund_native() {
     let tx_hash = [42; 64];
     let log_index = 1232;
     let ix = axelar_solana_gas_service::instructions::refund_native_fees_instruction(
-        &axelar_solana_gas_service::ID,
         &gas_utils.operator.pubkey(),
         &refunded_user.pubkey(),
-        &gas_utils.config_pda,
         tx_hash,
         log_index,
         gas_amount,
@@ -110,10 +108,8 @@ async fn test_refund_native_fails_if_not_signed_by_authority() {
     let tx_hash = [42; 64];
     let log_index = 1232;
     let mut ix = axelar_solana_gas_service::instructions::refund_native_fees_instruction(
-        &axelar_solana_gas_service::ID,
         &gas_utils.operator.pubkey(),
         &refunded_user.pubkey(),
-        &gas_utils.config_pda,
         tx_hash,
         log_index,
         gas_amount,

--- a/programs/axelar-solana-gas-service/tests/module/spl/add_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/add_gas.rs
@@ -54,11 +54,8 @@ async fn test_add_spl_gas(#[case] token_program_id: Pubkey) {
 
     // Create the instruction for paying gas fees with SPL tokens
     let ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
-        &axelar_solana_gas_service::ID,
         &payer.pubkey(),
         &payer_ata,
-        &gas_utils.config_pda,
-        &config_pda_ata,
         &mint,
         &token_program_id,
         &[],

--- a/programs/axelar-solana-gas-service/tests/module/spl/collet_fees.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/collet_fees.rs
@@ -46,12 +46,9 @@ async fn test_collect_spl_fees(#[case] token_program_id: Pubkey) {
 
     // Create the instruction for paying gas fees with SPL tokens
     let ix = axelar_solana_gas_service::instructions::collect_spl_fees_instruction(
-        &axelar_solana_gas_service::ID,
         &gas_utils.operator.pubkey(),
         &token_program_id,
         &mint,
-        &gas_utils.config_pda,
-        &config_pda_ata,
         &payer_ata,
         gas_amount,
         decimals,

--- a/programs/axelar-solana-gas-service/tests/module/spl/pay_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/pay_for_contract_call.rs
@@ -58,11 +58,8 @@ async fn test_pay_spl_for_contract_call(#[case] token_program_id: Pubkey) {
 
     // Create the instruction for paying gas fees with SPL tokens
     let ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
-        &axelar_solana_gas_service::ID,
         &payer.pubkey(),
         &payer_ata,
-        &gas_utils.config_pda,
-        &config_pda_ata,
         &mint,
         &token_program_id,
         destination_chain.clone(),

--- a/programs/axelar-solana-gas-service/tests/module/spl/refund_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/refund_gas.rs
@@ -51,12 +51,9 @@ async fn test_refund_spl_fees(#[case] token_program_id: Pubkey) {
     let tx_hash = [132; 64];
     let log_index = 42;
     let ix = axelar_solana_gas_service::instructions::refund_spl_fees_instruction(
-        &axelar_solana_gas_service::ID,
         &gas_utils.operator.pubkey(),
         &token_program_id,
         &mint,
-        &gas_utils.config_pda,
-        &config_pda_ata,
         &receiver_ata,
         tx_hash,
         log_index,

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -1018,14 +1018,13 @@ pub fn deploy_remote_canonical_interchain_token(
     mint: Pubkey,
     destination_chain: String,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
     let (metadata_account_key, _) = mpl_token_metadata::accounts::Metadata::find_pda(&mint);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -1034,7 +1033,7 @@ pub fn deploy_remote_canonical_interchain_token(
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1136,8 +1135,6 @@ pub fn deploy_remote_interchain_token(
     salt: [u8; 32],
     destination_chain: String,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
     let (its_root_pda, _) = crate::find_its_root_pda();
@@ -1146,6 +1143,7 @@ pub fn deploy_remote_interchain_token(
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
     let (metadata_account_key, _) = mpl_token_metadata::accounts::Metadata::find_pda(&mint);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -1154,7 +1152,7 @@ pub fn deploy_remote_interchain_token(
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1190,8 +1188,6 @@ pub fn deploy_remote_interchain_token_with_minter(
     destination_chain: String,
     destination_minter: Vec<u8>,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
     let (its_root_pda, _) = crate::find_its_root_pda();
@@ -1205,6 +1201,7 @@ pub fn deploy_remote_interchain_token_with_minter(
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
     let (minter_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::ID, &token_manager_pda, &minter);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -1217,7 +1214,7 @@ pub fn deploy_remote_interchain_token_with_minter(
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1251,13 +1248,12 @@ pub fn register_token_metadata(
     mint: Pubkey,
     token_program: Pubkey,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -1266,7 +1262,7 @@ pub fn register_token_metadata(
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1355,8 +1351,6 @@ pub fn link_token(
     token_manager_type: state::token_manager::Type,
     link_params: Vec<u8>,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
     let (its_root_pda, _) = crate::find_its_root_pda();
@@ -1364,6 +1358,7 @@ pub fn link_token(
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
     let token_id = crate::linked_token_id(&payer, &salt);
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -1371,7 +1366,7 @@ pub fn link_token(
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1411,8 +1406,6 @@ pub fn interchain_transfer(
     mint: Pubkey,
     token_program: Pubkey,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
     timestamp: i64,
 ) -> Result<Instruction, ProgramError> {
     let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
@@ -1424,6 +1417,7 @@ pub fn interchain_transfer(
         get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new_readonly(payer, true),
@@ -1436,7 +1430,7 @@ pub fn interchain_transfer(
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1476,8 +1470,6 @@ pub fn call_contract_with_interchain_token(
     data: Vec<u8>,
     token_program: Pubkey,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
     timestamp: i64,
 ) -> Result<Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
@@ -1488,6 +1480,7 @@ pub fn call_contract_with_interchain_token(
         get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new_readonly(payer, true),
@@ -1499,7 +1492,7 @@ pub fn call_contract_with_interchain_token(
         AccountMeta::new(flow_slot_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
@@ -1542,8 +1535,6 @@ pub fn call_contract_with_interchain_token_offchain_data(
     data: Vec<u8>,
     token_program: Pubkey,
     gas_value: u64,
-    gas_service: Pubkey,
-    gas_config_pda: Pubkey,
     timestamp: i64,
 ) -> Result<(Instruction, Vec<u8>), ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
@@ -1554,6 +1545,7 @@ pub fn call_contract_with_interchain_token_offchain_data(
         get_associated_token_address_with_program_id(&token_manager_pda, &mint, &token_program);
     let (call_contract_signing_pda, signing_pda_bump) =
         axelar_solana_gateway::get_call_contract_signing_pda(crate::ID);
+    let (gas_config_pda, _bump) = axelar_solana_gas_service::get_config_pda();
 
     let accounts = vec![
         AccountMeta::new_readonly(payer, true),
@@ -1565,7 +1557,7 @@ pub fn call_contract_with_interchain_token_offchain_data(
         AccountMeta::new(flow_slot_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
-        AccountMeta::new_readonly(gas_service, false),
+        AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),

--- a/programs/axelar-solana-its/src/processor/gmp.rs
+++ b/programs/axelar-solana-its/src/processor/gmp.rs
@@ -109,7 +109,7 @@ pub(crate) struct GmpAccounts<'a> {
     pub(crate) gateway_root_account: &'a AccountInfo<'a>,
     pub(crate) _gateway_program_id: &'a AccountInfo<'a>,
     pub(crate) gas_service_config_account: &'a AccountInfo<'a>,
-    pub(crate) gas_service: &'a AccountInfo<'a>,
+    pub(crate) _gas_service: &'a AccountInfo<'a>,
     pub(crate) system_program: &'a AccountInfo<'a>,
     pub(crate) its_root_account: &'a AccountInfo<'a>,
     pub(crate) call_contract_signing_account: &'a AccountInfo<'a>,
@@ -139,7 +139,7 @@ impl<'a> FromAccountInfoSlice<'a> for GmpAccounts<'a> {
             gateway_root_account: next_account_info(accounts_iter)?,
             _gateway_program_id: next_account_info(accounts_iter)?,
             gas_service_config_account: next_account_info(accounts_iter)?,
-            gas_service: next_account_info(accounts_iter)?,
+            _gas_service: next_account_info(accounts_iter)?,
             system_program: next_account_info(accounts_iter)?,
             its_root_account: next_account_info(accounts_iter)?,
             call_contract_signing_account: next_account_info(accounts_iter)?,
@@ -219,7 +219,6 @@ pub(crate) fn process_outbound<'a>(
     if gas_value > 0 {
         pay_gas(
             payer,
-            accounts.gas_service,
             accounts.gas_service_config_account,
             accounts.system_program,
             payload_hash,
@@ -246,23 +245,15 @@ pub(crate) fn process_outbound<'a>(
 
 fn pay_gas<'a>(
     payer: &'a AccountInfo<'a>,
-    gas_service: &'a AccountInfo<'a>,
     gas_service_config: &'a AccountInfo<'a>,
     system_program: &'a AccountInfo<'a>,
     payload_hash: [u8; 32],
     its_hub_address: String,
     gas_value: u64,
 ) -> ProgramResult {
-    if gas_service.key != &axelar_solana_gas_service::id() {
-        msg!("Invalid gas service account");
-        return Err(ProgramError::IncorrectProgramId);
-    }
-
     let gas_payment_ix =
         axelar_solana_gas_service::instructions::pay_native_for_contract_call_instruction(
-            gas_service.key,
             payer.key,
-            gas_service_config.key,
             crate::ITS_HUB_CHAIN_NAME.to_owned(),
             its_hub_address,
             payload_hash,

--- a/programs/axelar-solana-its/tests/module/deploy_interchain_token.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_interchain_token.rs
@@ -389,8 +389,6 @@ async fn test_prevent_deploy_approval_bypass(ctx: &mut ItsTestContext) -> anyhow
             destination_chain.to_string(),
             destination_minter.clone(),
             0, // gas value
-            axelar_solana_gas_service::id(),
-            ctx.solana_gas_utils.config_pda,
         )?;
 
     let (token_b_approval_pda, _) = axelar_solana_its::find_deployment_approval_pda(

--- a/programs/axelar-solana-its/tests/module/deploy_remote_metadata_validation.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_remote_metadata_validation.rs
@@ -66,8 +66,6 @@ async fn test_deploy_remote_interchain_token_with_valid_metadata(
             "ethereum".to_string(),
             vec![1, 2, 3, 4],
             0,
-            axelar_solana_gas_service::id(),
-            ctx.solana_gas_utils.config_pda,
         )?;
 
     let tx = ctx.send_solana_tx(&[deploy_remote_ix]).await;
@@ -183,8 +181,6 @@ async fn test_deploy_remote_interchain_token_with_mismatched_metadata(
             "ethereum".to_string(),
             vec![5, 6, 7, 8],
             0,
-            axelar_solana_gas_service::id(),
-            ctx.solana_gas_utils.config_pda,
         )?;
 
     // Get the accounts from the instruction
@@ -310,8 +306,6 @@ async fn test_deploy_remote_canonical_token_with_mismatched_metadata(
             canonical_mint,
             "ethereum".to_string(),
             0,
-            axelar_solana_gas_service::id(),
-            ctx.solana_gas_utils.config_pda,
         )?;
 
     // Get the accounts from the instruction
@@ -417,8 +411,6 @@ async fn test_deploy_remote_without_minter_with_mismatched_metadata(
         salt,
         "ethereum".to_string(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
     )?;
 
     // Get the accounts from the instruction

--- a/programs/axelar-solana-its/tests/module/flow_limits.rs
+++ b/programs/axelar-solana-its/tests/module/flow_limits.rs
@@ -232,8 +232,6 @@ async fn test_outgoing_interchain_transfer_within_limit(
         interchain_token_pda,
         spl_token_2022::id(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
         clock_sysvar.unix_timestamp,
     )?;
 
@@ -319,8 +317,6 @@ async fn test_outgoing_interchain_transfer_outside_limit(ctx: &mut ItsTestContex
         interchain_token_pda,
         spl_token_2022::id(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
         clock_sysvar.unix_timestamp,
     )
     .unwrap();
@@ -539,8 +535,6 @@ async fn test_flow_slot_initialization_outgoing_transfer(
         interchain_token_pda,
         spl_token_2022::id(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
         clock_sysvar.unix_timestamp,
     )?;
 
@@ -580,8 +574,6 @@ async fn test_flow_slot_initialization_outgoing_transfer(
         interchain_token_pda,
         spl_token_2022::id(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
         clock_sysvar.unix_timestamp,
     )?;
 

--- a/programs/axelar-solana-its/tests/module/from_evm_to_solana.rs
+++ b/programs/axelar-solana-its/tests/module/from_evm_to_solana.rs
@@ -80,8 +80,6 @@ async fn custom_token(
         custom_solana_token,
         spl_token_2022::id(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
     )?;
 
     let tx = ctx.send_solana_tx(&[register_metadata]).await.unwrap();

--- a/programs/axelar-solana-its/tests/module/main.rs
+++ b/programs/axelar-solana-its/tests/module/main.rs
@@ -315,8 +315,6 @@ impl ItsTestContext {
                 self.evm_chain_name.clone(),
                 self.evm_signer.wallet.address().as_bytes().to_vec(),
                 0,
-                axelar_solana_gas_service::id(),
-                self.solana_gas_utils.config_pda,
             )
             .unwrap();
 
@@ -359,8 +357,6 @@ impl ItsTestContext {
             solana_token,
             spl_token_2022::id(),
             0,
-            axelar_solana_gas_service::id(),
-            self.solana_gas_utils.config_pda,
             clock_sysvar.unix_timestamp,
         )
         .unwrap();

--- a/programs/axelar-solana-its/tests/module/pause_unpause.rs
+++ b/programs/axelar-solana-its/tests/module/pause_unpause.rs
@@ -132,8 +132,6 @@ async fn test_outbound_message_fails_when_paused(ctx: &mut ItsTestContext) {
         token_address,
         spl_token_2022::id(),
         0,
-        axelar_solana_gas_service::id(),
-        ctx.solana_gas_utils.config_pda,
         clock_sysvar.unix_timestamp,
     )
     .unwrap();


### PR DESCRIPTION
The GasService was initially designed such that multiple instances could coexist. This was due to the belief that we'd have multiple solana-axelar relayers, each with its own GasService state. After the introduction of the Operators contract, it was clear that that belief was wrong. Thus, we can simplify some APIs by removing the need for the user to provide the program id and config PDA, since these can be derived easily internally.