### PR TITLE
fix(gateway): remove initialization of multiple verifier sets (W10)

### DIFF
--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -13,6 +13,7 @@ use axelar_solana_encoding::types::payload::Payload;
 use axelar_solana_encoding::types::verifier_set::{verifier_set_hash, VerifierSet};
 use axelar_solana_encoding::{borsh, hash_payload};
 use axelar_solana_gateway::error::GatewayError;
+use axelar_solana_gateway::instructions::InitialVerifierSet;
 use axelar_solana_gateway::num_traits::FromPrimitive;
 use axelar_solana_gateway::processor::GatewayEvent;
 use axelar_solana_gateway::state::incoming_message::{command_id, IncomingMessage};
@@ -75,12 +76,15 @@ impl SolanaAxelarIntegrationMetadata {
     /// Get the gateway init verifier set data.
     /// This is useful for building the instantiation message for the gateway
     #[must_use]
-    pub fn init_gateway_config_verifier_set_data(&self) -> Vec<([u8; 32], Pubkey)> {
+    pub fn init_gateway_config_verifier_set_data(&self) -> InitialVerifierSet {
         let init_signers_hash =
             verifier_set_hash::<NativeHasher>(&self.signers.verifier_set(), &self.domain_separator)
                 .unwrap();
         let (initial_signers_pda, _initial_signers_bump) = self.signers.verifier_set_tracker();
-        vec![(init_signers_hash, initial_signers_pda)]
+        InitialVerifierSet {
+            hash: init_signers_hash,
+            pda: initial_signers_pda,
+        }
     }
 
     /// Initialise the gateway root config

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -423,11 +423,7 @@ pub fn initialize_config(
         AccountMeta::new_readonly(gateway_program_data, false),
         AccountMeta::new(gateway_config_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
-        AccountMeta {
-            pubkey: initial_verifier_set.pda,
-            is_signer: false,
-            is_writable: true,
-        },
+        AccountMeta::new(initial_verifier_set.pda, false),
     ];
 
     let data = to_vec(&GatewayInstruction::InitializeConfig(InitializeConfig {

--- a/programs/axelar-solana-gateway/tests/integration/initialize_config.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_config.rs
@@ -25,20 +25,20 @@ fn cmp_config(init: &SolanaAxelarIntegrationMetadata, created: &GatewayConfig) -
 #[allow(clippy::arithmetic_side_effects)]
 #[allow(clippy::as_conversions)]
 async fn assert_verifier_sets(metadata: &mut SolanaAxelarIntegrationMetadata) {
-    let vs_data = metadata.init_gateway_config_verifier_set_data();
-    for (idx, (verifier_set_hash, pda)) in vs_data.into_iter().enumerate() {
-        let vs_data = metadata.verifier_set_tracker(pda).await;
-        let epoch = U256::from_u64(idx as u64 + 1);
+    let initial_verifier_set = metadata.init_gateway_config_verifier_set_data();
+    let vs_data = metadata
+        .verifier_set_tracker(initial_verifier_set.pda)
+        .await;
+    let epoch = U256::from_u64(1);
 
-        assert_eq!(
-            vs_data.epoch, epoch,
-            "verifier set tracker not properly initialized"
-        );
-        assert_eq!(
-            vs_data.verifier_set_hash, verifier_set_hash,
-            "verifier set tracker not properly initialized"
-        );
-    }
+    assert_eq!(
+        vs_data.epoch, epoch,
+        "verifier set tracker not properly initialized"
+    );
+    assert_eq!(
+        vs_data.verifier_set_hash, initial_verifier_set.hash,
+        "verifier set tracker not properly initialized"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR refactors the Gateway's `InitializeConfig` instruction by removing unnecessary support for multiple verifier sets and replacing it with a single `InitialVerifierSet` struct.