### PR TITLE
fix(gateway): strict recovery ID validation for ECDSA signatures (H80)

### DIFF
--- a/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
@@ -117,9 +117,10 @@ impl TestSigningKey {
                 let mut signature_bytes = signature.serialize().to_vec();
                 // Convert recovery ID to Ethereum format (0,1 -> 27,28)
                 let recovery_value = recovery_id.serialize();
-                if recovery_value > 1 {
-                    panic!("Unexpected recovery ID: {} (expected 0 or 1)", recovery_value);
-                }
+                assert!(
+                    recovery_value > 1,
+                    "Unexpected recovery ID: {recovery_value} (expected 0 or 1)"
+                );
                 signature_bytes.push(recovery_value + 27);
                 Signature::EcdsaRecoverable(signature_bytes.try_into().unwrap())
             }

--- a/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
@@ -115,7 +115,12 @@ impl TestSigningKey {
                 let message = libsecp256k1::Message::parse(message.try_into().unwrap());
                 let (signature, recovery_id) = libsecp256k1::sign(&message, signing_key);
                 let mut signature_bytes = signature.serialize().to_vec();
-                signature_bytes.push(recovery_id.serialize());
+                // Convert recovery ID to Ethereum format (0,1 -> 27,28)
+                let recovery_value = recovery_id.serialize();
+                if recovery_value > 1 {
+                    panic!("Unexpected recovery ID: {} (expected 0 or 1)", recovery_value);
+                }
+                signature_bytes.push(recovery_value + 27);
                 Signature::EcdsaRecoverable(signature_bytes.try_into().unwrap())
             }
             Self::Ed25519(signing_key) => {

--- a/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
@@ -118,7 +118,7 @@ impl TestSigningKey {
                 // Convert recovery ID to Ethereum format (0,1 -> 27,28)
                 let recovery_value = recovery_id.serialize();
                 assert!(
-                    recovery_value > 1,
+                    recovery_value <= 1,
                     "Unexpected recovery ID: {recovery_value} (expected 0 or 1)"
                 );
                 signature_bytes.push(recovery_value + 27);

--- a/programs/axelar-solana-gateway/src/state/signature_verification.rs
+++ b/programs/axelar-solana-gateway/src/state/signature_verification.rs
@@ -255,10 +255,12 @@ pub fn verify_ecdsa_signature(
 
     // Transform from Ethereum recovery_id (27, 28) to a range accepted by
     // secp256k1_recover (0, 1, 2, 3)
-    let recovery_id = if *recovery_id >= 27 {
+    // Only values 27 and 28 are valid Ethereum recovery IDs
+    let recovery_id = if *recovery_id == 27 || *recovery_id == 28 {
         recovery_id.saturating_sub(27)
     } else {
-        *recovery_id
+        solana_program::msg!("Invalid recovery ID: {} (must be 27 or 28)", recovery_id);
+        return false;
     };
 
     // This is results in a Solana syscall.

--- a/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
+++ b/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
@@ -383,10 +383,11 @@ fn can_verify_signatures_with_ecrecover_recovery_id() {
     let (keypair, pubkey) = random_ecdsa_keypair();
     let message_hash = [42; 32];
     let signature = keypair.sign(&message_hash);
-    let Signature::EcdsaRecoverable(mut signature) = signature else {
+    let Signature::EcdsaRecoverable(signature) = signature else {
         panic!("unexpected signature type");
     };
-    signature[64] += 27;
+    // The test signer generates signatures with recovery IDs 27-28 (Ethereum format)
+    assert!((27_u8..=28_u8).contains(&signature[64]));
     let PublicKey::Secp256k1(pubkey) = pubkey else {
         panic!("unexpected pubkey type");
     };
@@ -403,7 +404,8 @@ fn can_verify_signatures_with_standard_recovery_id() {
     let Signature::EcdsaRecoverable(signature) = signature else {
         panic!("unexpected signature type");
     };
-    assert!((0_u8..=3_u8).contains(&signature[64]));
+    // The test signer generates signatures with recovery IDs 27-28 (Ethereum format)
+    assert!((27_u8..=28_u8).contains(&signature[64]));
     let PublicKey::Secp256k1(pubkey) = pubkey else {
         panic!("unexpected pubkey type");
     };


### PR DESCRIPTION
Implements proper Ethereum-standard recovery ID validation to prevent security vulnerabilities from invalid recovery IDs.

Changes:
- **Gateway**: Reject recovery IDs outside 27-28 range
- **Tests**: Update assertions to expect Ethereum-format recovery IDs (27-28)
- **Test fixtures**: Generate signatures with proper Ethereum recovery IDs (27-28)
