### PR TITLE
chore: allow unneeded_field_pattern at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ unseparated_literal_suffix = "allow"
 unused_trait_names = "allow"
 unwrap_used = "allow"
 use_self = "allow"
+unneeded_field_pattern = "allow"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "allow", priority = 0 }

--- a/programs/axelar-solana-governance/src/lib.rs
+++ b/programs/axelar-solana-governance/src/lib.rs
@@ -1,7 +1,5 @@
 //! # Governance program
 
-#![allow(clippy::unneeded_field_pattern)]
-
 use program_utils::ensure_single_feature;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::program_error::ProgramError;


### PR DESCRIPTION
This was already allowed in the governance crate.

[See the Clippy doc](https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_field_pattern)

Motivation: using `..` may make potentially breaking changes silent by not triggering a compilation error upon enum changes.