### PR TITLE
fix: use Ethereum format (27-28) recovery id range in unit tests

### DIFF
--- a/programs/axelar-solana-gateway/src/state/signature_verification.rs
+++ b/programs/axelar-solana-gateway/src/state/signature_verification.rs
@@ -429,7 +429,8 @@ mod tests {
             let message = libsecp256k1::Message::parse(&payload_merkle_root);
             let (signature, recovery_id) = libsecp256k1::sign(&message, &secret_key);
             let mut signature_bytes = signature.serialize().to_vec();
-            signature_bytes.push(recovery_id.serialize());
+            // Convert recovery_id from libsecp256k1 format (0-3) to Ethereum format (27-28)
+            signature_bytes.push(recovery_id.serialize() + 27);
             let signature_array: [u8; 65] = signature_bytes.try_into().unwrap();
             (payload_merkle_root, signature_array)
         };


### PR DESCRIPTION
This validation check at `programs/axelar-solana-gateway/src/state/signature_verification.rs:259-264`, added at #189, is the preventing our `test_process_signature_returns_slot_already_verified_error` test from passing:

https://github.com/eigerco/axelar-amplifier-solana/blob/517e778a67e9f7400e528c4034a9da2d86eb2a9e/programs/axelar-solana-gateway/src/state/signature_verification.rs#L256-L264

The test was creating signatures with `recovery_id.serialize()` which returns `0-3`, but this check requires` 27-28`. When the test passed values in the `0-3` range, this check failed and returned `false`, causing an assertion failure in the test.
