### PR TITLE
fix: prevent flow limiter operations on ITS root config

### DIFF
--- a/programs/axelar-solana-its/src/instruction/token_manager.rs
+++ b/programs/axelar-solana-its/src/instruction/token_manager.rs
@@ -62,6 +62,7 @@ pub fn add_flow_limiter(
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &flow_limiter);
 
     let accounts = vec![
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(payer_roles_pda, false),
@@ -97,6 +98,7 @@ pub fn remove_flow_limiter(
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &flow_limiter);
 
     let accounts = vec![
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(payer_roles_pda, false),

--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -484,6 +484,9 @@ pub(crate) fn process_add_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -> P
         return Err(ProgramError::InvalidAccountData);
     }
 
+    // Ensure resource is a `TokenManager`
+    TokenManager::load(resource)?;
+
     let role_management_accounts = RoleAddAccounts {
         system_account,
         payer,
@@ -519,6 +522,9 @@ pub(crate) fn process_remove_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -
         msg!("Resource is not a TokenManager");
         return Err(ProgramError::InvalidAccountData);
     }
+
+    // Ensure resource is a `TokenManager`
+    TokenManager::load(resource)?;
 
     let role_management_accounts = RoleRemoveAccounts {
         system_account,

--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -469,12 +469,20 @@ pub(crate) fn process_add_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -> P
     msg!("Instruction: AddTokenManagerFlowLimiter");
 
     let accounts_iter = &mut accounts.iter();
+    let its_config_account = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
     let payer_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
+
+    let its_config = InterchainTokenService::load(its_config_account)?;
+    assert_valid_its_root_pda(its_config_account, its_config.bump)?;
+    if resource.key == its_config_account.key {
+        msg!("Resource is not a TokenManager");
+        return Err(ProgramError::InvalidAccountData);
+    }
 
     let role_management_accounts = RoleAddAccounts {
         system_account,
@@ -497,12 +505,20 @@ pub(crate) fn process_remove_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -
     msg!("Instruction: RemoveTokenManagerFlowLimiter");
 
     let accounts_iter = &mut accounts.iter();
+    let its_config_account = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
     let payer_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
+
+    let its_config = InterchainTokenService::load(its_config_account)?;
+    assert_valid_its_root_pda(its_config_account, its_config.bump)?;
+    if resource.key == its_config_account.key {
+        msg!("Resource is not a TokenManager");
+        return Err(ProgramError::InvalidAccountData);
+    }
 
     let role_management_accounts = RoleRemoveAccounts {
         system_account,


### PR DESCRIPTION
Add validation to prevent adding/removing flow limiters on the ITS root config itself. This prevents potential security issues by ensuring flow limiter operations only target valid token managers.
