### PR TITLE
fix: ackee-15

### DIFF
--- a/crates/axelar-executable/src/lib.rs
+++ b/crates/axelar-executable/src/lib.rs
@@ -105,8 +105,8 @@ pub fn validate_message(accounts: &[AccountInfo<'_>], message: &Message) -> Prog
     )
 }
 
-/// Perform CPI call to the Axelar Gateway to ensure that the given command
-/// (containing a GMP message) is approved
+/// Perform CPI (Cross-Program Invocation) call to the Axelar Gateway to
+/// ensure that the given command (containing a GMP message) is approved
 ///
 /// This is useful for contracts that have custom legacy implementations by
 /// Axelar on other chains, and therefore they cannot provide the accounts in

--- a/programs/axelar-solana-governance/src/entrypoint.rs
+++ b/programs/axelar-solana-governance/src/entrypoint.rs
@@ -11,9 +11,9 @@ use crate::processor::Processor;
 
 solana_program::entrypoint!(process_instruction);
 
-fn process_instruction(
+fn process_instruction<'a, 'b: 'a>(
     program_id: &Pubkey,
-    accounts: &[AccountInfo<'_>],
+    accounts: &'b [AccountInfo<'a>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     Processor::process_instruction(program_id, accounts, instruction_data)

--- a/programs/axelar-solana-governance/src/lib.rs
+++ b/programs/axelar-solana-governance/src/lib.rs
@@ -1,5 +1,7 @@
 //! # Governance program
 
+#![allow(clippy::unneeded_field_pattern)]
+
 use program_utils::ensure_single_feature;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::program_error::ProgramError;

--- a/programs/axelar-solana-governance/src/processor/execute_operator_proposal.rs
+++ b/programs/axelar-solana-governance/src/processor/execute_operator_proposal.rs
@@ -2,8 +2,8 @@
 //!
 //! See [original implementation](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/governance/AxelarServiceGovernance.sol#L75).
 use borsh::to_vec;
-use program_utils::{pda::ValidPDA, validate_system_account_key};
-use solana_program::account_info::{next_account_info, AccountInfo};
+use program_utils::{account_array_structs, pda::ValidPDA, validate_system_account_key};
+use solana_program::account_info::AccountInfo;
 use solana_program::msg;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
@@ -11,6 +11,19 @@ use solana_program::pubkey::Pubkey;
 use crate::events::GovernanceEvent;
 use crate::state::proposal::{ExecutableProposal, ExecuteProposalData};
 use crate::state::{operator, GovernanceConfig};
+
+account_array_structs! {
+    // Struct whose attributes are of type `AccountInfo`
+    ExecuteOperatorProposalInfo,
+    // Struct whose attributes are of type `AccountMeta`
+    ExecuteOperatorProposalMeta,
+    // Attributes
+    system_account,
+    config_pda,
+    proposal_account,
+    operator_account,
+    operator_pda_marker_account
+}
 
 /// Executes a previously proposal whitelisted for execution by the operator.
 ///
@@ -22,13 +35,13 @@ pub(crate) fn process(
     accounts: &[AccountInfo<'_>],
     execute_proposal_data: &ExecuteProposalData,
 ) -> Result<(), ProgramError> {
-    let accounts_iter = &mut accounts.iter();
-    let system_account = next_account_info(accounts_iter)?;
-    let _payer = next_account_info(accounts_iter)?;
-    let config_pda = next_account_info(accounts_iter)?;
-    let proposal_account = next_account_info(accounts_iter)?;
-    let operator_account = next_account_info(accounts_iter)?;
-    let operator_pda_marker_account = next_account_info(accounts_iter)?;
+    let ExecuteOperatorProposalInfo {
+        system_account,
+        config_pda,
+        proposal_account,
+        operator_account,
+        operator_pda_marker_account,
+    } = ExecuteOperatorProposalInfo::from_account_iter(&mut accounts.iter())?;
 
     validate_system_account_key(system_account.key)?;
 

--- a/programs/axelar-solana-governance/src/processor/execute_proposal.rs
+++ b/programs/axelar-solana-governance/src/processor/execute_proposal.rs
@@ -6,10 +6,23 @@ use crate::events::GovernanceEvent;
 use crate::state::proposal::{ExecutableProposal, ExecuteProposalData};
 use crate::state::GovernanceConfig;
 use borsh::to_vec;
-use program_utils::{from_u64_to_u256_le_bytes, pda::ValidPDA, validate_system_account_key};
-use solana_program::account_info::{next_account_info, AccountInfo};
+use program_utils::{
+    account_array_structs, from_u64_to_u256_le_bytes, pda::ValidPDA, validate_system_account_key,
+};
+use solana_program::account_info::AccountInfo;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
+
+account_array_structs! {
+    // Struct whose attributes are of type `AccountInfo`
+    ExecuteProposalInfo,
+    // Struct whose attributes are of type `AccountMeta`
+    ExecuteProposalMeta,
+    // Attributes
+    system_account,
+    config_pda,
+    proposal_account
+}
 
 /// Executes a previously GMP received proposal if the proposal has reached its
 /// ETA.
@@ -22,10 +35,11 @@ pub(crate) fn process(
     accounts: &[AccountInfo<'_>],
     execute_proposal_data: &ExecuteProposalData,
 ) -> Result<(), ProgramError> {
-    let accounts_iter = &mut accounts.iter();
-    let system_account = next_account_info(accounts_iter)?;
-    let config_pda = next_account_info(accounts_iter)?;
-    let proposal_account = next_account_info(accounts_iter)?;
+    let ExecuteProposalInfo {
+        system_account,
+        config_pda,
+        proposal_account,
+    } = ExecuteProposalInfo::from_account_iter(&mut accounts.iter())?;
 
     validate_system_account_key(system_account.key)?;
 

--- a/programs/axelar-solana-governance/src/processor/gmp/cancel_operator_approval.rs
+++ b/programs/axelar-solana-governance/src/processor/gmp/cancel_operator_approval.rs
@@ -2,13 +2,27 @@
 //!
 //! See [original implementation](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/governance/AxelarServiceGovernance.sol#L17).
 
-use program_utils::validate_system_account_key;
-use solana_program::account_info::{next_account_info, AccountInfo};
+use program_utils::{account_array_structs, validate_system_account_key};
+use solana_program::account_info::AccountInfo;
 use solana_program::program_error::ProgramError;
 
 use super::ProcessGMPContext;
 use crate::events::GovernanceEvent;
 use crate::state::operator;
+
+account_array_structs! {
+    // Struct whose attributes are of type `AccountInfo`
+    CancelOperatorApprovalInfo,
+    // Struct whose attributes are of type `AccountMeta`
+    CancelOperatorApprovalMeta,
+    // Attributes
+    // Mandatory for every GMP instruction in the Governance program.
+    system_account,
+    // Mandatory for every GMP instruction in the Governance program.
+    root_pda,
+    proposal_pda,
+    operator_proposal_pda
+}
 
 /// Processes a Governance GMP `CancelOperatorApproval` command.
 ///
@@ -19,12 +33,12 @@ pub(crate) fn process(
     ctx: ProcessGMPContext,
     accounts: &[AccountInfo<'_>],
 ) -> Result<(), ProgramError> {
-    let accounts_iter = &mut accounts.iter();
-    let system_account = next_account_info(accounts_iter)?;
-    let _payer = next_account_info(accounts_iter)?;
-    let root_pda = next_account_info(accounts_iter)?;
-    let proposal_pda = next_account_info(accounts_iter)?;
-    let operator_proposal_pda = next_account_info(accounts_iter)?;
+    let CancelOperatorApprovalInfo {
+        system_account,
+        root_pda,
+        proposal_pda,
+        operator_proposal_pda,
+    } = CancelOperatorApprovalInfo::from_account_iter(&mut accounts.iter())?;
 
     validate_system_account_key(system_account.key)?;
 

--- a/programs/axelar-solana-governance/src/processor/gmp/cancel_time_lock_proposal.rs
+++ b/programs/axelar-solana-governance/src/processor/gmp/cancel_time_lock_proposal.rs
@@ -2,13 +2,26 @@
 //!
 //! See [original implementation](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/governance/AxelarServiceGovernance.sol#L18).
 
-use program_utils::validate_system_account_key;
-use solana_program::account_info::{next_account_info, AccountInfo};
+use program_utils::{account_array_structs, validate_system_account_key};
+use solana_program::account_info::AccountInfo;
 use solana_program::program_error::ProgramError;
 
 use super::ProcessGMPContext;
 use crate::events::GovernanceEvent;
 use crate::state::proposal::ExecutableProposal;
+
+account_array_structs! {
+    // Struct whose attributes are of type `AccountInfo`
+    CancelTimeLockProposalInfo,
+    // Struct whose attributes are of type `AccountMeta`
+    CancelTimeLockProposalMeta,
+    // Attributes
+    // Mandatory for every GMP instruction in the Governance program.
+    system_account,
+    // Mandatory for every GMP instruction in the Governance program.
+    root_pda,
+    proposal_pda
+}
 
 /// Processes a Governance GMP `CancelTimeLockProposal` command.
 ///
@@ -19,11 +32,11 @@ pub(crate) fn process(
     ctx: ProcessGMPContext,
     accounts: &[AccountInfo<'_>],
 ) -> Result<(), ProgramError> {
-    let accounts_iter = &mut accounts.iter();
-    let system_account = next_account_info(accounts_iter)?;
-    let _payer = next_account_info(accounts_iter)?;
-    let root_pda = next_account_info(accounts_iter)?;
-    let proposal_pda = next_account_info(accounts_iter)?;
+    let CancelTimeLockProposalInfo {
+        system_account,
+        root_pda,
+        proposal_pda,
+    } = CancelTimeLockProposalInfo::from_account_iter(&mut accounts.iter())?;
 
     validate_system_account_key(system_account.key)?;
 

--- a/programs/axelar-solana-governance/src/processor/gmp/mod.rs
+++ b/programs/axelar-solana-governance/src/processor/gmp/mod.rs
@@ -41,12 +41,17 @@ mod cancel_operator_approval;
 mod cancel_time_lock_proposal;
 mod schedule_time_lock_proposal;
 
+pub use approve_operator_proposal::ApproveOperatorProposalMeta;
+pub use cancel_operator_approval::CancelOperatorApprovalMeta;
+pub use cancel_time_lock_proposal::CancelTimeLockProposalMeta;
+pub use schedule_time_lock_proposal::ScheduleTimeLockProposalMeta;
+
 /// The index of the first account that is expected to be passed to the
 /// destination program.
 pub const PROGRAM_ACCOUNTS_SPLIT_AT: usize = 4;
 
 /// The index of the root PDA account in the accounts slice.
-const ROOT_PDA_ACCOUNT_INDEX: usize = 2;
+const ROOT_PDA_ACCOUNT_INDEX: usize = 1;
 
 pub(crate) fn process(
     program_id: &Pubkey,
@@ -92,9 +97,9 @@ impl ProcessGMPContext {
     /// # Errors
     ///
     /// Returns a `ProgramError` if any validation or decoding fails.
-    pub fn new_from_processor_context(
+    pub fn new_from_processor_context<'a>(
         _program_id: &Pubkey,
-        gw_accounts: &[AccountInfo<'_>],
+        gw_accounts: &'a [AccountInfo<'a>],
         gmp_accounts: &[AccountInfo<'_>],
         message: &Message,
     ) -> Result<Self, ProgramError> {

--- a/programs/axelar-solana-governance/src/processor/init_config.rs
+++ b/programs/axelar-solana-governance/src/processor/init_config.rs
@@ -1,9 +1,9 @@
 //! Initialize Governance Config Account with the provided Governance Config
 //! data.
 
-use program_utils::pda::ValidPDA;
+use program_utils::{account_array_structs, pda::ValidPDA};
 use role_management::processor::ensure_upgrade_authority;
-use solana_program::account_info::{next_account_info, AccountInfo};
+use solana_program::account_info::AccountInfo;
 use solana_program::msg;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
@@ -11,6 +11,18 @@ use solana_program::system_program;
 
 use crate::seed_prefixes;
 use crate::state::{GovernanceConfig, VALID_PROPOSAL_DELAY_RANGE};
+
+account_array_structs! {
+    // Struct whose attributes are of type `AccountInfo`
+    GovernanceConfigInfo,
+    // Struct whose attributes are of type `AccountMeta`
+    GovernanceConfigMeta,
+    // Attributes
+    payer,
+    program_data,
+    root_pda,
+    system_account
+}
 
 /// Initializes the Governance Config Account with the provided Governance
 /// Config.
@@ -23,11 +35,12 @@ pub(crate) fn process(
     accounts: &[AccountInfo<'_>],
     mut governance_config: GovernanceConfig,
 ) -> Result<(), ProgramError> {
-    let accounts_iter = &mut accounts.iter();
-    let payer = next_account_info(accounts_iter)?;
-    let program_data = next_account_info(accounts_iter)?;
-    let root_pda = next_account_info(accounts_iter)?;
-    let system_account = next_account_info(accounts_iter)?;
+    let GovernanceConfigInfo {
+        payer,
+        program_data,
+        root_pda,
+        system_account,
+    } = GovernanceConfigInfo::from_account_iter(&mut accounts.iter())?;
 
     ensure_upgrade_authority(program_id, payer, program_data)?;
 

--- a/programs/axelar-solana-governance/tests/module/execute_operator_proposal.rs
+++ b/programs/axelar-solana-governance/tests/module/execute_operator_proposal.rs
@@ -71,11 +71,7 @@ async fn test_full_flow_operator_proposal_execution() {
     // Send the operator execute proposal instruction
     let ix = ix_builder
         .clone()
-        .execute_operator_proposal(
-            &sol_integration.fixture.payer.pubkey(),
-            &config_pda,
-            &operator.pubkey(),
-        )
+        .execute_operator_proposal(&config_pda, &operator.pubkey())
         .build();
 
     let res = sol_integration
@@ -147,11 +143,7 @@ async fn test_non_previously_approved_operator_proposal_execution_fails() {
     // Send the operator execute proposal instruction
     let ix = ix_builder
         .clone()
-        .execute_operator_proposal(
-            &sol_integration.fixture.payer.pubkey(),
-            &config_pda,
-            &operator.pubkey(),
-        )
+        .execute_operator_proposal(&config_pda, &operator.pubkey())
         .build();
 
     let res = sol_integration
@@ -186,7 +178,7 @@ async fn test_only_operator_can_execute_ix() {
 
     let ix = ix_builder
         .clone()
-        .execute_operator_proposal(&fixture.payer.pubkey(), &config_pda, &operator.pubkey())
+        .execute_operator_proposal(&config_pda, &operator.pubkey())
         .build();
 
     let res = fixture
@@ -231,11 +223,7 @@ async fn test_program_checks_proposal_pda_is_correctly_derived() {
 
     let operator = operator_keypair();
     let ix = ix_builder
-        .execute_operator_proposal(
-            &sol_integration.fixture.payer.pubkey(),
-            &config_pda,
-            &operator.pubkey(),
-        )
+        .execute_operator_proposal(&config_pda, &operator.pubkey())
         .build();
 
     let res = sol_integration
@@ -289,11 +277,7 @@ async fn test_program_checks_operator_pda_is_correctly_derived() {
 
     let operator = operator_keypair();
     let ix = ix_builder
-        .execute_operator_proposal(
-            &sol_integration.fixture.payer.pubkey(),
-            &config_pda,
-            &operator.pubkey(),
-        )
+        .execute_operator_proposal(&config_pda, &operator.pubkey())
         .build();
 
     let res = sol_integration

--- a/programs/axelar-solana-governance/tests/module/gmp/cancel_operator.rs
+++ b/programs/axelar-solana-governance/tests/module/gmp/cancel_operator.rs
@@ -59,7 +59,7 @@ async fn test_successfully_process_gmp_cancel_operator_proposal() {
         .clone()
         .gmp_ix()
         .with_msg_metadata(meta.clone())
-        .cancel_operator_proposal(&sol_integration.fixture.payer.pubkey(), &config_pda)
+        .cancel_operator_proposal(&config_pda)
         .build();
 
     approve_ix_at_gateway(&mut sol_integration, &mut gmp_call_data).await;
@@ -130,7 +130,7 @@ async fn test_program_checks_proposal_pda_is_correctly_derived() {
         .clone()
         .gmp_ix()
         .with_msg_metadata(meta.clone())
-        .cancel_operator_proposal(&sol_integration.fixture.payer.pubkey(), &config_pda)
+        .cancel_operator_proposal(&config_pda)
         .build();
     approve_ix_at_gateway(&mut sol_integration, &mut gmp_call_data).await;
     let res = sol_integration.fixture.send_tx(&[gmp_call_data.ix]).await;
@@ -184,9 +184,9 @@ async fn test_program_checks_operator_pda_is_correctly_derived() {
         .clone()
         .gmp_ix()
         .with_msg_metadata(meta.clone())
-        .cancel_operator_proposal(&sol_integration.fixture.payer.pubkey(), &config_pda)
+        .cancel_operator_proposal(&config_pda)
         .build();
-    gmp_call_data.ix.accounts[4] = AccountMeta::new_readonly(Pubkey::new_unique(), false); // Wrong PDA account
+    gmp_call_data.ix.accounts[3] = AccountMeta::new_readonly(Pubkey::new_unique(), false); // Wrong PDA account
     approve_ix_at_gateway(&mut sol_integration, &mut gmp_call_data).await;
     let res = sol_integration.fixture.send_tx(&[gmp_call_data.ix]).await;
     assert!(res.is_err());

--- a/programs/axelar-solana-governance/tests/module/gmp/cancel_time_lock_proposal.rs
+++ b/programs/axelar-solana-governance/tests/module/gmp/cancel_time_lock_proposal.rs
@@ -32,7 +32,7 @@ async fn test_an_scheduled_proposal_can_be_cancelled() {
         .clone()
         .gmp_ix()
         .with_msg_metadata(meta.clone())
-        .cancel_time_lock_proposal(&sol_integration.fixture.payer.pubkey(), &config_pda)
+        .cancel_time_lock_proposal(&config_pda)
         .build();
     approve_ix_at_gateway(&mut sol_integration, &mut gmp_call_data).await;
     let res = sol_integration.fixture.send_tx(&[gmp_call_data.ix]).await;
@@ -73,7 +73,7 @@ async fn test_a_non_existent_scheduled_proposal_cannot_be_cancelled() {
         .clone()
         .gmp_ix()
         .with_msg_metadata(meta.clone())
-        .cancel_time_lock_proposal(&sol_integration.fixture.payer.pubkey(), &config_pda)
+        .cancel_time_lock_proposal(&config_pda)
         .build();
     approve_ix_at_gateway(&mut sol_integration, &mut gmp_call_data).await;
     let res = sol_integration.fixture.send_tx(&[gmp_call_data.ix]).await;
@@ -108,7 +108,7 @@ async fn test_program_checks_proposal_pda_is_correctly_derived() {
         .clone()
         .gmp_ix()
         .with_msg_metadata(meta.clone())
-        .cancel_time_lock_proposal(&sol_integration.fixture.payer.pubkey(), &config_pda)
+        .cancel_time_lock_proposal(&config_pda)
         .build();
 
     approve_ix_at_gateway(&mut sol_integration, &mut gmp_call_data).await;

--- a/programs/axelar-solana-governance/tests/module/transfer_operatorship.rs
+++ b/programs/axelar-solana-governance/tests/module/transfer_operatorship.rs
@@ -31,12 +31,7 @@ async fn test_operator_transfer_can_happen_being_operator_signer() {
     let new_operator = Pubkey::new_unique();
 
     let ix = IxBuilder::new()
-        .transfer_operatorship(
-            &fixture.payer.pubkey(),
-            &operator.pubkey(),
-            &config_pda,
-            &new_operator,
-        )
+        .transfer_operatorship(&operator.pubkey(), &config_pda, &new_operator)
         .build();
 
     let res = fixture
@@ -88,12 +83,7 @@ async fn test_error_is_emitted_when_no_required_signers() {
             .unwrap();
 
     let ix = IxBuilder::new()
-        .transfer_operatorship(
-            &fixture.payer.pubkey(),
-            &operator.pubkey(),
-            &config_pda,
-            &Pubkey::new_unique(),
-        )
+        .transfer_operatorship(&operator.pubkey(), &config_pda, &Pubkey::new_unique())
         .build();
 
     let res = fixture
@@ -116,7 +106,6 @@ async fn test_can_change_operator_via_gmp_proposal() {
     let new_operator = Pubkey::new_unique();
 
     let ix_builder = IxBuilder::new().builder_for_operatorship_transfership(
-        &sol_integration.fixture.payer.pubkey(),
         &config_pda,
         &operator_keypair().pubkey(),
         &new_operator,


### PR DESCRIPTION
Referenced issue
--

~~If applies, the issue this PR belongs to.~~

Summary of changes
--

A brief summary of the changes and motivations.

- [ ] ~~Does this PR change behavior or adds a new feature ?~~
- [x] docs updated
- [x] tests updated
- [x] code style matches guidelines

The `account_array_structs` macro helped me highlight inconsistencies between client and program parameters. Two recurring situations:
- `root_pda` was often unused in the GMP instruction modules but still needed for early validation in the GMP routing layer,
- `payer` was unused in a few instructions, please let me know if this is a sign of missing validation.

Reviewer recommendations
--

Apart from reading the above, please take a look at the comment I left myself to this PR. Feel free to resolve them if they make sense, are consistent and valid.

Ready-ready checklist
--

- [ ] Labels (ticket type and component) are set
- [ ] Project & Phase is assigned
- [ ] This checklist is removed
