### PR TITLE
fix(its): c50 check ATA derivation upon outbound transfer

### DIFF
--- a/crates/axelar-solana-gateway-test-fixtures/src/lib.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/lib.rs
@@ -14,3 +14,15 @@ pub mod gateway;
 pub mod test_signer;
 
 pub use gateway::{SolanaAxelarIntegration, SolanaAxelarIntegrationMetadata};
+use solana_program_test::BanksTransactionResultWithMetadata;
+
+pub fn assert_msg_present_in_logs(res: BanksTransactionResultWithMetadata, msg: &str) {
+    assert!(
+        res.metadata
+            .unwrap()
+            .log_messages
+            .into_iter()
+            .any(|x| x.contains(msg)),
+        "Expected error message not found!"
+    );
+}

--- a/programs/axelar-solana-governance/tests/module/execute_operator_proposal.rs
+++ b/programs/axelar-solana-governance/tests/module/execute_operator_proposal.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::FindLog;
 use axelar_solana_gateway_test_fixtures::base::TestFixture;
 use axelar_solana_governance::events::GovernanceEvent;
@@ -10,9 +11,9 @@ use solana_sdk::signature::{Keypair, Signer};
 
 use crate::fixtures::operator_keypair;
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, deploy_governance_program, events,
-    gmp_memo_metadata, gmp_sample_metadata, init_contract_with_operator,
-    ix_builder_with_memo_proposal_data, ix_builder_with_sample_proposal_data, setup_programs,
+    approve_ix_at_gateway, deploy_governance_program, events, gmp_memo_metadata,
+    gmp_sample_metadata, init_contract_with_operator, ix_builder_with_memo_proposal_data,
+    ix_builder_with_sample_proposal_data, setup_programs,
 };
 
 /// This is a full flow test that tests the execution of a proposal that reaches

--- a/programs/axelar-solana-governance/tests/module/execute_proposal.rs
+++ b/programs/axelar-solana-governance/tests/module/execute_proposal.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::FindLog;
 use axelar_solana_governance::events::GovernanceEvent;
 use axelar_solana_governance::instructions::builder::{IxBuilder, ProposalRelated};
@@ -8,9 +9,8 @@ use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::signature::Signer;
 
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, default_proposal_eta, events,
-    gmp_memo_metadata, gmp_sample_metadata, ix_builder_with_memo_proposal_data,
-    ix_builder_with_sample_proposal_data, setup_programs,
+    approve_ix_at_gateway, default_proposal_eta, events, gmp_memo_metadata, gmp_sample_metadata,
+    ix_builder_with_memo_proposal_data, ix_builder_with_sample_proposal_data, setup_programs,
 };
 
 #[tokio::test]

--- a/programs/axelar-solana-governance/tests/module/gateway_upgrade.rs
+++ b/programs/axelar-solana-governance/tests/module/gateway_upgrade.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::add_upgradeable_loader_account;
 use axelar_solana_governance::instructions::builder::IxBuilder;
 use solana_program_test::tokio;
@@ -6,8 +7,7 @@ use solana_sdk::bpf_loader_upgradeable::UpgradeableLoaderState;
 use solana_sdk::signature::{Keypair, Signer};
 
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, default_proposal_eta, gmp_memo_metadata,
-    setup_programs,
+    approve_ix_at_gateway, default_proposal_eta, gmp_memo_metadata, setup_programs,
 };
 #[tokio::test]
 async fn test_gateway_upgrade_through_proposal() {

--- a/programs/axelar-solana-governance/tests/module/gmp/approve_operator.rs
+++ b/programs/axelar-solana-governance/tests/module/gmp/approve_operator.rs
@@ -1,5 +1,7 @@
 use axelar_solana_gateway_test_fixtures::base::FindLog;
-use axelar_solana_gateway_test_fixtures::SolanaAxelarIntegrationMetadata;
+use axelar_solana_gateway_test_fixtures::{
+    assert_msg_present_in_logs, SolanaAxelarIntegrationMetadata,
+};
 use axelar_solana_governance::events::GovernanceEvent;
 use axelar_solana_governance::instructions::builder::{IxBuilder, ProposalRelated};
 use borsh::to_vec;
@@ -10,8 +12,7 @@ use solana_sdk::signer::Signer;
 
 use crate::gmp::gmp_sample_metadata;
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, events,
-    ix_builder_with_sample_proposal_data, setup_programs,
+    approve_ix_at_gateway, events, ix_builder_with_sample_proposal_data, setup_programs,
 };
 
 #[tokio::test]

--- a/programs/axelar-solana-governance/tests/module/gmp/cancel_operator.rs
+++ b/programs/axelar-solana-governance/tests/module/gmp/cancel_operator.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::FindLog;
 use axelar_solana_governance::events::GovernanceEvent;
 use axelar_solana_governance::instructions::builder::{IxBuilder, ProposalRelated};
@@ -8,9 +9,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
 
 use crate::gmp::{gmp_sample_metadata, setup_programs};
-use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, events, ix_builder_with_sample_proposal_data,
-};
+use crate::helpers::{approve_ix_at_gateway, events, ix_builder_with_sample_proposal_data};
 
 #[tokio::test]
 async fn test_successfully_process_gmp_cancel_operator_proposal() {

--- a/programs/axelar-solana-governance/tests/module/gmp/cancel_time_lock_proposal.rs
+++ b/programs/axelar-solana-governance/tests/module/gmp/cancel_time_lock_proposal.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::FindLog;
 use axelar_solana_governance::events::GovernanceEvent;
 use axelar_solana_governance::instructions::builder::{IxBuilder, ProposalRelated};
@@ -7,8 +8,7 @@ use solana_sdk::signature::Signer;
 
 use crate::gmp::gmp_sample_metadata;
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, events,
-    ix_builder_with_sample_proposal_data, setup_programs,
+    approve_ix_at_gateway, events, ix_builder_with_sample_proposal_data, setup_programs,
 };
 
 #[tokio::test]

