### PR TITLE
fix: move the flow slot to the token manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,7 +4072,6 @@ dependencies = [
  "axelar-solana-encoding",
  "axelar-solana-gateway",
  "axelar-solana-its",
- "bincode",
  "borsh 1.5.7",
  "interchain-token-transfer-gmp",
  "solana-client",

--- a/helpers/its-instruction-builder/Cargo.toml
+++ b/helpers/its-instruction-builder/Cargo.toml
@@ -14,7 +14,6 @@ axelar-solana-gateway.workspace = true
 async-recursion.workspace = true
 axelar-solana-encoding.workspace = true
 axelar-solana-its = { workspace = true, features = ["no-entrypoint"] }
-bincode.workspace = true
 borsh.workspace = true
 interchain-token-transfer-gmp.workspace = true
 solana-client.workspace = true

--- a/helpers/its-instruction-builder/src/lib.rs
+++ b/helpers/its-instruction-builder/src/lib.rs
@@ -9,11 +9,9 @@ use axelar_solana_its::state::token_manager::TokenManager;
 use borsh::BorshDeserialize;
 use interchain_token_transfer_gmp::GMPPayload;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::clock::Clock;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::program_error::ProgramError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::sysvar::clock;
 
 /// Creates a [`InterchainTokenServiceInstruction::ItsGmpPayload`] instruction.
 ///
@@ -41,14 +39,6 @@ where
             .map_err(|_err| ProgramError::InvalidArgument)?,
     );
 
-    let clock_account = rpc_client
-        .get_account(&clock::id())
-        .await
-        .map_err(|_err| ProgramError::InvalidAccountData)?;
-    let clock: Clock = bincode::deserialize(&clock_account.data)
-        .map_err(|_err| ProgramError::InvalidAccountData)?;
-    let timestamp = clock.unix_timestamp;
-
     let (mint, token_program) =
         try_infer_mint_and_program(&token_manager_pda, &payload, rpc_client).await?;
 
@@ -60,7 +50,6 @@ where
         .payload(payload)
         .token_program(token_program)
         .mint_opt(mint)
-        .timestamp(timestamp)
         .build();
 
     axelar_solana_its::instruction::its_gmp_payload(inputs)

--- a/programs/axelar-solana-its/src/lib.rs
+++ b/programs/axelar-solana-its/src/lib.rs
@@ -398,55 +398,6 @@ pub fn create_flow_slot_pda(
     )?)
 }
 
-/// Derives the PDA for a `FlowSlot`.
-#[inline]
-#[must_use]
-pub fn find_flow_slot_pda(token_manager_pda: &Pubkey, epoch: u64) -> (Pubkey, u8) {
-    Pubkey::find_program_address(
-        &[
-            seed_prefixes::FLOW_SLOT_SEED,
-            token_manager_pda.as_ref(),
-            &epoch.to_ne_bytes(),
-        ],
-        &crate::id(),
-    )
-}
-
-/// Tries to create the PDA for a `FlowSlot` using the provided bump,
-/// falling back to `find_program_address` if the bump is `None` or invalid.
-///
-/// # Errors
-///
-/// If the bump is invalid.
-pub fn flow_slot_pda(
-    token_manager_pda: &Pubkey,
-    epoch: u64,
-    maybe_bump: Option<u8>,
-) -> Result<(Pubkey, u8), ProgramError> {
-    if let Some(bump) = maybe_bump {
-        create_flow_slot_pda(token_manager_pda, epoch, bump).map(|pubkey| (pubkey, bump))
-    } else {
-        Ok(find_flow_slot_pda(token_manager_pda, epoch))
-    }
-}
-
-pub(crate) fn assert_valid_flow_slot_pda(
-    flow_slot_pda_account: &AccountInfo<'_>,
-    token_manager_pda: &Pubkey,
-    current_flow_epoch: u64,
-    canonical_bump: u8,
-) -> ProgramResult {
-    let expected_flow_slot_pda =
-        create_flow_slot_pda(token_manager_pda, current_flow_epoch, canonical_bump)?;
-
-    if expected_flow_slot_pda.ne(flow_slot_pda_account.key) {
-        msg!("Invalid flow limit slot PDA provided");
-        return Err(ProgramError::InvalidArgument);
-    }
-
-    Ok(())
-}
-
 /// Tries to create the PDA for a `DeploymentApproval` using the provided bump,
 /// falling back to `find_program_address` if the bump is invalid.
 ///

