### PR TITLE
fix(its): make the user address the source of interchain transfers

### DIFF
--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -265,7 +265,7 @@ pub(crate) fn process_outbound_transfer<'a>(
 
     let transfer_event = event::InterchainTransfer {
         token_id,
-        source_address: *take_token_accounts.token_manager_ata.key,
+        source_address: *take_token_accounts.source_account.key,
         destination_chain,
         destination_address,
         amount,
@@ -286,7 +286,7 @@ pub(crate) fn process_outbound_transfer<'a>(
             .try_into()
             .map_err(|_err| ProgramError::ArithmeticOverflow)?,
         token_id: token_id.into(),
-        source_address: take_token_accounts.token_mint.key.to_bytes().into(),
+        source_address: transfer_event.source_address.to_bytes().into(),
         destination_address: transfer_event.destination_address.into(),
         amount: alloy_primitives::U256::from(amount),
         data: data.unwrap_or_default().into(),

--- a/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
+++ b/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
@@ -1,5 +1,7 @@
 use axelar_solana_gateway_test_fixtures::base::FindLog;
+use axelar_solana_its::event::InterchainTransfer;
 use borsh::BorshDeserialize;
+use event_utils::Event;
 use evm_contracts_test_suite::ethers::signers::Signer;
 use mpl_token_metadata::accounts::Metadata;
 use mpl_token_metadata::instructions::CreateV1Builder;
@@ -953,6 +955,119 @@ async fn test_ata_must_match_pda_derivation(ctx: &mut ItsTestContext) -> anyhow:
         res.err().unwrap(),
         "Provided token_manager_ata doesn't match expected derivation",
     );
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_source_address_stays_consistent_through_the_transfer(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let salt = solana_sdk::keccak::hash(b"SourceAddressTestToken").0;
+    let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
+        salt,
+        "Source Test Token".to_owned(),
+        "STT".to_owned(),
+        9,
+        1000,
+        Some(ctx.solana_wallet),
+    )?;
+
+    ctx.send_solana_tx(&[deploy_local_ix]).await.unwrap();
+
+    let token_id = axelar_solana_its::interchain_token_id(&ctx.solana_wallet, &salt);
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let (interchain_token_mint, _) =
+        axelar_solana_its::find_interchain_token_pda(&its_root_pda, &token_id);
+
+    // Get user's token account
+    let user_token_account = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &interchain_token_mint,
+        &spl_token_2022::id(),
+    );
+
+    // Perform interchain transfer to verify source_address
+    let transfer_amount = 50;
+    let destination_address = b"0x1234567890123456789012345678901234567890".to_vec();
+    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
+
+    let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
+        ctx.solana_wallet,
+        user_token_account, // This should be the source_address
+        token_id,
+        ctx.evm_chain_name.clone(),
+        destination_address.clone(),
+        transfer_amount,
+        interchain_token_mint,
+        spl_token_2022::id(),
+        0,
+        clock_sysvar.unix_timestamp,
+    )?;
+
+    let tx = ctx.send_solana_tx(&[transfer_ix]).await.unwrap();
+
+    // Extract the CallContract event to get the GMP payload first
+    let call_contract_event = fetch_first_call_contract_event_from_tx(&tx);
+    let gmp_payload = GMPPayload::decode(&call_contract_event.payload)?;
+
+    // Extract the InterchainTransfer event from logs
+    let logs = tx.metadata.unwrap().log_messages;
+    let transfer_event = logs
+        .iter()
+        .find_map(|log| InterchainTransfer::try_from_log(log).ok())
+        .expect("InterchainTransfer event should be present");
+
+    // Extract the InterchainTransfer from the GMP payload
+    let GMPPayload::SendToHub(send_to_hub) = gmp_payload else {
+        panic!("Expected SendToHub GMP payload, got: {gmp_payload:?}");
+    };
+
+    // The actual InterchainTransfer is in the inner payload
+    let inner_gmp_payload = GMPPayload::decode(&send_to_hub.payload)?;
+    let GMPPayload::InterchainTransfer(gmp_transfer) = inner_gmp_payload else {
+        panic!("Expected InterchainTransfer in inner payload, got: {inner_gmp_payload:?}");
+    };
+
+    // Both event and GMP payload should use the same source address
+    // and it should be the user's token account (not token manager ATA or mint)
+    assert_eq!(
+        transfer_event.source_address, user_token_account,
+        "Event source_address should be the user's token account"
+    );
+
+    assert_eq!(
+        gmp_transfer.source_address.as_ref(),
+        user_token_account.to_bytes(),
+        "GMP payload source_address should be the user's token account"
+    );
+
+    // Verify that the source address is NOT any system account
+    let (token_manager_pda, _) =
+        axelar_solana_its::find_token_manager_pda(&its_root_pda, &token_id);
+    let token_manager_ata = get_associated_token_address_with_program_id(
+        &token_manager_pda,
+        &interchain_token_mint,
+        &spl_token_2022::id(),
+    );
+
+    assert_ne!(
+        transfer_event.source_address, token_manager_ata,
+        "Source address should NOT be token manager ATA"
+    );
+
+    assert_ne!(
+        transfer_event.source_address, interchain_token_mint,
+        "Source address should NOT be the mint account"
+    );
+
+    // Additional verification: check other event fields
+    assert_eq!(transfer_event.token_id, token_id);
+    assert_eq!(transfer_event.destination_chain, ctx.evm_chain_name);
+    assert_eq!(transfer_event.destination_address, destination_address);
+    assert_eq!(transfer_event.amount, transfer_amount);
 
     Ok(())
 }


### PR DESCRIPTION
The source was inconsistent in interchain transfers events and GMP payload