### PR TITLE
fix(gateway): confusing log message

### DIFF
--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -60,7 +60,7 @@ impl Processor {
 
         // Check verification session account requirements
         if verification_session_account.is_signer {
-            solana_program::msg!("Error: verification session account is not a signer");
+            solana_program::msg!("Error: verification session account cannot be a signer");
             return Err(ProgramError::InvalidAccountData);
         }
         if !verification_session_account.is_writable {


### PR DESCRIPTION
The check does something and the message was telling something else.
Since the verification session account is created by the gateway, it can
only sign if the transaction is invoked with invoke_signed by the
gateway. We expect `initialize_payload_verification_session` to invoked
by the relayer, thus this account cannot be a signer.