--- a/programs/axelar-solana-its/src/processor/gmp.rs
+++ b/programs/axelar-solana-its/src/processor/gmp.rs
@@ -6,13 +6,11 @@ use interchain_token_transfer_gmp::{GMPPayload, SendToHub};
 use itertools::{self, Itertools};
 use program_utils::{pda::BorshPda, validate_system_account_key};
 use solana_program::account_info::{next_account_info, AccountInfo};
-use solana_program::clock::Clock;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
 use solana_program::program::invoke;
 use solana_program::program::invoke_signed;
 use solana_program::program_error::ProgramError;
-use solana_program::sysvar::Sysvar;
 
 use crate::processor::interchain_token::{self, DeployInterchainTokenAccounts};
 use crate::processor::interchain_transfer::process_inbound_transfer;
@@ -279,12 +277,8 @@ fn validate_its_accounts(accounts: &[AccountInfo<'_>], payload: &GMPPayload) -> 
         .map(|account| *account.key)
         .ok_or(ProgramError::InvalidAccountData)?;
 
-    let derived_its_accounts = instruction::derive_its_accounts(
-        payload,
-        token_program,
-        maybe_mint,
-        Some(Clock::get()?.unix_timestamp),
-    )?;
+    let derived_its_accounts =
+        instruction::derive_its_accounts(payload, token_program, maybe_mint)?;
 
     for element in accounts.iter().zip_longest(derived_its_accounts.iter()) {
         match element {

--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -40,7 +40,7 @@ pub(crate) fn set_flow_limit(
     )?;
 
     let mut token_manager = TokenManager::load(accounts.token_manager_pda)?;
-    token_manager.flow_limit = flow_limit;
+    token_manager.flow_slot.flow_limit = flow_limit;
     token_manager.store(
         accounts.flow_limiter,
         accounts.token_manager_pda,

--- a/programs/axelar-solana-its/src/state/flow_limit.rs
+++ b/programs/axelar-solana-its/src/state/flow_limit.rs
@@ -1,8 +1,6 @@
 //! Module with data structure definition for handling flow limits on interchain
 //! tokens.
 
-use core::any::type_name;
-use core::mem::size_of;
 use core::time::Duration;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -11,26 +9,27 @@ use solana_program::clock::Clock;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
 use solana_program::program_error::ProgramError;
-use solana_program::program_pack::{Pack, Sealed};
 use solana_program::sysvar::Sysvar;
 
 const EPOCH_TIME: Duration = Duration::from_secs(6 * 60 * 60);
 
 #[derive(Debug, Eq, PartialEq, Clone, BorshSerialize, BorshDeserialize)]
 /// Struct containing flow information for a specific epoch.
-pub struct FlowSlot {
+pub struct FlowState {
+    pub flow_limit: u64,
     pub flow_in: u64,
     pub flow_out: u64,
-    pub bump: u8,
+    pub epoch: u64,
 }
 
 /// Module for handling flow limits on interchain tokens.
-impl FlowSlot {
-    pub(crate) fn new(bump: u8) -> Self {
+impl FlowState {
+    pub(crate) const fn new(flow_limit: u64, epoch: u64) -> Self {
         Self {
             flow_in: 0,
             flow_out: 0,
-            bump,
+            epoch,
+            flow_limit,
         }
     }
 
@@ -92,29 +91,7 @@ impl FlowSlot {
     }
 }
 
-impl Pack for FlowSlot {
-    const LEN: usize = 2 * size_of::<u64>() + size_of::<u8>();
-
-    #[allow(clippy::unwrap_used)]
-    fn pack_into_slice(&self, mut dst: &mut [u8]) {
-        self.serialize(&mut dst).unwrap();
-    }
-
-    fn unpack_from_slice(src: &[u8]) -> Result<Self, solana_program::program_error::ProgramError> {
-        let mut mut_src: &[u8] = src;
-        Self::deserialize(&mut mut_src).map_err(|err| {
-            msg!(
-                "Error: failed to deserialize account as {}: {}",
-                type_name::<Self>(),
-                err
-            );
-            ProgramError::InvalidAccountData
-        })
-    }
-}
-
-impl Sealed for FlowSlot {}
-impl BorshPda for FlowSlot {}
+impl BorshPda for FlowState {}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum FlowDirection {
@@ -122,7 +99,7 @@ pub(crate) enum FlowDirection {
     Out,
 }
 
-pub(crate) fn current_flow_epoch() -> Result<u64, ProgramError> {
+pub fn current_flow_epoch() -> Result<u64, ProgramError> {
     flow_epoch_with_timestamp(Clock::get()?.unix_timestamp)
 }
 
@@ -151,7 +128,7 @@ mod tests {
         let expected_flow_in = 0;
         let expected_flow_out = 0;
 
-        let slot = FlowSlot::new(0);
+        let slot = FlowState::new(0, 0);
         assert_eq!(slot.flow_in, expected_flow_in);
         assert_eq!(slot.flow_out, expected_flow_out);
     }
@@ -160,7 +137,7 @@ mod tests {
     fn test_add_flow_in_valid() {
         // Test adding flow_in within limits
         let flow_limit = 100;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, 20, FlowDirection::In).unwrap();
         slot.add_flow(flow_limit, 30, FlowDirection::Out).unwrap();
         let amount = 40;
@@ -174,7 +151,7 @@ mod tests {
     fn test_add_flow_in_exceeds_limit() {
         // Test adding flow_in that exceeds limit should fail
         let flow_limit = 100;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, 80, FlowDirection::In).unwrap();
         let amount = 30; // This would make flow_in 110, exceeding the limit
 
@@ -187,7 +164,7 @@ mod tests {
     fn test_add_flow_out_valid() {
         // Test adding flow_out within limits
         let flow_limit = 100;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, 30, FlowDirection::In).unwrap();
         slot.add_flow(flow_limit, 20, FlowDirection::Out).unwrap();
         let amount = 50;
@@ -201,7 +178,7 @@ mod tests {
     fn test_add_flow_out_exceeds_limit() {
         // Test adding flow_out that exceeds limit should fail
         let flow_limit = 100;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, 90, FlowDirection::Out).unwrap();
         let amount = 20; // This would make flow_out 110, exceeding the limit
 
@@ -214,7 +191,7 @@ mod tests {
     fn test_add_flow_in_overflow() {
         // Test arithmetic overflow in add_flow_in
         let flow_limit = u64::MAX;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, u64::MAX - 10, FlowDirection::In)
             .unwrap();
         let amount = 20;
@@ -229,7 +206,7 @@ mod tests {
     fn test_add_flow_out_overflow() {
         // Test arithmetic overflow in add_flow_out
         let flow_limit = u64::MAX;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, u64::MAX - 10, FlowDirection::Out)
             .unwrap();
         let amount = 20;
@@ -244,7 +221,7 @@ mod tests {
     fn test_add_flow_zero_flow_limit() {
         // Test behavior when flow_limit is zero in add_flow methods
         let flow_limit = 0;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
 
         let result_in = slot.add_flow(flow_limit, 10, FlowDirection::In);
         let result_out = slot.add_flow(flow_limit, 10, FlowDirection::Out);
@@ -261,7 +238,7 @@ mod tests {
     fn test_add_flow_amount_exceeds_flow_limit() {
         // Test when amount exceeds flow_limit in add_flow methods
         let flow_limit = 50;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         let amount = 60; // Exceeds flow_limit
 
         let result_in = slot.add_flow(flow_limit, amount, FlowDirection::In);
@@ -277,7 +254,7 @@ mod tests {
     fn test_add_flow_new_total_exceeds_max_allowed_flow() {
         // Test when new_total exceeds max_allowed_flow in add_flow methods
         let flow_limit = 100;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, 80, FlowDirection::In).unwrap();
         slot.add_flow(flow_limit, 50, FlowDirection::Out).unwrap();
         let amount = 80; // This would make flow_in 160, which exceeds max_allowed_flow (flow_out +
@@ -293,7 +270,7 @@ mod tests {
     fn test_add_flow_new_total_exceeds_max_allowed_flow_over_multiple_updates() {
         // Test when new_total exceeds max_allowed_flow in add_flow methods
         let flow_limit = 100;
-        let mut slot = FlowSlot::new(0);
+        let mut slot = FlowState::new(flow_limit, 0);
         slot.add_flow(flow_limit, 80, FlowDirection::In).unwrap();
         slot.add_flow(flow_limit, 50, FlowDirection::Out).unwrap();
         let amount = 20; // This would make flow_in 100, which does not exceed max_allowed_flow (flow_out
@@ -319,7 +296,7 @@ mod tests {
         let amount = 50;
 
         // Test incoming transfer initialization
-        let mut slot_in = FlowSlot::new(0);
+        let mut slot_in = FlowState::new(flow_limit, 0);
         slot_in
             .add_flow(flow_limit, amount, FlowDirection::In)
             .unwrap();
@@ -327,7 +304,7 @@ mod tests {
         assert_eq!(slot_in.flow_out, 0);
 
         // Test outgoing transfer initialization
-        let mut slot_out = FlowSlot::new(0);
+        let mut slot_out = FlowState::new(flow_limit, 0);
         slot_out
             .add_flow(flow_limit, amount, FlowDirection::Out)
             .unwrap();

--- a/programs/axelar-solana-its/tests/module/fee_handling.rs
+++ b/programs/axelar-solana-its/tests/module/fee_handling.rs
@@ -121,7 +121,6 @@ async fn test_canonical_token_with_fee_lock_unlock(ctx: &mut ItsTestContext) -> 
 
     // Test transfer
     let transfer_amount = 1000_u64;
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         user_ata,
@@ -132,7 +131,6 @@ async fn test_canonical_token_with_fee_lock_unlock(ctx: &mut ItsTestContext) -> 
         canonical_mint,
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     let transfer_tx = ctx.send_solana_tx(&[transfer_ix]).await.unwrap();
@@ -146,6 +144,7 @@ async fn test_canonical_token_with_fee_lock_unlock(ctx: &mut ItsTestContext) -> 
         .unwrap();
     let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data.data).unwrap();
     let fee_config = mint_state.get_extension::<TransferFeeConfig>().unwrap();
+    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let epoch = clock_sysvar.epoch;
     let fee = fee_config
         .calculate_epoch_fee(epoch, transfer_amount)
@@ -263,7 +262,6 @@ async fn test_canonical_token_various_fee_configs(ctx: &mut ItsTestContext) -> a
 
     // Test transfer
     let transfer_amount = 10_000_u64;
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         user_ata,
@@ -274,7 +272,6 @@ async fn test_canonical_token_various_fee_configs(ctx: &mut ItsTestContext) -> a
         canonical_mint,
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     let transfer_tx = ctx.send_solana_tx(&[transfer_ix]).await.unwrap();
@@ -288,6 +285,7 @@ async fn test_canonical_token_various_fee_configs(ctx: &mut ItsTestContext) -> a
         .unwrap();
     let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data.data).unwrap();
     let fee_config = mint_state.get_extension::<TransferFeeConfig>().unwrap();
+    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let epoch = clock_sysvar.epoch;
     let fee = fee_config
         .calculate_epoch_fee(epoch, transfer_amount)
@@ -402,7 +400,6 @@ async fn test_canonical_token_maximum_fee_cap(ctx: &mut ItsTestContext) -> anyho
         .unwrap();
 
     // Test transfer
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         user_ata,
@@ -413,7 +410,6 @@ async fn test_canonical_token_maximum_fee_cap(ctx: &mut ItsTestContext) -> anyho
         canonical_mint,
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     let transfer_tx = ctx.send_solana_tx(&[transfer_ix]).await.unwrap();
@@ -427,6 +423,7 @@ async fn test_canonical_token_maximum_fee_cap(ctx: &mut ItsTestContext) -> anyho
         .unwrap();
     let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data.data).unwrap();
     let fee_config = mint_state.get_extension::<TransferFeeConfig>().unwrap();
+    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let epoch = clock_sysvar.epoch;
     let fee = fee_config.calculate_epoch_fee(epoch, large_amount).unwrap();
 
@@ -626,7 +623,6 @@ async fn test_custom_token_with_fee_lock_unlock_fee(
 
     // Outbound transfer
     let transfer_amount = 3000_u64;
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         user_ata,
@@ -637,7 +633,6 @@ async fn test_custom_token_with_fee_lock_unlock_fee(
         solana_custom_token,
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     let outbound_tx = ctx.send_solana_tx(&[transfer_ix]).await.unwrap();
@@ -651,6 +646,7 @@ async fn test_custom_token_with_fee_lock_unlock_fee(
         .unwrap();
     let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data.data).unwrap();
     let fee_config = mint_state.get_extension::<TransferFeeConfig>().unwrap();
+    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let epoch = clock_sysvar.epoch;
     let outbound_fee = fee_config
         .calculate_epoch_fee(epoch, transfer_amount)

--- a/programs/axelar-solana-its/tests/module/main.rs
+++ b/programs/axelar-solana-its/tests/module/main.rs
@@ -39,7 +39,6 @@ use solana_program_test::BanksTransactionResultWithMetadata;
 use solana_sdk::account::Account;
 use solana_sdk::account_info::Account as AccountTrait;
 use solana_sdk::account_info::IntoAccountInfo;
-use solana_sdk::clock::Clock;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::program_error::ProgramError;
 use solana_sdk::program_pack::Pack as _;
@@ -179,8 +178,6 @@ impl ItsTestContext {
             .unwrap()
             .clone();
 
-        let clock_sysvar = self.solana_chain.get_sysvar::<Clock>().await;
-
         let its_ix_inputs = ItsGmpInstructionInputs::builder()
             .payer(self.solana_chain.fixture.payer.pubkey())
             .incoming_message_pda(incoming_message_pda)
@@ -188,7 +185,6 @@ impl ItsTestContext {
             .message(merkelised_message.leaf.message)
             .payload(payload)
             .token_program(token_program)
-            .timestamp(clock_sysvar.unix_timestamp)
             .mint_opt(maybe_mint)
             .build();
 
@@ -352,7 +348,6 @@ impl ItsTestContext {
     ) {
         let amount = 100;
 
-        let clock_sysvar = self.solana_chain.get_sysvar::<Clock>().await;
         let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
             self.solana_wallet,
             token_account,
@@ -363,7 +358,6 @@ impl ItsTestContext {
             solana_token,
             spl_token_2022::id(),
             0,
-            clock_sysvar.unix_timestamp,
         )
         .unwrap();
 

--- a/programs/axelar-solana-its/tests/module/pause_unpause.rs
+++ b/programs/axelar-solana-its/tests/module/pause_unpause.rs
@@ -1,6 +1,6 @@
 use borsh::BorshDeserialize;
 use solana_program_test::tokio;
-use solana_sdk::{clock::Clock, pubkey::Pubkey, signer::Signer};
+use solana_sdk::{pubkey::Pubkey, signer::Signer};
 use spl_associated_token_account::{
     get_associated_token_address_with_program_id, instruction::create_associated_token_account,
 };
@@ -112,7 +112,6 @@ async fn test_outbound_message_fails_when_paused(ctx: &mut ItsTestContext) {
         &token_address,
         &spl_token_2022::id(),
     );
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
         ctx.deployed_interchain_token,
         token_address,
@@ -132,7 +131,6 @@ async fn test_outbound_message_fails_when_paused(ctx: &mut ItsTestContext) {
         token_address,
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )
     .unwrap();
 

--- a/programs/axelar-solana-its/tests/module/token_id_validation.rs
+++ b/programs/axelar-solana-its/tests/module/token_id_validation.rs
@@ -4,7 +4,6 @@ use mpl_token_metadata::accounts::Metadata;
 use mpl_token_metadata::instructions::CreateV1Builder;
 use mpl_token_metadata::types::TokenStandard;
 use solana_program_test::tokio;
-use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_associated_token_account::instruction::create_associated_token_account;
@@ -180,7 +179,6 @@ async fn test_valid_token_id_mint_matches_token_address(
 
     // This should succeed because the token_id corresponds to the correct mint
     let transfer_amount = 100;
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         token_account,
@@ -191,7 +189,6 @@ async fn test_valid_token_id_mint_matches_token_address(
         solana_token,
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     // This should succeed without errors
@@ -299,7 +296,6 @@ async fn test_invalid_token_id_mint_mismatch_rejected(
 
     // Now try to transfer using token_id_a but with mint B (this should fail after the fix)
     let transfer_amount = 100;
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let malicious_transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         token_account_a, // Using account A (which has tokens)
@@ -310,7 +306,6 @@ async fn test_invalid_token_id_mint_mismatch_rejected(
         solana_token_a, // With mint A (which doesn't match token_id_b's token_manager.token_address)
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     // This should fail with "Mint and token ID don't match" error
@@ -381,7 +376,6 @@ async fn test_lock_unlock_token_id_validation(ctx: &mut ItsTestContext) -> anyho
     // Try to transfer the worthless tokens using the legitimate token_id
     // This should fail because the mint doesn't match the token_manager's token_address
     let transfer_amount = 100;
-    let clock_sysvar = ctx.solana_chain.get_sysvar::<Clock>().await;
     let malicious_transfer_ix = axelar_solana_its::instruction::interchain_transfer(
         ctx.solana_wallet,
         worthless_token_account, // Using worthless tokens
@@ -392,7 +386,6 @@ async fn test_lock_unlock_token_id_validation(ctx: &mut ItsTestContext) -> anyho
         worthless_token, // Worthless mint (mismatch!)
         spl_token_2022::id(),
         0,
-        clock_sysvar.unix_timestamp,
     )?;
 
     // This should fail with the validation error


### PR DESCRIPTION
Move the flow slot to the token manager, rename it to `FlowState`. This effectively removes the need for flow slot PDAs.

Add a test for epoch changes.