### PR TITLE
fix(its)!: include the chain hash in token ID derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,8 +3297,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4300,7 +4300,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -4314,7 +4314,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.9",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4531,11 +4531,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -5616,7 +5616,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6001,17 +6001,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6022,14 +6013,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -10912,13 +10897,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "thread_local",
  "tracing",

--- a/programs/axelar-solana-its/src/lib.rs
+++ b/programs/axelar-solana-its/src/lib.rs
@@ -33,6 +33,31 @@ solana_program::declare_id!("its1111111111111111111111111111111111111111");
 
 pub(crate) const ITS_HUB_CHAIN_NAME: &str = "axelar";
 
+// Chain name hash constants for token ID derivation
+#[cfg(feature = "devnet-amplifier")]
+pub const CHAIN_NAME_HASH: [u8; 32] = [
+    10, 171, 102, 67, 72, 176, 161, 92, 42, 179, 148, 228, 13, 72, 172, 178, 168, 16, 138, 252, 99,
+    222, 187, 187, 25, 30, 121, 52, 235, 103, 11, 169,
+]; // keccak256("solana-devnet")
+
+#[cfg(feature = "stagenet")]
+pub const CHAIN_NAME_HASH: [u8; 32] = [
+    67, 5, 100, 18, 3, 83, 80, 76, 10, 94, 7, 166, 63, 92, 244, 200, 233, 32, 8, 242, 33, 188, 46,
+    11, 38, 32, 244, 151, 37, 161, 40, 0,
+]; // keccak256("solana-stagenet")
+
+#[cfg(feature = "testnet")]
+pub const CHAIN_NAME_HASH: [u8; 32] = [
+    159, 1, 245, 195, 103, 184, 207, 215, 88, 74, 183, 125, 33, 47, 221, 82, 55, 77, 255, 177, 89,
+    88, 76, 133, 128, 193, 177, 171, 2, 107, 173, 86,
+]; // keccak256("solana-testnet")
+
+#[cfg(feature = "mainnet")]
+pub const CHAIN_NAME_HASH: [u8; 32] = [
+    110, 239, 41, 235, 176, 58, 162, 20, 74, 26, 107, 98, 18, 206, 116, 245, 4, 163, 77, 183, 153,
+    184, 22, 26, 33, 20, 0, 23, 232, 13, 61, 138,
+]; // keccak256("solana")
+
 pub(crate) trait Validate {
     fn validate(&self) -> Result<(), ProgramError>;
 }
@@ -529,13 +554,18 @@ pub(crate) fn create_associated_token_account_idempotent<'a>(
 
 #[must_use]
 pub(crate) fn canonical_interchain_token_deploy_salt(mint: &Pubkey) -> [u8; 32] {
-    solana_program::keccak::hashv(&[seed_prefixes::PREFIX_CANONICAL_TOKEN_SALT, mint.as_ref()])
-        .to_bytes()
+    solana_program::keccak::hashv(&[
+        seed_prefixes::PREFIX_CANONICAL_TOKEN_SALT,
+        &CHAIN_NAME_HASH,
+        mint.as_ref(),
+    ])
+    .to_bytes()
 }
 
 pub(crate) fn interchain_token_deployer_salt(deployer: &Pubkey, salt: &[u8; 32]) -> [u8; 32] {
     solana_program::keccak::hashv(&[
         seed_prefixes::PREFIX_INTERCHAIN_TOKEN_SALT,
+        &CHAIN_NAME_HASH,
         deployer.as_ref(),
         salt,
     ])
@@ -545,6 +575,7 @@ pub(crate) fn interchain_token_deployer_salt(deployer: &Pubkey, salt: &[u8; 32])
 pub(crate) fn linked_token_deployer_salt(deployer: &Pubkey, salt: &[u8; 32]) -> [u8; 32] {
     solana_program::keccak::hashv(&[
         seed_prefixes::PREFIX_CUSTOM_TOKEN_SALT,
+        &CHAIN_NAME_HASH,
         deployer.as_ref(),
         salt,
     ])
@@ -578,4 +609,23 @@ pub fn linked_token_id(deployer: &Pubkey, salt: &[u8; 32]) -> [u8; 32] {
     let salt = linked_token_deployer_salt(deployer, salt);
 
     interchain_token_id_internal(&salt)
+}
+#[cfg(test)]
+mod tests {
+    use super::CHAIN_NAME_HASH;
+
+    #[test]
+    fn test_chain_name_hash_constants() {
+        #[cfg(feature = "mainnet")]
+        let chain_name = "solana";
+        #[cfg(feature = "testnet")]
+        let chain_name = "solana-stagenet";
+        #[cfg(feature = "stagenet")]
+        let chain_name = "solana-testnet";
+        #[cfg(feature = "devnet-amplifier")]
+        let chain_name = "solana-devnet";
+
+        let actual = solana_program::keccak::hash(chain_name.as_bytes()).to_bytes();
+        assert_eq!(CHAIN_NAME_HASH, actual, "hash constant mismatch");
+    }
 }


### PR DESCRIPTION
This is more consistent with our [reference implementation](https://github.com/axelarnetwork/interchain-token-service/blob/d61ef1b238a91d20a97bc1db23d20302984f9857/contracts/InterchainTokenFactory.sol/#L76).

I will take care of the update on the relayer once merged.