### PR TITLE
feat(axelar_gateway)!: add payer to the seeds of the message_payload pda

### DIFF
--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -398,8 +398,10 @@ impl SolanaAxelarIntegrationMetadata {
         self.commit_message_payload(msg_command_id).await?;
 
         let (incoming_message_pda, _) = get_incoming_message_pda(&msg_command_id);
-        let (message_payload_account, _bump) =
-            axelar_solana_gateway::find_message_payload_pda(incoming_message_pda);
+        let (message_payload_account, _bump) = axelar_solana_gateway::find_message_payload_pda(
+            incoming_message_pda,
+            self.fixture.payer.pubkey(),
+        );
 
         Ok(message_payload_account)
     }

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -544,7 +544,7 @@ pub fn initialize_message_payload(
     buffer_size: u64,
 ) -> Result<Instruction, ProgramError> {
     let (incoming_message_pda, _) = crate::get_incoming_message_pda(&command_id);
-    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda);
+    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda, payer);
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -573,15 +573,15 @@ pub fn initialize_message_payload(
 /// Returns a [`ProgramError::BorshIoError`] if the instruction serialization fails.t
 pub fn write_message_payload(
     gateway_root_pda: Pubkey,
-    authority: Pubkey,
+    payer: Pubkey,
     command_id: [u8; 32],
     bytes: &[u8],
     offset: u64,
 ) -> Result<Instruction, ProgramError> {
     let (incoming_message_pda, _) = crate::get_incoming_message_pda(&command_id);
-    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda);
+    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda, payer);
     let accounts = vec![
-        AccountMeta::new(authority, true),
+        AccountMeta::new(payer, true),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(incoming_message_pda, false),
         AccountMeta::new(message_payload_pda, false),
@@ -605,14 +605,14 @@ pub fn write_message_payload(
 /// Returns a [`ProgramError::BorshIoError`] if the instruction serialization fails.
 pub fn commit_message_payload(
     gateway_root_pda: Pubkey,
-    authority: Pubkey,
+    payer: Pubkey,
     command_id: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
     let (incoming_message_pda, _) = crate::get_incoming_message_pda(&command_id);
-    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda);
+    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda, payer);
 
     let accounts = vec![
-        AccountMeta::new(authority, true),
+        AccountMeta::new(payer, true),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(incoming_message_pda, false),
         AccountMeta::new(message_payload_pda, false),
@@ -633,13 +633,13 @@ pub fn commit_message_payload(
 /// Returns a [`ProgramError::BorshIoError`] if the instruction serialization fails.
 pub fn close_message_payload(
     gateway_root_pda: Pubkey,
-    authority: Pubkey,
+    payer: Pubkey,
     command_id: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
     let (incoming_message_pda, _) = crate::get_incoming_message_pda(&command_id);
-    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda);
+    let (message_payload_pda, _) = crate::find_message_payload_pda(incoming_message_pda, payer);
     let accounts = vec![
-        AccountMeta::new(authority, false),
+        AccountMeta::new(payer, true),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(incoming_message_pda, false),
         AccountMeta::new(message_payload_pda, false),

--- a/programs/axelar-solana-gateway/src/lib.rs
+++ b/programs/axelar-solana-gateway/src/lib.rs
@@ -347,11 +347,12 @@ pub fn create_call_contract_signing_pda(
 /// using [`create_message_payload_pda`] instead.
 #[inline]
 #[must_use]
-pub fn find_message_payload_pda(incoming_message_pda: Pubkey) -> (Pubkey, u8) {
+pub fn find_message_payload_pda(incoming_message_pda: Pubkey, payer: Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
             seed_prefixes::MESSAGE_PAYLOAD_SEED,
             incoming_message_pda.as_ref(),
+            payer.as_ref(),
         ],
         &crate::ID,
     )
@@ -367,12 +368,14 @@ pub fn find_message_payload_pda(incoming_message_pda: Pubkey) -> (Pubkey, u8) {
 #[inline]
 pub fn create_message_payload_pda(
     incoming_message_pda: Pubkey,
+    payer: Pubkey,
     bump: u8,
 ) -> Result<Pubkey, PubkeyError> {
     Pubkey::create_program_address(
         &[
             seed_prefixes::MESSAGE_PAYLOAD_SEED,
             incoming_message_pda.as_ref(),
+            payer.as_ref(),
             &[bump],
         ],
         &crate::ID,
@@ -399,8 +402,9 @@ mod tests {
     #[test]
     fn test_find_and_create_message_payload_pda_bump_reuse() {
         let incoming_message_pda = Pubkey::new_unique();
-        let (found_pda, bump) = find_message_payload_pda(incoming_message_pda);
-        let created_pda = create_message_payload_pda(incoming_message_pda, bump).unwrap();
+        let payer = Pubkey::new_unique();
+        let (found_pda, bump) = find_message_payload_pda(incoming_message_pda, payer);
+        let created_pda = create_message_payload_pda(incoming_message_pda, payer, bump).unwrap();
         assert_eq!(found_pda, created_pda);
     }
 

--- a/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
@@ -69,7 +69,7 @@ impl Processor {
         // Check: Buffer PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
         let message_payload_pda =
-            crate::create_message_payload_pda(incoming_message_pda, *message_payload.bump)?;
+            crate::create_message_payload_pda(incoming_message_pda, *payer.key, *message_payload.bump)?;
         if &message_payload_pda != message_payload_account.key {
             solana_program::msg!("Error: failed to derive message payload account address");
             return Err(ProgramError::InvalidSeeds);

--- a/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
@@ -68,8 +68,11 @@ impl Processor {
 
         // Check: Buffer PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
-        let message_payload_pda =
-            crate::create_message_payload_pda(incoming_message_pda, *payer.key, *message_payload.bump)?;
+        let message_payload_pda = crate::create_message_payload_pda(
+            incoming_message_pda,
+            *payer.key,
+            *message_payload.bump,
+        )?;
         if &message_payload_pda != message_payload_account.key {
             solana_program::msg!("Error: failed to derive message payload account address");
             return Err(ProgramError::InvalidSeeds);

--- a/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
@@ -66,7 +66,7 @@ impl Processor {
         // Check: Message Payload PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
         let message_payload_pda =
-            crate::create_message_payload_pda(incoming_message_pda, *message_payload.bump)?;
+            crate::create_message_payload_pda(incoming_message_pda, *payer.key, *message_payload.bump)?;
 
         if &message_payload_pda != message_payload_account.key {
             solana_program::msg!("Error: failed to derive message payload account address");

--- a/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
@@ -65,8 +65,11 @@ impl Processor {
 
         // Check: Message Payload PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
-        let message_payload_pda =
-            crate::create_message_payload_pda(incoming_message_pda, *payer.key, *message_payload.bump)?;
+        let message_payload_pda = crate::create_message_payload_pda(
+            incoming_message_pda,
+            *payer.key,
+            *message_payload.bump,
+        )?;
 
         if &message_payload_pda != message_payload_account.key {
             solana_program::msg!("Error: failed to derive message payload account address");

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -114,7 +114,7 @@ impl Processor {
             payer.key.as_ref(),
             &[bump_seed],
         ];
-        
+
         init_pda_raw(
             payer,
             message_payload_account,

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -92,7 +92,7 @@ impl Processor {
         // Check: Buffer PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
         let (message_payload_pda, bump_seed) =
-            crate::find_message_payload_pda(incoming_message_pda);
+            crate::find_message_payload_pda(incoming_message_pda, *payer.key);
         if message_payload_account.key != &message_payload_pda {
             solana_program::msg!("Error: failed to derive message payload account address");
             return Err(ProgramError::InvalidArgument);

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -111,9 +111,10 @@ impl Processor {
         let signers_seeds = &[
             crate::seed_prefixes::MESSAGE_PAYLOAD_SEED,
             incoming_message_pda.as_ref(),
+            payer.key.as_ref(),
             &[bump_seed],
         ];
-
+        
         init_pda_raw(
             payer,
             message_payload_account,

--- a/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
@@ -69,8 +69,11 @@ impl Processor {
 
         // Check: Message Payload PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
-        let message_payload_pda =
-            crate::create_message_payload_pda(incoming_message_pda, *payer.key, *message_payload.bump)?;
+        let message_payload_pda = crate::create_message_payload_pda(
+            incoming_message_pda,
+            *payer.key,
+            *message_payload.bump,
+        )?;
         if message_payload_account.key != &message_payload_pda {
             solana_program::msg!("Error: failed to derive message payload account address");
             return Err(ProgramError::InvalidArgument);

--- a/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
@@ -70,7 +70,7 @@ impl Processor {
         // Check: Message Payload PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
         let message_payload_pda =
-            crate::create_message_payload_pda(incoming_message_pda, *message_payload.bump)?;
+            crate::create_message_payload_pda(incoming_message_pda, *payer.key, *message_payload.bump)?;
         if message_payload_account.key != &message_payload_pda {
             solana_program::msg!("Error: failed to derive message payload account address");
             return Err(ProgramError::InvalidArgument);

--- a/programs/axelar-solana-gateway/tests/integration/commit_message_payload.rs
+++ b/programs/axelar-solana-gateway/tests/integration/commit_message_payload.rs
@@ -91,8 +91,10 @@ async fn successfully_commit_message_payload_pda() {
     // Setup: Build and send an instruction to write the message payload bytes
     let command_id = message_to_command_id(&message);
     let (incoming_message_pda, _) = axelar_solana_gateway::get_incoming_message_pda(&command_id);
-    let (message_payload_pda, _) =
-        axelar_solana_gateway::find_message_payload_pda(incoming_message_pda);
+    let (message_payload_pda, _) = axelar_solana_gateway::find_message_payload_pda(
+        incoming_message_pda,
+        runner.payer.pubkey(),
+    );
     let write_ix = axelar_solana_gateway::instructions::write_message_payload(
         gateway_root_pda,
         runner.payer.pubkey(),

--- a/programs/axelar-solana-gateway/tests/integration/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_message_payload.rs
@@ -35,8 +35,10 @@ pub async fn get_message_account(
 ) -> Option<Account> {
     let command_id = message_to_command_id(message);
     let (incoming_message_pda, _) = get_incoming_message_pda(&command_id);
-    let (message_payload_pda, _bump) =
-        axelar_solana_gateway::find_message_payload_pda(incoming_message_pda);
+    let (message_payload_pda, _bump) = axelar_solana_gateway::find_message_payload_pda(
+        incoming_message_pda,
+        runner.payer.pubkey(),
+    );
     runner
         .try_get_account(&message_payload_pda, &axelar_solana_gateway::ID)
         .await
@@ -147,7 +149,7 @@ pub async fn initialize_message_payload_pda(
 
     // Check the bump too
     let (incoming_message_pda, _) = get_incoming_message_pda(&command_id);
-    let (_, bump) = find_message_payload_pda(incoming_message_pda);
+    let (_, bump) = find_message_payload_pda(incoming_message_pda, runner.payer.pubkey());
     assert_eq!(*message_payload.bump, bump);
 }
 


### PR DESCRIPTION
**Referenced issue**

If applies, the issue this PR belongs to.

**Summary of changes**

Added the payer to the seeds for derivation of the message_payload PDA. This ensures that no one can block the creation/writing of message_payload PDAs, and that in order to close it the payer associated with it has to sign for it, also removing the ability for anyone to steal their funds. This means that the relayer that started to execute a message has to see it through.

- [ ] Does this PR change behavior or adds a new feature ?
- [ ] docs updated
- [ ] tests updated
- [ ] code style matches guidelines

**Reviewer recommendations**

How to make the review easier. i.e "Its a big PR and the recommendation is to go through each commit" or "In order to run the tests, execute ..."

**Ready-ready checklist**

- [ ] Labels (ticket type and component) are set
- [ ] Project & Phase is assigned
- [ ] This checklist is removed