--- a/programs/axelar-solana-governance/tests/module/gmp/mod.rs
+++ b/programs/axelar-solana-governance/tests/module/gmp/mod.rs
@@ -1,11 +1,12 @@
 use axelar_solana_encoding::types::messages::CrossChainId;
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_governance::state::proposal::ExecutableProposal;
 use solana_program_test::tokio;
 use solana_sdk::{instruction::AccountMeta, signature::Signer};
 
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, gmp_sample_metadata,
-    ix_builder_with_sample_proposal_data, setup_programs,
+    approve_ix_at_gateway, gmp_sample_metadata, ix_builder_with_sample_proposal_data,
+    setup_programs,
 };
 
 mod approve_operator;

--- a/programs/axelar-solana-governance/tests/module/helpers.rs
+++ b/programs/axelar-solana-governance/tests/module/helpers.rs
@@ -13,7 +13,7 @@ use axelar_solana_governance::instructions::builder::{
 use axelar_solana_governance::state::GovernanceConfig;
 use axelar_solana_memo_program::instruction::AxelarMemoInstruction;
 use borsh::to_vec;
-use solana_program_test::{tokio, BanksTransactionResultWithMetadata, ProgramTest};
+use solana_program_test::{tokio, ProgramTest};
 use solana_sdk::bpf_loader_upgradeable;
 use solana_sdk::instruction::AccountMeta;
 use solana_sdk::program_error::ProgramError;
@@ -208,17 +208,6 @@ pub(crate) fn events(
         .iter()
         .filter_map(GovernanceEvent::parse_log)
         .collect::<Vec<_>>()
-}
-
-pub(crate) fn assert_msg_present_in_logs(res: BanksTransactionResultWithMetadata, msg: &str) {
-    assert!(
-        res.metadata
-            .unwrap()
-            .log_messages
-            .into_iter()
-            .any(|x| x.contains(msg)),
-        "Expected error message not found!"
-    );
 }
 
 pub(crate) async fn approve_ix_at_gateway(

--- a/programs/axelar-solana-governance/tests/module/initialize_config.rs
+++ b/programs/axelar-solana-governance/tests/module/initialize_config.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::TestFixture;
 use axelar_solana_governance::instructions::builder::IxBuilder;
 use axelar_solana_governance::state::{GovernanceConfig, VALID_PROPOSAL_DELAY_RANGE};
@@ -6,10 +7,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
 use crate::fixtures::MINIMUM_PROPOSAL_DELAY;
-use crate::helpers::{
-    assert_msg_present_in_logs, deploy_governance_program,
-    deploy_governance_program_with_upgrade_authority,
-};
+use crate::helpers::{deploy_governance_program, deploy_governance_program_with_upgrade_authority};
 
 #[tokio::test]
 async fn test_successfully_initialize_config() {

--- a/programs/axelar-solana-governance/tests/module/transfer_operatorship.rs
+++ b/programs/axelar-solana-governance/tests/module/transfer_operatorship.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_gateway_test_fixtures::base::TestFixture;
 use axelar_solana_governance::events::GovernanceEvent;
 use axelar_solana_governance::instructions::builder::IxBuilder;
@@ -9,9 +10,8 @@ use solana_sdk::signer::Signer;
 
 use crate::fixtures::operator_keypair;
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, default_proposal_eta,
-    deploy_governance_program, events, gmp_sample_metadata, init_contract_with_operator,
-    setup_programs,
+    approve_ix_at_gateway, default_proposal_eta, deploy_governance_program, events,
+    gmp_sample_metadata, init_contract_with_operator, setup_programs,
 };
 
 #[tokio::test]

--- a/programs/axelar-solana-governance/tests/module/withdraw_tokens.rs
+++ b/programs/axelar-solana-governance/tests/module/withdraw_tokens.rs
@@ -1,3 +1,4 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
 use axelar_solana_governance::instructions::builder::IxBuilder;
 use solana_program_test::tokio;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
@@ -5,8 +6,7 @@ use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::system_instruction;
 
 use crate::helpers::{
-    approve_ix_at_gateway, assert_msg_present_in_logs, default_proposal_eta, gmp_sample_metadata,
-    setup_programs,
+    approve_ix_at_gateway, default_proposal_eta, gmp_sample_metadata, setup_programs,
 };
 
 #[tokio::test]

--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -236,12 +236,24 @@ pub(crate) fn process_outbound_transfer<'a>(
 
     msg!("Instruction: OutboundTransfer");
     let token_manager = TokenManager::load(take_token_accounts.token_manager_pda)?;
+
     assert_valid_token_manager_pda(
         take_token_accounts.token_manager_pda,
         take_token_accounts.its_root_pda.key,
         &token_id,
         token_manager.bump,
     )?;
+
+    let expected_token_manager_ata =
+        spl_associated_token_account::get_associated_token_address_with_program_id(
+            take_token_accounts.token_manager_pda.key,
+            take_token_accounts.token_mint.key,
+            take_token_accounts.token_program.key,
+        );
+    if *take_token_accounts.token_manager_ata.key != expected_token_manager_ata {
+        msg!("Provided token_manager_ata doesn't match expected derivation");
+        return Err(ProgramError::InvalidAccountData);
+    }
 
     if token_manager.token_address != *take_token_accounts.token_mint.key {
         msg!("Mint and token ID don't match");


### PR DESCRIPTION
Make sure the provided ATA can be derived from the PDA & token ID.
This prevents anyone from passing an arbitrary ATA that would be the recipient of locked funds.