### PR TITLE
refactor(its): allow different accounts for inbound transfers

### DIFF
--- a/programs/axelar-solana-its/src/event.rs
+++ b/programs/axelar-solana-its/src/event.rs
@@ -6,6 +6,7 @@ use solana_program::pubkey::Pubkey;
 pub struct InterchainTransfer {
     pub token_id: [u8; 32],
     pub source_address: Pubkey,
+    pub source_token_account: Pubkey,
     pub destination_chain: String,
     pub destination_address: Vec<u8>,
     pub amount: u64,
@@ -19,6 +20,7 @@ pub struct InterchainTransferReceived {
     pub source_chain: String,
     pub source_address: Vec<u8>,
     pub destination_address: Pubkey,
+    pub destination_token_account: Pubkey,
     pub amount: u64,
     pub data_hash: [u8; 32],
 }

--- a/programs/axelar-solana-its/src/executable.rs
+++ b/programs/axelar-solana-its/src/executable.rs
@@ -20,9 +20,7 @@ use crate::state::InterchainTokenService;
 /// 2. [] The token program (spl-token or spl-token-2022).
 /// 3. [writable] The token mint.
 /// 4. [writable] The Destination Program Associated Token Account.
-/// 5. [] The Metaplex Metadata Program account.
-/// 6. [writable] The Metaplex Metadata account associated with the mint.
-pub const PROGRAM_ACCOUNTS_START_INDEX: usize = 7;
+pub const PROGRAM_ACCOUNTS_START_INDEX: usize = 5;
 
 /// This is the payload that the `executeWithInterchainToken` processor on the destinatoin program
 /// must expect

--- a/programs/axelar-solana-its/src/instruction/interchain_token.rs
+++ b/programs/axelar-solana-its/src/instruction/interchain_token.rs
@@ -4,6 +4,8 @@ use borsh::to_vec;
 use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
+use solana_program::system_program;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
 
 use super::InterchainTokenServiceInstruction;
 
@@ -12,6 +14,7 @@ use super::InterchainTokenServiceInstruction;
 /// # Errors
 /// If serialization fails.
 pub fn mint(
+    payer: Pubkey,
     token_id: [u8; 32],
     mint: Pubkey,
     to: Pubkey,
@@ -24,17 +27,22 @@ pub fn mint(
     let (minter_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &minter);
     let data = to_vec(&InterchainTokenServiceInstruction::MintInterchainToken { amount })?;
+    let ata = get_associated_token_address_with_program_id(&to, &mint, &token_program);
 
     Ok(solana_program::instruction::Instruction {
         program_id: crate::id(),
         accounts: vec![
+            AccountMeta::new(payer, true),
             AccountMeta::new(mint, false),
             AccountMeta::new(to, false),
+            AccountMeta::new(ata, false),
             AccountMeta::new_readonly(its_root_pda, false),
             AccountMeta::new_readonly(token_manager_pda, false),
             AccountMeta::new_readonly(minter, true),
             AccountMeta::new_readonly(minter_roles_pda, false),
             AccountMeta::new_readonly(token_program, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+            AccountMeta::new_readonly(spl_associated_token_account::ID, false),
         ],
         data,
     })

--- a/programs/axelar-solana-its/src/lib.rs
+++ b/programs/axelar-solana-its/src/lib.rs
@@ -467,7 +467,8 @@ pub fn deployment_approval_pda(
 }
 
 /// Creates an associated token account for the given program address and token
-/// mint, if it doesn't already exist.
+/// mint, if it doesn't already exist. If it exists, it ensures the wallet is the owner of the
+/// given ATA.
 ///
 /// # Errors
 ///

--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -6,8 +6,8 @@ use axelar_solana_gateway::state::incoming_message::command_id;
 use event_utils::Event as _;
 use interchain_token_transfer_gmp::{GMPPayload, InterchainTransfer};
 use program_utils::{
-    pda::BorshPda, validate_mpl_token_metadata_key, validate_rent_key,
-    validate_spl_associated_token_account_key, validate_system_account_key,
+    pda::BorshPda, validate_rent_key, validate_spl_associated_token_account_key,
+    validate_system_account_key,
 };
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::clock::Clock;
@@ -21,7 +21,7 @@ use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::Sysvar;
 use spl_token_2022::extension::transfer_fee::TransferFeeConfig;
 use spl_token_2022::extension::{BaseStateWithExtensions, StateWithExtensions};
-use spl_token_2022::state::Mint;
+use spl_token_2022::state::{Account as TokenAccount, Mint};
 
 use crate::executable::{AxelarInterchainTokenExecutablePayload, AXELAR_INTERCHAIN_TOKEN_EXECUTE};
 use crate::processor::token_manager as token_manager_processor;
@@ -31,6 +31,26 @@ use crate::state::InterchainTokenService;
 use crate::{assert_valid_token_manager_pda, event, seed_prefixes, FromAccountInfoSlice, Validate};
 
 use super::gmp::{self, GmpAccounts};
+
+/// Checks if an account is a valid Token account for the given mint and owner.
+pub(super) fn is_valid_token_account(
+    account: &AccountInfo,
+    token_program: &Pubkey,
+    expected_mint: &Pubkey,
+) -> bool {
+    // Check account owner is the token program
+    if account.owner != token_program {
+        return false;
+    }
+
+    // Try to unpack as TokenAccount and verify mint/owner
+    let account_data = account.data.borrow();
+    if let Ok(token_account) = StateWithExtensions::<TokenAccount>::unpack(&account_data) {
+        return token_account.base.mint == *expected_mint;
+    }
+
+    false
+}
 
 /// Processes an incoming [`InterchainTransfer`] GMP message.
 ///
@@ -90,11 +110,7 @@ pub(crate) fn process_inbound_transfer<'a>(
         token_id: token_manager.token_id,
         source_chain,
         source_address: payload.source_address.to_vec(),
-        destination_address: *parsed_accounts
-            .program_ata
-            .map_or(parsed_accounts.destination_account.key, |account| {
-                account.key
-            }),
+        destination_address: *parsed_accounts.destination.key,
         amount: transferred_amount,
         data_hash: if payload.data.is_empty() {
             [0; 32]
@@ -105,7 +121,7 @@ pub(crate) fn process_inbound_transfer<'a>(
     .emit();
 
     if !payload.data.is_empty() {
-        let program_account = parsed_accounts.destination_account;
+        let program_account = parsed_accounts.destination;
         if !program_account.executable {
             return Err(ProgramError::InvalidInstructionData);
         }
@@ -125,12 +141,6 @@ pub(crate) fn process_inbound_transfer<'a>(
                 axelar_executable_accounts.token_program.clone(),
                 axelar_executable_accounts.token_mint.clone(),
                 axelar_executable_accounts.program_ata.clone(),
-                axelar_executable_accounts
-                    .mpl_token_metadata_program
-                    .clone(),
-                axelar_executable_accounts
-                    .mpl_token_metadata_account
-                    .clone(),
             ],
             axelar_executable_accounts.destination_program_accounts,
         ]
@@ -180,18 +190,6 @@ fn build_axelar_interchain_token_execute(
         AccountMeta::new_readonly(*axelar_its_executable_accounts.token_program.key, false),
         AccountMeta::new(*axelar_its_executable_accounts.token_mint.key, false),
         AccountMeta::new(*axelar_its_executable_accounts.program_ata.key, false),
-        AccountMeta::new_readonly(
-            *axelar_its_executable_accounts
-                .mpl_token_metadata_program
-                .key,
-            false,
-        ),
-        AccountMeta::new(
-            *axelar_its_executable_accounts
-                .mpl_token_metadata_account
-                .key,
-            false,
-        ),
     ];
     accounts.append(&mut program_accounts);
 
@@ -226,7 +224,7 @@ pub(crate) fn process_outbound_transfer<'a>(
     signing_pda_bump: u8,
     data: Option<Vec<u8>>,
 ) -> ProgramResult {
-    const GMP_ACCOUNTS_IDX: usize = 6;
+    const GMP_ACCOUNTS_IDX: usize = 7;
     let take_token_accounts = TakeTokenAccounts::from_account_info_slice(accounts, &())?;
     let (_other, outbound_message_accounts) = accounts.split_at(GMP_ACCOUNTS_IDX);
     let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
@@ -262,7 +260,7 @@ pub(crate) fn process_outbound_transfer<'a>(
 
     let transfer_event = event::InterchainTransfer {
         token_id,
-        source_address: *take_token_accounts.source_account.key,
+        source_address: *take_token_accounts.wallet.key,
         destination_chain,
         destination_address,
         amount,
@@ -325,18 +323,28 @@ fn give_token(
         accounts.token_manager_pda,
     )?;
 
-    if let Some(program_ata) = accounts.program_ata {
+    // Check if source is already a valid token account for this mint
+    let use_destination_directly = is_valid_token_account(
+        accounts.destination,
+        accounts.token_program.key,
+        accounts.token_mint.key,
+    );
+
+    if !use_destination_directly {
+        // The `source` is a wallet, let's make sure the ATA exists. This will also ensure the
+        // owner of the token account is the wallet, reverting in case it's not.
         crate::create_associated_token_account_idempotent(
             accounts.payer,
             accounts.token_mint,
-            program_ata,
-            accounts.destination_account,
+            accounts.destination_ata,
+            accounts.destination,
             accounts.system_account,
             accounts.token_program,
         )?;
     }
 
-    let transferred_amount = handle_give_token_transfer(accounts, token_manager, amount)?;
+    let transferred_amount =
+        handle_give_token_transfer(accounts, token_manager, amount, use_destination_directly)?;
 
     Ok(transferred_amount)
 }
@@ -378,12 +386,11 @@ fn handle_give_token_transfer(
     accounts: &GiveTokenAccounts<'_>,
     token_manager: &TokenManager,
     amount: u64,
+    use_destination_directly: bool,
 ) -> Result<u64, ProgramError> {
     use token_manager::Type::{
         LockUnlock, LockUnlockFee, MintBurn, MintBurnFrom, NativeInterchainToken,
     };
-
-    let destination = accounts.program_ata.unwrap_or(accounts.destination_account);
 
     track_token_flow(
         &accounts.into(),
@@ -402,11 +409,16 @@ fn handle_give_token_transfer(
     ];
     let transferred = match token_manager.ty {
         NativeInterchainToken | MintBurn | MintBurnFrom => {
+            let destination_account = if use_destination_directly {
+                accounts.destination
+            } else {
+                accounts.destination_ata
+            };
             mint_to(
                 accounts.its_root_pda,
                 accounts.token_program,
                 accounts.token_mint,
-                destination,
+                destination_account,
                 accounts.token_manager_pda,
                 token_manager,
                 amount,
@@ -415,8 +427,14 @@ fn handle_give_token_transfer(
         }
         LockUnlock => {
             let decimals = get_mint_decimals(accounts.token_mint)?;
-            let transfer_info =
-                create_give_token_transfer_info(accounts, amount, decimals, None, signer_seeds);
+            let transfer_info = create_give_token_transfer_info(
+                accounts,
+                amount,
+                decimals,
+                None,
+                signer_seeds,
+                use_destination_directly,
+            );
             transfer_to(&transfer_info)?;
 
             amount
@@ -429,6 +447,7 @@ fn handle_give_token_transfer(
                 decimals,
                 Some(fee),
                 signer_seeds,
+                use_destination_directly,
             );
             transfer_with_fee_to(&transfer_info)?;
             amount
@@ -462,7 +481,7 @@ fn handle_take_token_transfer(
                 accounts.payer,
                 accounts.token_program,
                 accounts.token_mint,
-                accounts.source_account,
+                accounts.source_ata,
                 amount,
                 &[],
             )?;
@@ -510,7 +529,7 @@ fn get_fee_and_decimals(
     Ok((fee, mint_state.base.decimals))
 }
 
-const fn create_take_token_transfer_info<'a, 'b>(
+fn create_take_token_transfer_info<'a, 'b>(
     accounts: &TakeTokenAccounts<'a>,
     amount: u64,
     decimals: u8,
@@ -520,9 +539,9 @@ const fn create_take_token_transfer_info<'a, 'b>(
     TransferInfo {
         token_program: accounts.token_program,
         token_mint: accounts.token_mint,
-        destination_ata: accounts.token_manager_ata,
-        authority: accounts.payer,
-        source_ata: accounts.source_account,
+        destination: accounts.token_manager_ata,
+        authority: accounts.wallet,
+        source: accounts.source_ata,
         signers_seeds,
         amount,
         decimals,
@@ -536,13 +555,20 @@ fn create_give_token_transfer_info<'a, 'b>(
     decimals: u8,
     fee: Option<u64>,
     signers_seeds: &'b [&[u8]],
+    use_destination_directly: bool,
 ) -> TransferInfo<'a, 'b> {
+    let destination_account = if use_destination_directly {
+        accounts.destination
+    } else {
+        accounts.destination_ata
+    };
+
     TransferInfo {
         token_program: accounts.token_program,
         token_mint: accounts.token_mint,
-        destination_ata: accounts.program_ata.unwrap_or(accounts.destination_account),
+        destination: destination_account,
         authority: accounts.token_manager_pda,
-        source_ata: accounts.token_manager_ata,
+        source: accounts.token_manager_ata,
         signers_seeds,
         amount,
         decimals,
@@ -554,7 +580,7 @@ fn mint_to<'a>(
     its_root_pda: &AccountInfo<'a>,
     token_program: &AccountInfo<'a>,
     token_mint: &AccountInfo<'a>,
-    destination_ata: &AccountInfo<'a>,
+    destination: &AccountInfo<'a>,
     token_manager_pda: &AccountInfo<'a>,
     token_manager: &TokenManager,
     amount: u64,
@@ -563,14 +589,14 @@ fn mint_to<'a>(
         &spl_token_2022::instruction::mint_to(
             token_program.key,
             token_mint.key,
-            destination_ata.key,
+            destination.key,
             token_manager_pda.key,
             &[],
             amount,
         )?,
         &[
             token_mint.clone(),
-            destination_ata.clone(),
+            destination.clone(),
             token_manager_pda.clone(),
         ],
         &[&[
@@ -614,9 +640,9 @@ fn burn<'a>(
 struct TransferInfo<'a, 'b> {
     token_program: &'b AccountInfo<'a>,
     token_mint: &'b AccountInfo<'a>,
-    destination_ata: &'b AccountInfo<'a>,
+    destination: &'b AccountInfo<'a>,
     authority: &'b AccountInfo<'a>,
-    source_ata: &'b AccountInfo<'a>,
+    source: &'b AccountInfo<'a>,
     signers_seeds: &'b [&'b [u8]],
     amount: u64,
     decimals: u8,
@@ -627,9 +653,9 @@ fn transfer_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
     invoke_signed(
         &spl_token_2022::instruction::transfer_checked(
             info.token_program.key,
-            info.source_ata.key,
+            info.source.key,
             info.token_mint.key,
-            info.destination_ata.key,
+            info.destination.key,
             info.authority.key,
             &[],
             info.amount,
@@ -637,9 +663,9 @@ fn transfer_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
         )?,
         &[
             info.token_mint.clone(),
-            info.source_ata.clone(),
+            info.source.clone(),
             info.authority.clone(),
-            info.destination_ata.clone(),
+            info.destination.clone(),
         ],
         &[info.signers_seeds],
     )?;
@@ -650,9 +676,9 @@ fn transfer_with_fee_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
     invoke_signed(
         &spl_token_2022::extension::transfer_fee::instruction::transfer_checked_with_fee(
             info.token_program.key,
-            info.source_ata.key,
+            info.source.key,
             info.token_mint.key,
-            info.destination_ata.key,
+            info.destination.key,
             info.authority.key,
             &[],
             info.amount,
@@ -661,9 +687,9 @@ fn transfer_with_fee_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
         )?,
         &[
             info.token_mint.clone(),
-            info.source_ata.clone(),
+            info.source.clone(),
             info.authority.clone(),
-            info.destination_ata.clone(),
+            info.destination.clone(),
         ],
         &[info.signers_seeds],
     )?;
@@ -673,7 +699,8 @@ fn transfer_with_fee_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
 #[derive(Debug)]
 pub(crate) struct TakeTokenAccounts<'a> {
     pub(crate) payer: &'a AccountInfo<'a>,
-    pub(crate) source_account: &'a AccountInfo<'a>,
+    pub(crate) wallet: &'a AccountInfo<'a>,
+    pub(crate) source_ata: &'a AccountInfo<'a>,
     pub(crate) token_mint: &'a AccountInfo<'a>,
     pub(crate) token_manager_pda: &'a AccountInfo<'a>,
     pub(crate) token_manager_ata: &'a AccountInfo<'a>,
@@ -699,7 +726,8 @@ impl<'a> FromAccountInfoSlice<'a> for TakeTokenAccounts<'a> {
 
         Ok(TakeTokenAccounts {
             payer: next_account_info(accounts_iter)?,
-            source_account: next_account_info(accounts_iter)?,
+            wallet: next_account_info(accounts_iter)?,
+            source_ata: next_account_info(accounts_iter)?,
             token_mint: next_account_info(accounts_iter)?,
             token_manager_pda: next_account_info(accounts_iter)?,
             token_manager_ata: next_account_info(accounts_iter)?,
@@ -729,10 +757,8 @@ struct GiveTokenAccounts<'a> {
     ata_program: &'a AccountInfo<'a>,
     _its_roles_pda: &'a AccountInfo<'a>,
     rent_sysvar: &'a AccountInfo<'a>,
-    destination_account: &'a AccountInfo<'a>,
-    program_ata: Option<&'a AccountInfo<'a>>,
-    mpl_token_metadata_program: Option<&'a AccountInfo<'a>>,
-    mpl_token_metadata_account: Option<&'a AccountInfo<'a>>,
+    destination: &'a AccountInfo<'a>,
+    destination_ata: &'a AccountInfo<'a>,
 }
 
 impl Validate for GiveTokenAccounts<'_> {
@@ -740,9 +766,6 @@ impl Validate for GiveTokenAccounts<'_> {
         validate_system_account_key(self.system_account.key)?;
         validate_spl_associated_token_account_key(self.ata_program.key)?;
         validate_rent_key(self.rent_sysvar.key)?;
-        if let Some(val) = self.mpl_token_metadata_program {
-            validate_mpl_token_metadata_key(val.key)?;
-        }
         Ok(())
     }
 }
@@ -768,10 +791,8 @@ impl<'a> FromAccountInfoSlice<'a> for GiveTokenAccounts<'a> {
             ata_program: next_account_info(accounts_iter)?,
             _its_roles_pda: next_account_info(accounts_iter)?,
             rent_sysvar: next_account_info(accounts_iter)?,
-            destination_account: next_account_info(accounts_iter)?,
-            program_ata: next_account_info(accounts_iter).ok(),
-            mpl_token_metadata_program: next_account_info(accounts_iter).ok(),
-            mpl_token_metadata_account: next_account_info(accounts_iter).ok(),
+            destination: next_account_info(accounts_iter)?,
+            destination_ata: next_account_info(accounts_iter)?,
         })
     }
 }
@@ -782,14 +803,11 @@ struct AxelarInterchainTokenExecutableAccounts<'a> {
     token_program: &'a AccountInfo<'a>,
     token_mint: &'a AccountInfo<'a>,
     program_ata: &'a AccountInfo<'a>,
-    mpl_token_metadata_program: &'a AccountInfo<'a>,
-    mpl_token_metadata_account: &'a AccountInfo<'a>,
     destination_program_accounts: &'a [AccountInfo<'a>],
 }
 
 impl Validate for AxelarInterchainTokenExecutableAccounts<'_> {
     fn validate(&self) -> Result<(), ProgramError> {
-        validate_mpl_token_metadata_key(self.mpl_token_metadata_program.key)?;
         Ok(())
     }
 }
@@ -820,15 +838,7 @@ impl<'a> FromAccountInfoSlice<'a> for AxelarInterchainTokenExecutableAccounts<'a
             message_payload_pda: give_token_accounts.message_payload_pda,
             token_program: give_token_accounts.token_program,
             token_mint: give_token_accounts.token_mint,
-            program_ata: give_token_accounts
-                .program_ata
-                .ok_or(ProgramError::NotEnoughAccountKeys)?,
-            mpl_token_metadata_program: give_token_accounts
-                .mpl_token_metadata_program
-                .ok_or(ProgramError::NotEnoughAccountKeys)?,
-            mpl_token_metadata_account: give_token_accounts
-                .mpl_token_metadata_account
-                .ok_or(ProgramError::NotEnoughAccountKeys)?,
+            program_ata: give_token_accounts.destination_ata,
             destination_program_accounts,
         })
     }

--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -58,8 +58,7 @@ pub(super) fn is_valid_token_account(
 ///
 /// For incoming `InterchainTransfer` messages, the behaviour of the
 /// [`NativeInterchainToken`], [`MintBurn`] and [`MintBurnFrom`]
-/// [`TokenManager`]s are the same: the token is minted to the destination
-/// wallet's associated token account.
+/// [`TokenManager`]s are the same: the token is minted to the destination token account.
 ///
 /// As for [`LockUnlock`] and [`LockUnlockFee`] [`TokenManager`]s, they are
 /// typically used in the home chain of the token, thus, if we're getting an
@@ -75,6 +74,24 @@ pub(super) fn is_valid_token_account(
 /// calculate the fee according to the fee configuration and call the correct
 /// instruction to keep the fee withheld wherever the user defined they should
 /// be withheld.
+///
+/// # Destination Address
+///
+/// When processing incoming token transfers, the program handles the destination address as
+/// follows:
+///
+/// 1. **If `destination_address` is a Token Account**: Transfers funds directly to that account.
+///
+/// 2. **If `destination_address` is NOT a Token Account**: Derives and uses the Associated Token
+///    Account (ATA) for that address.
+///    
+///    For security, the program verifies that the ATA's owner matches the `destination_address`:
+///    - **SPL Token 2022 ATAs**: Always safe (have `ImmutableOwner` extension preventing ownership
+///    changes)
+///    - **SPL Token ATAs**: Can have ownership transferred, creating a security risk
+///    
+///    If ownership verification fails, the transaction is rejected to prevent funds being sent to
+///    accounts controlled by unexpected parties./
 ///
 /// # Errors
 ///

--- a/programs/axelar-solana-its/tests/module/deploy_interchain_token.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_interchain_token.rs
@@ -111,23 +111,12 @@ async fn test_deploy_interchain_token_with_minter_but_no_initial_supply(
         assert_eq!(account.amount, 0, "Initial supply should be zero");
     }
 
-    let create_token_account_ix =
-        spl_associated_token_account::instruction::create_associated_token_account(
-            &ctx.solana_wallet,
-            &ctx.solana_wallet,
-            &interchain_token_pda,
-            &spl_token_2022::id(),
-        );
-
-    ctx.send_solana_tx(&[create_token_account_ix])
-        .await
-        .expect("Failed to create token account");
-
     let mint_amount = 500u64;
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        ctx.solana_wallet,
         token_id,
         interchain_token_pda,
-        payer_ata,
+        ctx.solana_wallet,
         ctx.solana_wallet,
         spl_token_2022::id(),
         mint_amount,
@@ -282,6 +271,7 @@ async fn test_deploy_interchain_token_with_no_minter_but_initial_supply(
     );
 
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        ctx.solana_wallet,
         token_id,
         interchain_token_pda,
         payer_ata,

--- a/programs/axelar-solana-its/tests/module/fee_handling.rs
+++ b/programs/axelar-solana-its/tests/module/fee_handling.rs
@@ -115,11 +115,9 @@ async fn test_canonical_token_with_fee_lock_unlock(ctx: &mut ItsTestContext) -> 
         user_balance,
     )?;
 
-    dbg!("WILL MINT");
     ctx.send_solana_tx(&[create_user_ata_ix, mint_to_user_ix])
         .await
         .unwrap();
-    dbg!("MINTED");
 
     // Test transfer
     let transfer_amount = 1000_u64;

--- a/programs/axelar-solana-its/tests/module/fee_handling.rs
+++ b/programs/axelar-solana-its/tests/module/fee_handling.rs
@@ -115,15 +115,17 @@ async fn test_canonical_token_with_fee_lock_unlock(ctx: &mut ItsTestContext) -> 
         user_balance,
     )?;
 
+    dbg!("WILL MINT");
     ctx.send_solana_tx(&[create_user_ata_ix, mint_to_user_ix])
         .await
         .unwrap();
+    dbg!("MINTED");
 
     // Test transfer
     let transfer_amount = 1000_u64;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
-        user_ata,
+        ctx.solana_wallet,
         canonical_token_id,
         ctx.evm_chain_name.clone(),
         ctx.evm_signer.wallet.address().as_bytes().to_vec(),
@@ -264,7 +266,7 @@ async fn test_canonical_token_various_fee_configs(ctx: &mut ItsTestContext) -> a
     let transfer_amount = 10_000_u64;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
-        user_ata,
+        ctx.solana_wallet,
         canonical_token_id,
         ctx.evm_chain_name.clone(),
         ctx.evm_signer.wallet.address().as_bytes().to_vec(),
@@ -402,7 +404,7 @@ async fn test_canonical_token_maximum_fee_cap(ctx: &mut ItsTestContext) -> anyho
     // Test transfer
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
-        user_ata,
+        ctx.solana_wallet,
         canonical_token_id,
         ctx.evm_chain_name.clone(),
         ctx.evm_signer.wallet.address().as_bytes().to_vec(),
@@ -625,7 +627,7 @@ async fn test_custom_token_with_fee_lock_unlock_fee(
     let transfer_amount = 3000_u64;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
-        user_ata,
+        ctx.solana_wallet,
         token_id,
         ctx.evm_chain_name.clone(),
         ctx.evm_signer.wallet.address().as_bytes().to_vec(),
@@ -683,7 +685,7 @@ async fn test_custom_token_with_fee_lock_unlock_fee(
         .interchain_transfer(
             token_id,
             ctx.solana_chain_name.clone(),
-            user_ata.to_bytes().into(),
+            ctx.solana_wallet.to_bytes().into(),
             inbound_transfer_amount.into(),
             vec![].into(),
             0.into(),

--- a/programs/axelar-solana-its/tests/module/handover_mint_authority.rs
+++ b/programs/axelar-solana-its/tests/module/handover_mint_authority.rs
@@ -370,30 +370,12 @@ async fn test_successful_handover_mint_authority(ctx: &mut ItsTestContext) {
         &spl_token_2022::id(),
     );
 
-    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
-        &alice.pubkey(),
-        &alice.pubkey(),
-        &alice_token_mint,
-        &spl_token_2022::id(),
-    );
-
-    ctx.solana_chain
-        .fixture
-        .send_tx_with_custom_signers(
-            &[create_ata_ix],
-            &[
-                &alice.insecure_clone(),
-                &ctx.solana_chain.fixture.payer.insecure_clone(),
-            ],
-        )
-        .await
-        .unwrap();
-
     let mint_amount = 1000u64;
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        ctx.solana_wallet,
         alice_token_id,
         alice_token_mint,
-        alice_ata,
+        alice.pubkey(),
         alice.pubkey(),
         spl_token_2022::id(),
         mint_amount,

--- a/programs/axelar-solana-its/tests/module/main.rs
+++ b/programs/axelar-solana-its/tests/module/main.rs
@@ -33,6 +33,7 @@ mod metadata_retrieval;
 mod pause_unpause;
 mod role_management;
 mod token_id_validation;
+mod transfer_destination;
 
 use event_utils::Event;
 use solana_program_test::BanksTransactionResultWithMetadata;
@@ -350,7 +351,7 @@ impl ItsTestContext {
 
         let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
             self.solana_wallet,
-            token_account,
+            self.solana_wallet,
             token_id,
             self.evm_chain_name.clone(),
             self.evm_signer.wallet.address().as_bytes().to_vec(),
@@ -388,7 +389,7 @@ impl ItsTestContext {
             .interchain_transfer(
                 token_id,
                 self.solana_chain_name.clone(),
-                token_account.to_bytes().into(),
+                self.solana_wallet.to_bytes().into(),
                 amount_back.into(),
                 Bytes::new(),
                 0.into(),

--- a/programs/axelar-solana-its/tests/module/role_management.rs
+++ b/programs/axelar-solana-its/tests/module/role_management.rs
@@ -660,6 +660,7 @@ async fn test_fail_mint_without_minter_role(ctx: &mut ItsTestContext) {
         .unwrap();
 
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        ctx.solana_wallet,
         token_id,
         token_address,
         ata,

--- a/programs/axelar-solana-its/tests/module/transfer_destination.rs
+++ b/programs/axelar-solana-its/tests/module/transfer_destination.rs
@@ -1,0 +1,398 @@
+use event_utils::Event;
+use interchain_token_transfer_gmp::{GMPPayload, InterchainTransfer};
+use solana_program_test::tokio;
+use solana_sdk::program_pack::Pack as _;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer as _;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token_2022::instruction::initialize_account3;
+use test_context::test_context;
+
+use crate::ItsTestContext;
+use axelar_solana_its::state::token_manager::Type as TokenManagerType;
+
+/// Helper function to create a custom mint for testing
+async fn setup_custom_mint_and_token_manager(
+    ctx: &mut ItsTestContext,
+    token_manager_type: TokenManagerType,
+) -> anyhow::Result<([u8; 32], Pubkey)> {
+    let salt = solana_sdk::keccak::hash(b"wallet-as-token-account-test").to_bytes();
+
+    let custom_mint = ctx
+        .solana_chain
+        .fixture
+        .init_new_mint(ctx.solana_wallet, spl_token_2022::id(), 9)
+        .await;
+
+    let token_id = axelar_solana_its::linked_token_id(&ctx.solana_wallet, &salt);
+    let register_custom_token_ix = axelar_solana_its::instruction::register_custom_token(
+        ctx.solana_wallet,
+        salt,
+        custom_mint,
+        token_manager_type,
+        spl_token_2022::id(),
+        None,
+    )?;
+
+    ctx.send_solana_tx(&[register_custom_token_ix])
+        .await
+        .unwrap();
+
+    Ok((token_id, custom_mint))
+}
+
+/// Creates a token account
+async fn create_direct_token_account(
+    ctx: &mut ItsTestContext,
+    mint: Pubkey,
+    owner: Pubkey,
+) -> anyhow::Result<Pubkey> {
+    let token_account_keypair = Keypair::new();
+    let token_account = token_account_keypair.pubkey();
+
+    let rent_exempt_balance = ctx
+        .solana_chain
+        .fixture
+        .get_rent(spl_token_2022::state::Account::LEN)
+        .await;
+
+    let create_account_ix = solana_sdk::system_instruction::create_account(
+        &ctx.solana_wallet,
+        &token_account,
+        rent_exempt_balance,
+        spl_token_2022::state::Account::LEN as u64,
+        &spl_token_2022::id(),
+    );
+
+    let init_account_ix =
+        initialize_account3(&spl_token_2022::id(), &token_account, &mint, &owner)?;
+
+    ctx.solana_chain
+        .fixture
+        .send_tx_with_custom_signers(
+            &[create_account_ix, init_account_ix],
+            &[
+                ctx.solana_chain.fixture.payer.insecure_clone(),
+                token_account_keypair.insecure_clone(),
+            ],
+        )
+        .await
+        .unwrap();
+
+    Ok(token_account)
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_inbound_transfer_using_token_account_mint_burn(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (token_id, custom_mint) =
+        setup_custom_mint_and_token_manager(ctx, TokenManagerType::MintBurn).await?;
+
+    let authority_transfer_ix =
+        axelar_solana_its::instruction::token_manager::handover_mint_authority(
+            ctx.solana_wallet,
+            token_id,
+            custom_mint,
+            spl_token_2022::id(),
+        )?;
+    ctx.send_solana_tx(&[authority_transfer_ix]).await.unwrap();
+
+    let token_account = create_direct_token_account(ctx, custom_mint, ctx.solana_wallet).await?;
+
+    let transfer_amount = 300u64;
+    let interchain_transfer = InterchainTransfer {
+        selector: InterchainTransfer::MESSAGE_TYPE_ID.try_into().unwrap(),
+        token_id: token_id.into(),
+        source_address: b"0x1234567890123456789012345678901234567890"
+            .to_vec()
+            .into(),
+        destination_address: token_account.to_bytes().into(),
+        amount: alloy_primitives::U256::from(transfer_amount),
+        data: vec![].into(),
+    };
+
+    let payload = GMPPayload::SendToHub(interchain_token_transfer_gmp::SendToHub {
+        selector: interchain_token_transfer_gmp::SendToHub::MESSAGE_TYPE_ID
+            .try_into()
+            .unwrap(),
+        destination_chain: ctx.solana_chain_name.clone(),
+        payload: GMPPayload::InterchainTransfer(interchain_transfer)
+            .encode()
+            .into(),
+    });
+
+    let tx = ctx
+        .relay_to_solana(&payload.encode(), Some(custom_mint), spl_token_2022::id())
+        .await;
+
+    let logs = tx.metadata.unwrap().log_messages;
+    let transfer_received_event = logs
+        .iter()
+        .find_map(|log| {
+            axelar_solana_its::event::InterchainTransferReceived::try_from_log(log).ok()
+        })
+        .expect("InterchainTransferReceived event should be present");
+
+    assert_eq!(transfer_received_event.amount, transfer_amount);
+    assert_eq!(transfer_received_event.token_id, token_id);
+    assert_eq!(transfer_received_event.destination_address, token_account);
+
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&token_account)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+    assert_eq!(account.amount, transfer_amount);
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_inbound_transfer_using_token_account_lock_unlock(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (token_id, custom_mint) =
+        setup_custom_mint_and_token_manager(ctx, TokenManagerType::LockUnlock).await?;
+
+    let token_account = create_direct_token_account(ctx, custom_mint, ctx.solana_wallet).await?;
+
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let (token_manager_pda, _) =
+        axelar_solana_its::find_token_manager_pda(&its_root_pda, &token_id);
+    let token_manager_ata = get_associated_token_address_with_program_id(
+        &token_manager_pda,
+        &custom_mint,
+        &spl_token_2022::id(),
+    );
+
+    let mint_amount = 1000;
+    let mint_ix = spl_token_2022::instruction::mint_to(
+        &spl_token_2022::id(),
+        &custom_mint,
+        &token_manager_ata,
+        &ctx.solana_wallet,
+        &[],
+        mint_amount,
+    )?;
+    ctx.send_solana_tx(&[mint_ix]).await.unwrap();
+
+    let transfer_amount = 300u64;
+    let interchain_transfer = InterchainTransfer {
+        selector: InterchainTransfer::MESSAGE_TYPE_ID.try_into().unwrap(),
+        token_id: token_id.into(),
+        source_address: b"0x1234567890123456789012345678901234567890"
+            .to_vec()
+            .into(),
+        destination_address: token_account.to_bytes().into(),
+        amount: alloy_primitives::U256::from(transfer_amount),
+        data: vec![].into(),
+    };
+
+    let payload = GMPPayload::SendToHub(interchain_token_transfer_gmp::SendToHub {
+        selector: interchain_token_transfer_gmp::SendToHub::MESSAGE_TYPE_ID
+            .try_into()
+            .unwrap(),
+        destination_chain: ctx.solana_chain_name.clone(),
+        payload: GMPPayload::InterchainTransfer(interchain_transfer)
+            .encode()
+            .into(),
+    });
+
+    let tx = ctx
+        .relay_to_solana(&payload.encode(), Some(custom_mint), spl_token_2022::id())
+        .await;
+
+    let logs = tx.metadata.unwrap().log_messages;
+    let transfer_received_event = logs
+        .iter()
+        .find_map(|log| {
+            axelar_solana_its::event::InterchainTransferReceived::try_from_log(log).ok()
+        })
+        .expect("InterchainTransferReceived event should be present");
+
+    assert_eq!(transfer_received_event.amount, transfer_amount);
+    assert_eq!(transfer_received_event.token_id, token_id);
+    assert_eq!(transfer_received_event.destination_address, token_account);
+
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&token_account)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+    assert_eq!(account.amount, transfer_amount);
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_inbound_transfer_using_wallet_mint_burn(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (token_id, custom_mint) =
+        setup_custom_mint_and_token_manager(ctx, TokenManagerType::MintBurn).await?;
+
+    let authority_transfer_ix =
+        axelar_solana_its::instruction::token_manager::handover_mint_authority(
+            ctx.solana_wallet,
+            token_id,
+            custom_mint,
+            spl_token_2022::id(),
+        )?;
+    ctx.send_solana_tx(&[authority_transfer_ix]).await.unwrap();
+
+    let transfer_amount = 300u64;
+    let interchain_transfer = InterchainTransfer {
+        selector: InterchainTransfer::MESSAGE_TYPE_ID.try_into().unwrap(),
+        token_id: token_id.into(),
+        source_address: b"0x1234567890123456789012345678901234567890"
+            .to_vec()
+            .into(),
+        destination_address: ctx.solana_wallet.to_bytes().to_vec().into(),
+        amount: alloy_primitives::U256::from(transfer_amount),
+        data: vec![].into(),
+    };
+
+    let payload = GMPPayload::SendToHub(interchain_token_transfer_gmp::SendToHub {
+        selector: interchain_token_transfer_gmp::SendToHub::MESSAGE_TYPE_ID
+            .try_into()
+            .unwrap(),
+        destination_chain: ctx.solana_chain_name.clone(),
+        payload: GMPPayload::InterchainTransfer(interchain_transfer)
+            .encode()
+            .into(),
+    });
+
+    let tx = ctx
+        .relay_to_solana(&payload.encode(), Some(custom_mint), spl_token_2022::id())
+        .await;
+
+    let logs = tx.metadata.unwrap().log_messages;
+    let transfer_received_event = logs
+        .iter()
+        .find_map(|log| {
+            axelar_solana_its::event::InterchainTransferReceived::try_from_log(log).ok()
+        })
+        .expect("InterchainTransferReceived event should be present");
+
+    assert_eq!(transfer_received_event.amount, transfer_amount);
+    assert_eq!(transfer_received_event.token_id, token_id);
+    assert_eq!(
+        transfer_received_event.destination_address,
+        ctx.solana_wallet
+    );
+
+    let wallet_ata = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &custom_mint,
+        &spl_token_2022::id(),
+    );
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&wallet_ata)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+    assert_eq!(account.amount, transfer_amount);
+
+    Ok(())
+}
+
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_inbound_transfer_using_wallet_lock_unlock(
+    ctx: &mut ItsTestContext,
+) -> anyhow::Result<()> {
+    let (token_id, custom_mint) =
+        setup_custom_mint_and_token_manager(ctx, TokenManagerType::LockUnlock).await?;
+
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let (token_manager_pda, _) =
+        axelar_solana_its::find_token_manager_pda(&its_root_pda, &token_id);
+    let token_manager_ata = get_associated_token_address_with_program_id(
+        &token_manager_pda,
+        &custom_mint,
+        &spl_token_2022::id(),
+    );
+
+    let mint_amount = 1000;
+    let mint_ix = spl_token_2022::instruction::mint_to(
+        &spl_token_2022::id(),
+        &custom_mint,
+        &token_manager_ata,
+        &ctx.solana_wallet,
+        &[],
+        mint_amount,
+    )?;
+    ctx.send_solana_tx(&[mint_ix]).await.unwrap();
+
+    let transfer_amount = 300u64;
+    let interchain_transfer = InterchainTransfer {
+        selector: InterchainTransfer::MESSAGE_TYPE_ID.try_into().unwrap(),
+        token_id: token_id.into(),
+        source_address: b"0x1234567890123456789012345678901234567890"
+            .to_vec()
+            .into(),
+        destination_address: ctx.solana_wallet.to_bytes().into(),
+        amount: alloy_primitives::U256::from(transfer_amount),
+        data: vec![].into(),
+    };
+
+    let payload = GMPPayload::SendToHub(interchain_token_transfer_gmp::SendToHub {
+        selector: interchain_token_transfer_gmp::SendToHub::MESSAGE_TYPE_ID
+            .try_into()
+            .unwrap(),
+        destination_chain: ctx.solana_chain_name.clone(),
+        payload: GMPPayload::InterchainTransfer(interchain_transfer)
+            .encode()
+            .into(),
+    });
+
+    let tx = ctx
+        .relay_to_solana(&payload.encode(), Some(custom_mint), spl_token_2022::id())
+        .await;
+
+    let logs = tx.metadata.unwrap().log_messages;
+    let transfer_received_event = logs
+        .iter()
+        .find_map(|log| {
+            axelar_solana_its::event::InterchainTransferReceived::try_from_log(log).ok()
+        })
+        .expect("InterchainTransferReceived event should be present");
+
+    assert_eq!(transfer_received_event.amount, transfer_amount);
+    assert_eq!(transfer_received_event.token_id, token_id);
+    assert_eq!(
+        transfer_received_event.destination_address,
+        ctx.solana_wallet
+    );
+
+    let token_account = get_associated_token_address_with_program_id(
+        &ctx.solana_wallet,
+        &custom_mint,
+        &spl_token_2022::id(),
+    );
+    let token_account_data = ctx
+        .solana_chain
+        .try_get_account_no_checks(&token_account)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let account = spl_token_2022::state::Account::unpack_from_slice(&token_account_data)?;
+    assert_eq!(account.amount, transfer_amount);
+
+    Ok(())
+}

--- a/programs/axelar-solana-its/tests/module/transfer_destination.rs
+++ b/programs/axelar-solana-its/tests/module/transfer_destination.rs
@@ -57,6 +57,7 @@ async fn create_direct_token_account(
         .get_rent(spl_token_2022::state::Account::LEN)
         .await;
 
+    #[allow(clippy::disallowed_methods)]
     let create_account_ix = solana_sdk::system_instruction::create_account(
         &ctx.solana_wallet,
         &token_account,

--- a/programs/axelar-solana-memo-program/src/processor.rs
+++ b/programs/axelar-solana-memo-program/src/processor.rs
@@ -65,7 +65,6 @@ pub fn process_message_from_axelar_with_token<'a>(
     let _token_program = next_account_info(accounts_iter)?;
     let _token_mint = next_account_info(accounts_iter)?;
     let _ata_account = next_account_info(accounts_iter)?;
-    let _mpl_token_metadata_program = next_account_info(accounts_iter)?;
     let mpl_token_metadata_account = next_account_info(accounts_iter)?;
     let instruction_accounts = accounts_iter.as_slice();
     let token_metadata = Metadata::from_bytes(&mpl_token_metadata_account.try_borrow_data()?)?;


### PR DESCRIPTION
When processing incoming token transfers, the program handles the destination address as
follows:

1. **If `destination_address` is a Token Account**: Transfers funds directly to that account.

2. **If `destination_address` is NOT a Token Account**: Derives and uses the Associated Token
   Account (ATA) for that address.
   
   For security, the program verifies that the ATA's owner matches the `destination_address`:
   - **SPL Token 2022 ATAs**: Always safe (have `ImmutableOwner` extension preventing ownership
   changes)
   - **SPL Token ATAs**: Can have ownership transferred, creating a security risk
   
   If ownership verification fails, the transaction is rejected to prevent funds being sent to
   accounts controlled by unexpected parties.

Besides that, the patch also removes the metaplex metadata and metaplex metadata program accounts as default. In case the destination program needs these accounts, it should add in together with other accounts it needs, the protocol shouldn't infer that the destination program needs them.