### PR TITLE
fix(its): assert valid ITS config account

### DIFF
--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -465,6 +465,9 @@ impl<'a> FromAccountInfoSlice<'a> for SetFlowLimitAccounts<'a> {
 impl Validate for SetFlowLimitAccounts<'_> {
     fn validate(&self) -> Result<(), ProgramError> {
         validate_system_account_key(self.system_account.key)?;
+
+        let its_config_account = InterchainTokenService::load(self.its_root_pda)?;
+        assert_valid_its_root_pda(self.its_root_pda, its_config_account.bump)?;
         Ok(())
     }
 }


### PR DESCRIPTION
H1 and M3 have already been mostly fixed. The initial vulnerabilities were fixed (see last Ackee report). There were only some leftover improvements/simplifications suggested. These simplifications were implemented in e5424f86.
As for the additional notes: Adding operator role to ITS on the `TokenManager`, even though it's not used, follows the ref. implementation and I believe we should keep it that way.

 This patch basically adds the missing check on the ITS root pda, which is the last of the additional notes.