### PR TITLE
fix(gateway): add missing check for verification session's signer set hash (C25)

### DIFF
--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -92,6 +92,13 @@ impl Processor {
             return Err(GatewayError::SigningSessionNotValid.into());
         }
 
+        // Check: message signing verifier set matches the verification session verifier set
+        if message.leaf.signing_verifier_set
+            != session.signature_verification.signing_verifier_set_hash
+        {
+            return Err(GatewayError::SigningSessionNotValid.into());
+        }
+
         let leaf_hash = message.leaf.hash::<SolanaSyscallHasher>();
         let message_hash = message.leaf.message.hash::<SolanaSyscallHasher>();
         let proof = rs_merkle::MerkleProof::<SolanaSyscallHasher>::from_bytes(&message.proof)

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -96,7 +96,7 @@ impl Processor {
         if message.leaf.signing_verifier_set
             != session.signature_verification.signing_verifier_set_hash
         {
-            return Err(GatewayError::SigningSessionNotValid.into());
+            return Err(GatewayError::InvalidVerificationSessionPDA.into());
         }
 
         let leaf_hash = message.leaf.hash::<SolanaSyscallHasher>();


### PR DESCRIPTION
Adds a check to verify the correct `signing_verifier_set_hash` when approving messages in the Gateway.

We considered an alternative approach where we'd remove `singing_verifier_set_hash` from the `MessageLeaf` struct and use it as a PDA derivation seed to determine the signature verification session program account. However, we went with the current implementation for these reasons:

- It's a simpler fix that just adds the missing check. The alternative would require redefining multiple components that handle seed derivation and verification for that program account.
- Storage costs are comparable since we can reclaim the lamports from the signature verification session after the message batch approval process completes.

That said, we're open to implementing the alternative approach if that's preferred.