### PR TITLE
feat: make governance config fields updatable (w13)

### DIFF
--- a/helpers/program-utils/src/pda.rs
+++ b/helpers/program-utils/src/pda.rs
@@ -236,7 +236,7 @@ impl<'a> ValidPDA for &AccountInfo<'a> {
     }
 }
 
-/// Convenience trait to store and load rkyv serialized data to/from an account.
+/// Convenience trait to store and load borsh serialized data to/from an account.
 pub trait BorshPda
 where
     Self: Sized + Clone + BorshSerialize + BorshDeserialize,

--- a/programs/axelar-solana-governance/src/processor/init_config.rs
+++ b/programs/axelar-solana-governance/src/processor/init_config.rs
@@ -9,7 +9,6 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_program;
 
-use crate::processor::validate_config;
 use crate::seed_prefixes;
 use crate::state::{validate_config, GovernanceConfig};
 

--- a/programs/axelar-solana-governance/src/processor/init_config.rs
+++ b/programs/axelar-solana-governance/src/processor/init_config.rs
@@ -9,8 +9,9 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_program;
 
+use crate::processor::validate_config;
 use crate::seed_prefixes;
-use crate::state::{GovernanceConfig, VALID_PROPOSAL_DELAY_RANGE};
+use crate::state::{validate_config, GovernanceConfig};
 
 account_array_structs! {
     // Struct whose attributes are of type `AccountInfo`
@@ -44,7 +45,7 @@ pub(crate) fn process(
 
     ensure_upgrade_authority(program_id, payer, program_data)?;
 
-    validate(&governance_config)?;
+    validate_config(&governance_config)?;
 
     // Check: System Program Account
     if !system_program::check_id(system_account.key) {
@@ -71,19 +72,6 @@ pub(crate) fn process(
         governance_config,
         &[seed_prefixes::GOVERNANCE_CONFIG, &[bump]],
     )?;
-
-    Ok(())
-}
-
-fn validate(config: &GovernanceConfig) -> Result<(), ProgramError> {
-    if !VALID_PROPOSAL_DELAY_RANGE.contains(&config.minimum_proposal_eta_delay) {
-        msg!(
-            "The minimum proposal ETA delay must be among {} and {} seconds",
-            VALID_PROPOSAL_DELAY_RANGE.start(),
-            VALID_PROPOSAL_DELAY_RANGE.end()
-        );
-        return Err(ProgramError::InvalidArgument);
-    }
 
     Ok(())
 }

--- a/programs/axelar-solana-governance/src/processor/mod.rs
+++ b/programs/axelar-solana-governance/src/processor/mod.rs
@@ -23,6 +23,7 @@ mod execute_proposal;
 pub mod gmp;
 mod init_config;
 mod transfer_operatorship;
+mod update_config;
 mod withdraw_tokens;
 
 pub use execute_operator_proposal::ExecuteOperatorProposalMeta;
@@ -33,6 +34,7 @@ pub use gmp::{
 };
 pub use init_config::GovernanceConfigMeta;
 pub use transfer_operatorship::TransferOperatorshipMeta;
+pub use update_config::GovernanceConfigUpdateMeta;
 pub use withdraw_tokens::WithdrawTokensMeta;
 
 /// Program state handler.
@@ -60,6 +62,9 @@ impl Processor {
         match governance_instruction {
             GovernanceInstruction::InitializeConfig(governance_config) => {
                 init_config::process(program_id, accounts, governance_config)
+            }
+            GovernanceInstruction::UpdateConfig(governance_config) => {
+                update_config::process(accounts, governance_config)
             }
             // GMP instructions
             GovernanceInstruction::ProcessGmp { message } => {

--- a/programs/axelar-solana-governance/src/processor/update_config.rs
+++ b/programs/axelar-solana-governance/src/processor/update_config.rs
@@ -8,7 +8,7 @@ use solana_program::program_error::ProgramError;
 
 use crate::{
     processor::ensure_valid_governance_root_pda,
-    state::{validate_config, GovernanceConfig},
+    state::{GovernanceConfig, GovernanceConfigUpdate},
 };
 
 account_array_structs! {
@@ -25,42 +25,35 @@ account_array_structs! {
 /// This function will return a [`ProgramError`] if any of the subcmds fail.
 pub(crate) fn process(
     accounts: &[AccountInfo<'_>],
-    mut new_governance_config: GovernanceConfig,
+    config_update: GovernanceConfigUpdate,
 ) -> Result<(), ProgramError> {
     let GovernanceConfigUpdateInfo { payer, root_pda } =
         GovernanceConfigUpdateInfo::from_account_iter(&mut accounts.iter())?;
 
     // Check: The operator is the payer and has signed
-    let current_config = root_pda.check_initialized_pda::<GovernanceConfig>(&crate::id())?;
+    let mut config = root_pda.check_initialized_pda::<GovernanceConfig>(&crate::id())?;
 
-    ensure_valid_governance_root_pda(current_config.bump, root_pda.key)?;
+    ensure_valid_governance_root_pda(config.bump, root_pda.key)?;
 
     if !payer.is_signer {
         msg!("The operator account must sign the transaction");
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    if current_config.operator != payer.key.to_bytes() {
+    if config.operator != payer.key.to_bytes() {
         msg!("Only the current operator can update the governance config");
         return Err(ProgramError::InvalidAccountData);
     }
 
-    // Check: Ensure the config data is valid
-    validate_config(&new_governance_config)?;
-
-    // We overwrite/preserve from initial config the fields that should not be changed
-    new_governance_config.bump = current_config.bump;
-    new_governance_config.operator = current_config.operator;
+    config.update(config_update)?;
 
     // Overwrite the config data in the PDA
     let mut data = root_pda.try_borrow_mut_data()?;
 
-    new_governance_config
-        .serialize(&mut &mut data[..])
-        .map_err(|err| {
-            msg!("Failed to serialize new governance config: {}", err);
-            ProgramError::InvalidAccountData
-        })?;
+    config.serialize(&mut data.as_mut()).map_err(|err| {
+        msg!("Failed to serialize new governance config: {}", err);
+        ProgramError::InvalidAccountData
+    })?;
 
     Ok(())
 }

--- a/programs/axelar-solana-governance/src/processor/update_config.rs
+++ b/programs/axelar-solana-governance/src/processor/update_config.rs
@@ -1,0 +1,66 @@
+//! Update Governance Config Account with new Governance Config data.
+
+use borsh::BorshSerialize;
+use program_utils::{account_array_structs, pda::ValidPDA};
+use solana_program::account_info::AccountInfo;
+use solana_program::msg;
+use solana_program::program_error::ProgramError;
+
+use crate::{
+    processor::ensure_valid_governance_root_pda,
+    state::{validate_config, GovernanceConfig},
+};
+
+account_array_structs! {
+    GovernanceConfigUpdateInfo,
+    GovernanceConfigUpdateMeta,
+    payer,
+    root_pda
+}
+
+/// Updates the Governance Config Account with the provided Governance Config.
+///
+/// # Errors
+///
+/// This function will return a [`ProgramError`] if any of the subcmds fail.
+pub(crate) fn process(
+    accounts: &[AccountInfo<'_>],
+    mut new_governance_config: GovernanceConfig,
+) -> Result<(), ProgramError> {
+    let GovernanceConfigUpdateInfo { payer, root_pda } =
+        GovernanceConfigUpdateInfo::from_account_iter(&mut accounts.iter())?;
+
+    // Check: The operator is the payer and has signed
+    let current_config = root_pda.check_initialized_pda::<GovernanceConfig>(&crate::id())?;
+
+    ensure_valid_governance_root_pda(current_config.bump, root_pda.key)?;
+
+    if !payer.is_signer {
+        msg!("The operator account must sign the transaction");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if current_config.operator != payer.key.to_bytes() {
+        msg!("Only the current operator can update the governance config");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Check: Ensure the config data is valid
+    validate_config(&new_governance_config)?;
+
+    // We overwrite/preserve from initial config the fields that should not be changed
+    new_governance_config.bump = current_config.bump;
+    new_governance_config.operator = current_config.operator;
+
+    // Overwrite the config data in the PDA
+    let mut data = root_pda.try_borrow_mut_data()?;
+
+    new_governance_config
+        .serialize(&mut &mut data[..])
+        .map_err(|err| {
+            msg!("Failed to serialize new governance config: {}", err);
+            ProgramError::InvalidAccountData
+        })?;
+
+    Ok(())
+}

--- a/programs/axelar-solana-governance/src/state/mod.rs
+++ b/programs/axelar-solana-governance/src/state/mod.rs
@@ -61,6 +61,23 @@ impl GovernanceConfig {
             operator,
         }
     }
+
+    /// Creates a new governance config only for updates with the allowed
+    /// updatable fields.
+    #[must_use]
+    pub const fn new_for_update(
+        chain_hash: Hash,
+        address_hash: Hash,
+        minimum_proposal_eta_delay: u32,
+    ) -> Self {
+        Self {
+            bump: 0, // This field will be ignored on updates
+            chain_hash,
+            address_hash,
+            minimum_proposal_eta_delay,
+            operator: [0; 32], // This field will be ignored on updates
+        }
+    }
     /// Calculate governance config PDA
     #[must_use]
     pub fn pda() -> (Pubkey, u8) {
@@ -94,7 +111,6 @@ impl Pack for GovernanceConfig {
         })
     }
 }
-
 
 pub(crate) fn validate_config(config: &GovernanceConfig) -> Result<(), ProgramError> {
     if !VALID_PROPOSAL_DELAY_RANGE.contains(&config.minimum_proposal_eta_delay) {

--- a/programs/axelar-solana-governance/src/state/mod.rs
+++ b/programs/axelar-solana-governance/src/state/mod.rs
@@ -94,3 +94,17 @@ impl Pack for GovernanceConfig {
         })
     }
 }
+
+
+pub(crate) fn validate_config(config: &GovernanceConfig) -> Result<(), ProgramError> {
+    if !VALID_PROPOSAL_DELAY_RANGE.contains(&config.minimum_proposal_eta_delay) {
+        msg!(
+            "The minimum proposal ETA delay must be among {} and {} seconds",
+            VALID_PROPOSAL_DELAY_RANGE.start(),
+            VALID_PROPOSAL_DELAY_RANGE.end()
+        );
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    Ok(())
+}

--- a/programs/axelar-solana-governance/tests/module/main.rs
+++ b/programs/axelar-solana-governance/tests/module/main.rs
@@ -22,4 +22,5 @@ mod gmp;
 mod helpers;
 mod initialize_config;
 mod transfer_operatorship;
+mod update_config;
 mod withdraw_tokens;

--- a/programs/axelar-solana-governance/tests/module/update_config.rs
+++ b/programs/axelar-solana-governance/tests/module/update_config.rs
@@ -1,0 +1,254 @@
+use axelar_solana_gateway_test_fixtures::assert_msg_present_in_logs;
+use axelar_solana_gateway_test_fixtures::base::TestFixture;
+use axelar_solana_governance::instructions::builder::IxBuilder;
+use axelar_solana_governance::state::{GovernanceConfig, VALID_PROPOSAL_DELAY_RANGE};
+use borsh::BorshSerialize;
+use solana_program_test::{tokio, ProgramTest};
+use solana_sdk::account::Account;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signer};
+
+use crate::fixtures::MINIMUM_PROPOSAL_DELAY;
+use crate::helpers::deploy_governance_program;
+
+#[tokio::test]
+async fn test_successfully_update_config() {
+    let mut fixture = TestFixture::new(ProgramTest::default()).await;
+    deploy_governance_program(&mut fixture).await;
+    let (config_pda, _) = GovernanceConfig::pda();
+
+    init_gov_config(&mut fixture, &config_pda).await;
+
+    let new_config = GovernanceConfig {
+        bump: 40, // This will be preserved from the initial config.
+        chain_hash: [1_u8; 32],
+        address_hash: [2_u8; 32],
+        minimum_proposal_eta_delay: MINIMUM_PROPOSAL_DELAY + 1,
+        operator: Pubkey::new_unique().to_bytes(), // Trying to change the operator should have no effect
+    };
+
+    let ix = IxBuilder::new()
+        .update_config(&fixture.payer.pubkey(), &config_pda, new_config.clone())
+        .build();
+    let res = fixture.send_tx(&[ix]).await;
+    assert!(res.is_ok());
+    let updated_config = fixture
+        .get_account_with_borsh::<GovernanceConfig>(&config_pda)
+        .await
+        .unwrap();
+
+    // We assert all allowed fields are updated.
+    assert_eq!(&new_config.address_hash, &updated_config.address_hash);
+    assert_eq!(&new_config.chain_hash, &updated_config.chain_hash);
+    assert_eq!(
+        &new_config.minimum_proposal_eta_delay,
+        &updated_config.minimum_proposal_eta_delay
+    );
+
+    // We are sure the operator field and bump are not changed.
+    let initial_config = gov_config_fixture(&fixture.payer.pubkey());
+    assert_eq!(&initial_config.operator, &updated_config.operator);
+    assert_ne!(initial_config.bump, updated_config.bump);
+}
+
+#[tokio::test]
+async fn test_program_checks_config_pda_successfully_derived() {
+    let program_test = ProgramTest::default();
+    let mut fixture = TestFixture::new(program_test).await;
+    deploy_governance_program(&mut fixture).await;
+    let (config_pda, _) = GovernanceConfig::pda();
+    init_gov_config(&mut fixture, &config_pda).await;
+
+    let config = GovernanceConfig::new(
+        [1_u8; 32],
+        [2_u8; 32],
+        MINIMUM_PROPOSAL_DELAY,
+        Pubkey::new_unique().to_bytes(),
+    );
+
+    let wrong_config_pda = Keypair::new();
+
+    // Store the the config in the wrong pda
+    let mut fake_config_account =
+        Account::new(1_000_000_000, 10000, &axelar_solana_governance::id());
+    config.serialize(&mut fake_config_account.data).unwrap();
+    fixture.set_account_state(&wrong_config_pda.pubkey(), fake_config_account);
+
+    // fund the wrong config pda so the transaction does not fail because of insufficient funds
+    let ix = solana_sdk::system_instruction::transfer(
+        &fixture.payer.pubkey(),
+        &wrong_config_pda.pubkey(),
+        1_000_000_000,
+    );
+    fixture.send_tx(&[ix]).await.unwrap();
+    // Set governance program as owner of the wrong config pda
+    let ix = solana_sdk::system_instruction::assign(
+        &wrong_config_pda.pubkey(),
+        &axelar_solana_governance::id(),
+    );
+    fixture
+        .send_tx_with_custom_signers(
+            &[ix],
+            &[
+                wrong_config_pda.insecure_clone(),
+                fixture.payer.insecure_clone(),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let ix = IxBuilder::new()
+        .update_config(
+            &fixture.payer.pubkey(),
+            &wrong_config_pda.pubkey(), // Wrong config PDA
+            config.clone(),
+        )
+        .build();
+    let res = fixture.send_tx(&[ix]).await;
+    assert!(res.is_err());
+    assert_msg_present_in_logs(res.err().unwrap(), "Invalid config/root pda");
+}
+
+#[tokio::test]
+async fn test_only_operator_can_update_config() {
+    let mut fixture = TestFixture::new(ProgramTest::default()).await;
+    deploy_governance_program(&mut fixture).await;
+    let (config_pda, _) = GovernanceConfig::pda();
+    init_gov_config(&mut fixture, &config_pda).await;
+
+    let config = GovernanceConfig::new(
+        [1_u8; 32],
+        [2_u8; 32],
+        MINIMUM_PROPOSAL_DELAY,
+        Pubkey::new_unique().to_bytes(),
+    );
+
+    // Transfer lamports to a new payer that is not the current operator
+    let new_payer = solana_sdk::signature::Keypair::new();
+    let ix = solana_sdk::system_instruction::transfer(
+        &fixture.payer.pubkey(),
+        &new_payer.pubkey(),
+        1_000_000_000,
+    );
+    fixture.send_tx(&[ix]).await.unwrap();
+    // try to update the config with the new payer that is not the current operator
+    let ix = IxBuilder::new()
+        .update_config(&new_payer.pubkey(), &config_pda, config.clone())
+        .build();
+    let res = fixture
+        .send_tx_with_custom_signers(
+            &[ix],
+            &[fixture.payer.insecure_clone(), new_payer.insecure_clone()],
+        )
+        .await;
+    assert!(res.is_err());
+    assert_msg_present_in_logs(
+        res.err().unwrap(),
+        "Only the current operator can update the governance config",
+    );
+}
+
+#[tokio::test]
+async fn test_operator_must_sign_tx() {
+    let mut fixture = TestFixture::new(ProgramTest::default()).await;
+    deploy_governance_program(&mut fixture).await;
+    let (config_pda, _) = GovernanceConfig::pda();
+    init_gov_config(&mut fixture, &config_pda).await;
+
+    let config = GovernanceConfig::new(
+        [1_u8; 32],
+        [2_u8; 32],
+        MINIMUM_PROPOSAL_DELAY,
+        Pubkey::new_unique().to_bytes(),
+    );
+
+    let non_signer_operator = Keypair::new();
+
+    // try to update the config with the new payer that is not the current operator
+    let mut ix = IxBuilder::new()
+        .update_config(&non_signer_operator.pubkey(), &config_pda, config.clone())
+        .build();
+
+    ix.accounts[0].is_signer = false; // The operator is not a signer
+    let res = fixture.send_tx(&[ix]).await;
+    assert!(res.is_err());
+    assert_msg_present_in_logs(
+        res.err().unwrap(),
+        "The operator account must sign the transaction",
+    );
+}
+
+#[tokio::test]
+async fn test_upper_bound_for_proposal_delay() {
+    let mut fixture = TestFixture::new(ProgramTest::default()).await;
+    deploy_governance_program(&mut fixture).await;
+    let (config_pda, _) = GovernanceConfig::pda();
+    init_gov_config(&mut fixture, &config_pda).await;
+
+    let config = GovernanceConfig::new(
+        [1_u8; 32],
+        [2_u8; 32],
+        VALID_PROPOSAL_DELAY_RANGE.end() + 1, // Go up the upper limit, this should fail
+        Pubkey::new_unique().to_bytes(),
+    );
+    let ix = IxBuilder::new()
+        .update_config(&fixture.payer.pubkey(), &config_pda, config.clone())
+        .build();
+    let res = fixture.send_tx(&[ix]).await;
+    assert!(res.is_err());
+    assert_msg_present_in_logs(
+        res.err().unwrap(),
+        &format!(
+            "The minimum proposal ETA delay must be among {} and {} seconds",
+            VALID_PROPOSAL_DELAY_RANGE.start(),
+            VALID_PROPOSAL_DELAY_RANGE.end()
+        ),
+    );
+}
+
+#[tokio::test]
+async fn test_lower_bound_for_proposal_delay() {
+    let mut fixture = TestFixture::new(ProgramTest::default()).await;
+    deploy_governance_program(&mut fixture).await;
+    let (config_pda, _) = GovernanceConfig::pda();
+    init_gov_config(&mut fixture, &config_pda).await;
+
+    let config = GovernanceConfig::new(
+        [1_u8; 32],
+        [2_u8; 32],
+        VALID_PROPOSAL_DELAY_RANGE.start() - 1, // Go down the lower limit, this should fail
+        Pubkey::new_unique().to_bytes(),
+    );
+    let ix = IxBuilder::new()
+        .update_config(&fixture.payer.pubkey(), &config_pda, config.clone())
+        .build();
+    let res = fixture.send_tx(&[ix]).await;
+    assert!(res.is_err());
+    assert_msg_present_in_logs(
+        res.err().unwrap(),
+        &format!(
+            "The minimum proposal ETA delay must be among {} and {} seconds",
+            VALID_PROPOSAL_DELAY_RANGE.start(),
+            VALID_PROPOSAL_DELAY_RANGE.end()
+        ),
+    );
+}
+
+fn gov_config_fixture(operator: &Pubkey) -> GovernanceConfig {
+    GovernanceConfig::new(
+        [0_u8; 32],
+        [0_u8; 32],
+        MINIMUM_PROPOSAL_DELAY,
+        operator.to_bytes(),
+    )
+}
+
+async fn init_gov_config(fixture: &mut TestFixture, config_pda: &Pubkey) {
+    let config = gov_config_fixture(&fixture.payer.pubkey());
+
+    let ix = IxBuilder::new()
+        .initialize_config(&fixture.payer.pubkey(), config_pda, config.clone())
+        .build();
+
+    fixture.send_tx(&[ix]).await.unwrap();
+}


### PR DESCRIPTION
- **refactor: move gov validate config function to state crate and rename**
- **fix: comment**
- **feat: make governance config fields updatable**
