### PR TITLE
fix(its)!: flow limit unwanted failure

### DIFF
--- a/helpers/program-utils/src/pda.rs
+++ b/helpers/program-utils/src/pda.rs
@@ -287,10 +287,12 @@ where
             let lamports_needed = Rent::get()?.minimum_balance(serialized_data.len());
             let lamports_diff = lamports_needed.saturating_sub(destination.lamports());
 
-            invoke(
-                &system_instruction::transfer(payer.key, destination.key, lamports_diff),
-                &[payer.clone(), destination.clone(), system_program.clone()],
-            )?;
+            if lamports_diff > 0 {
+                invoke(
+                    &system_instruction::transfer(payer.key, destination.key, lamports_diff),
+                    &[payer.clone(), destination.clone(), system_program.clone()],
+                )?;
+            }
         }
 
         destination.realloc(serialized_data.len(), false)?;

--- a/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
+++ b/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
@@ -488,7 +488,7 @@ async fn test_verify_all_signatures_when_session_pda_has_lamports() {
         .send_tx(&[system_instruction::transfer(
             &payer,
             &verification_session_pda,
-            100000000000,
+            100_000_000_000,
         )])
         .await
         .unwrap();

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -432,7 +432,7 @@ pub enum InterchainTokenServiceInstruction {
     /// 4. [writable] The account holding the roles of the payer on the `TokenManager`
     SetFlowLimit {
         /// The new flow limit.
-        flow_limit: u64,
+        flow_limit: Option<u64>,
     },
 
     /// Transfers operatorship to another account.
@@ -506,7 +506,7 @@ pub enum InterchainTokenServiceInstruction {
     /// 4. [] The PDA account with the user roles on ITS.
     SetTokenManagerFlowLimit {
         /// The new flow limit.
-        flow_limit: u64,
+        flow_limit: Option<u64>,
     },
 
     /// Transfers operatorship to another account.
@@ -1472,7 +1472,7 @@ pub fn call_contract_with_interchain_token(
 pub fn set_flow_limit(
     payer: Pubkey,
     token_id: [u8; 32],
-    flow_limit: u64,
+    flow_limit: Option<u64>,
 ) -> Result<Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
@@ -1484,7 +1484,7 @@ pub fn set_flow_limit(
 
     let data = to_vec(&InterchainTokenServiceInstruction::SetFlowLimit { flow_limit })?;
     let accounts = vec![
-        AccountMeta::new_readonly(payer, true),
+        AccountMeta::new(payer, true),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(token_manager_pda, false),
         AccountMeta::new_readonly(its_user_roles_pda, false),

--- a/programs/axelar-solana-its/src/instruction/token_manager.rs
+++ b/programs/axelar-solana-its/src/instruction/token_manager.rs
@@ -17,7 +17,7 @@ use super::InterchainTokenServiceInstruction;
 pub fn set_flow_limit(
     payer: Pubkey,
     token_id: [u8; 32],
-    flow_limit: u64,
+    flow_limit: Option<u64>,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
@@ -29,7 +29,7 @@ pub fn set_flow_limit(
     let data = to_vec(&InterchainTokenServiceInstruction::SetTokenManagerFlowLimit { flow_limit })?;
 
     let accounts = vec![
-        AccountMeta::new_readonly(payer, true),
+        AccountMeta::new(payer, true),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(token_manager_pda, false),
         AccountMeta::new_readonly(token_manager_user_roles_pda, false),

--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -355,9 +355,10 @@ fn track_token_flow(
 ) -> ProgramResult {
     let mut token_manager = TokenManager::load(accounts.token_manager_pda)?;
 
-    if token_manager.flow_slot.flow_limit == 0 {
+    if token_manager.flow_slot.flow_limit.is_none() {
         return Ok(());
     }
+
     // Reset the flow slot upon epoch change.
     let current_epoch = crate::state::flow_limit::current_flow_epoch()?;
     if token_manager.flow_slot.epoch != current_epoch {

--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -350,16 +350,14 @@ fn give_token(
 
 fn track_token_flow(
     accounts: &FlowTrackingAccounts<'_>,
-    flow_limit: u64,
     amount: u64,
     direction: FlowDirection,
 ) -> ProgramResult {
-    if flow_limit == 0 {
-        return Ok(());
-    }
-
     let mut token_manager = TokenManager::load(accounts.token_manager_pda)?;
 
+    if token_manager.flow_slot.flow_limit == 0 {
+        return Ok(());
+    }
     // Reset the flow slot upon epoch change.
     let current_epoch = crate::state::flow_limit::current_flow_epoch()?;
     if token_manager.flow_slot.epoch != current_epoch {
@@ -369,9 +367,7 @@ fn track_token_flow(
         token_manager.flow_slot.epoch = current_epoch;
     }
 
-    token_manager
-        .flow_slot
-        .add_flow(flow_limit, amount, direction)?;
+    token_manager.flow_slot.add_flow(amount, direction)?;
     token_manager.store(
         accounts.payer,
         accounts.token_manager_pda,
@@ -390,12 +386,7 @@ fn handle_give_token_transfer(
         LockUnlock, LockUnlockFee, MintBurn, MintBurnFrom, NativeInterchainToken,
     };
 
-    track_token_flow(
-        &accounts.into(),
-        token_manager.flow_slot.flow_limit,
-        amount,
-        FlowDirection::In,
-    )?;
+    track_token_flow(&accounts.into(), amount, FlowDirection::In)?;
     let token_id = token_manager.token_id;
     let token_manager_pda_bump = token_manager.bump;
 
@@ -454,12 +445,7 @@ fn handle_take_token_transfer(
         LockUnlock, LockUnlockFee, MintBurn, MintBurnFrom, NativeInterchainToken,
     };
 
-    track_token_flow(
-        &accounts.into(),
-        token_manager.flow_slot.flow_limit,
-        amount,
-        FlowDirection::Out,
-    )?;
+    track_token_flow(&accounts.into(), amount, FlowDirection::Out)?;
 
     let transferred = match token_manager.ty {
         NativeInterchainToken | MintBurn | MintBurnFrom => {

--- a/programs/axelar-solana-its/src/processor/mod.rs
+++ b/programs/axelar-solana-its/src/processor/mod.rs
@@ -182,19 +182,18 @@ pub fn process_instruction<'a>(
             signing_pda_bump,
         ),
         InterchainTokenServiceInstruction::SetFlowLimit { flow_limit } => {
-            let mut instruction_accounts =
-                SetFlowLimitAccounts::from_account_info_slice(accounts, &())?;
+            let instruction_accounts =
+                SetFlowLimitAccounts::from_account_info_slice(accounts, &true)?;
 
             msg!("Instruction: SetFlowLimit");
             ensure_signer_roles(
                 &crate::id(),
                 instruction_accounts.its_root_pda,
-                instruction_accounts.flow_limiter,
+                instruction_accounts.payer,
                 instruction_accounts.its_user_roles_pda,
                 Roles::OPERATOR,
             )?;
 
-            instruction_accounts.flow_limiter = instruction_accounts.its_root_pda;
             token_manager::set_flow_limit(&instruction_accounts, flow_limit)
         }
         InterchainTokenServiceInstruction::TransferOperatorship => {

--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -399,9 +399,9 @@ impl Validate for DeployTokenManagerAccounts<'_> {
         validate_spl_associated_token_account_key(self.ata_program.key)?;
         validate_rent_key(self.rent_sysvar.key)?;
         if &get_associated_token_address_with_program_id(
-            &self.token_manager_pda.key,
-            &self.token_mint.key,
-            &self.token_program.key,
+            self.token_manager_pda.key,
+            self.token_mint.key,
+            self.token_program.key,
         ) != self.token_manager_ata.key
         {
             msg!("Wrong ata account key");

--- a/programs/axelar-solana-its/src/state/flow_limit.rs
+++ b/programs/axelar-solana-its/src/state/flow_limit.rs
@@ -16,7 +16,7 @@ const EPOCH_TIME: Duration = Duration::from_secs(6 * 60 * 60);
 #[derive(Debug, Eq, PartialEq, Clone, BorshSerialize, BorshDeserialize)]
 /// Struct containing flow information for a specific epoch.
 pub struct FlowState {
-    pub flow_limit: u64,
+    pub flow_limit: Option<u64>,
     pub flow_in: u64,
     pub flow_out: u64,
     pub epoch: u64,
@@ -24,7 +24,7 @@ pub struct FlowState {
 
 /// Module for handling flow limits on interchain tokens.
 impl FlowState {
-    pub(crate) const fn new(flow_limit: u64, epoch: u64) -> Self {
+    pub(crate) const fn new(flow_limit: Option<u64>, epoch: u64) -> Self {
         Self {
             flow_in: 0,
             flow_out: 0,
@@ -34,16 +34,16 @@ impl FlowState {
     }
 
     pub(crate) fn add_flow(&mut self, amount: u64, direction: FlowDirection) -> ProgramResult {
-        if self.flow_limit == 0 {
+        let Some(flow_limit) = self.flow_limit else {
             return Ok(());
-        }
+        };
 
         let (to_add, to_compare) = match direction {
             FlowDirection::In => (&mut self.flow_in, self.flow_out),
             FlowDirection::Out => (&mut self.flow_out, self.flow_in),
         };
 
-        Self::update_flow(self.flow_limit, to_add, to_compare, amount)
+        Self::update_flow(flow_limit, to_add, to_compare, amount)
     }
 
     fn update_flow(
@@ -121,7 +121,7 @@ mod tests {
         let expected_flow_in = 0;
         let expected_flow_out = 0;
 
-        let slot = FlowState::new(0, 0);
+        let slot = FlowState::new(Some(0), 0);
         assert_eq!(slot.flow_in, expected_flow_in);
         assert_eq!(slot.flow_out, expected_flow_out);
     }
@@ -130,7 +130,7 @@ mod tests {
     fn test_add_flow_in_valid() {
         // Test adding flow_in within limits
         let flow_limit = 100;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(20, FlowDirection::In).unwrap();
         slot.add_flow(30, FlowDirection::Out).unwrap();
         let amount = 40;
@@ -144,7 +144,7 @@ mod tests {
     fn test_add_flow_in_exceeds_limit() {
         // Test adding flow_in that exceeds limit should fail
         let flow_limit = 100;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(80, FlowDirection::In).unwrap();
         let amount = 30; // This would make flow_in 110, exceeding the limit
 
@@ -157,7 +157,7 @@ mod tests {
     fn test_add_flow_out_valid() {
         // Test adding flow_out within limits
         let flow_limit = 100;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(30, FlowDirection::In).unwrap();
         slot.add_flow(20, FlowDirection::Out).unwrap();
         let amount = 50;
@@ -171,7 +171,7 @@ mod tests {
     fn test_add_flow_out_exceeds_limit() {
         // Test adding flow_out that exceeds limit should fail
         let flow_limit = 100;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(90, FlowDirection::Out).unwrap();
         let amount = 20; // This would make flow_out 110, exceeding the limit
 
@@ -184,7 +184,7 @@ mod tests {
     fn test_add_flow_in_overflow() {
         // Test arithmetic overflow in add_flow_in
         let flow_limit = u64::MAX;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(u64::MAX - 10, FlowDirection::In).unwrap();
         let amount = 20;
 
@@ -198,7 +198,7 @@ mod tests {
     fn test_add_flow_out_overflow() {
         // Test arithmetic overflow in add_flow_out
         let flow_limit = u64::MAX;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(u64::MAX - 10, FlowDirection::Out).unwrap();
         let amount = 20;
 
@@ -212,24 +212,20 @@ mod tests {
     fn test_add_flow_zero_flow_limit() {
         // Test behavior when flow_limit is zero in add_flow methods
         let flow_limit = 0;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
 
-        let result_in = slot.add_flow(10, FlowDirection::In);
-        let result_out = slot.add_flow(10, FlowDirection::Out);
+        let result_in = slot.add_flow(1, FlowDirection::In);
+        let result_out = slot.add_flow(1, FlowDirection::Out);
 
-        // Since flow_limit is zero, the methods should return Ok without modifying
-        // flow_in or flow_out
-        assert!(result_in.is_ok());
-        assert!(result_out.is_ok());
-        assert_eq!(slot.flow_in, 0);
-        assert_eq!(slot.flow_out, 0);
+        assert!(result_in.is_err());
+        assert!(result_out.is_err());
     }
 
     #[test]
     fn test_add_flow_amount_exceeds_flow_limit() {
         // Test when amount exceeds flow_limit in add_flow methods
         let flow_limit = 50;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         let amount = 60; // Exceeds flow_limit
 
         let result_in = slot.add_flow(amount, FlowDirection::In);
@@ -245,7 +241,7 @@ mod tests {
     fn test_add_flow_new_total_exceeds_max_allowed_flow() {
         // Test when new_total exceeds max_allowed_flow in add_flow methods
         let flow_limit = 100;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(80, FlowDirection::In).unwrap();
         slot.add_flow(50, FlowDirection::Out).unwrap();
         let amount = 80; // This would make flow_in 160, which exceeds max_allowed_flow (flow_out +
@@ -261,7 +257,7 @@ mod tests {
     fn test_add_flow_new_total_exceeds_max_allowed_flow_over_multiple_updates() {
         // Test when new_total exceeds max_allowed_flow in add_flow methods
         let flow_limit = 100;
-        let mut slot = FlowState::new(flow_limit, 0);
+        let mut slot = FlowState::new(Some(flow_limit), 0);
         slot.add_flow(80, FlowDirection::In).unwrap();
         slot.add_flow(50, FlowDirection::Out).unwrap();
         let amount = 20; // This would make flow_in 100, which does not exceed max_allowed_flow (flow_out
@@ -287,13 +283,13 @@ mod tests {
         let amount = 50;
 
         // Test incoming transfer initialization
-        let mut slot_in = FlowState::new(flow_limit, 0);
+        let mut slot_in = FlowState::new(Some(flow_limit), 0);
         slot_in.add_flow(amount, FlowDirection::In).unwrap();
         assert_eq!(slot_in.flow_in, amount);
         assert_eq!(slot_in.flow_out, 0);
 
         // Test outgoing transfer initialization
-        let mut slot_out = FlowState::new(flow_limit, 0);
+        let mut slot_out = FlowState::new(Some(flow_limit), 0);
         slot_out.add_flow(amount, FlowDirection::Out).unwrap();
         assert_eq!(slot_out.flow_in, 0);
         assert_eq!(slot_out.flow_out, amount);

--- a/programs/axelar-solana-its/src/state/token_manager.rs
+++ b/programs/axelar-solana-its/src/state/token_manager.rs
@@ -171,7 +171,7 @@ impl TokenManager {
             token_id,
             token_address,
             associated_token_account,
-            flow_slot: FlowState::new(0, 0),
+            flow_slot: FlowState::new(None, 0),
             bump,
         }
     }

--- a/programs/axelar-solana-its/tests/module/flow_limits.rs
+++ b/programs/axelar-solana-its/tests/module/flow_limits.rs
@@ -36,7 +36,7 @@ async fn test_incoming_interchain_transfer_within_limit(
     let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
         ctx.solana_wallet,
         ctx.deployed_interchain_token,
-        flow_limit,
+        Some(flow_limit),
     )?;
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;
@@ -99,7 +99,7 @@ async fn test_incoming_interchain_transfer_beyond_limit(ctx: &mut ItsTestContext
     let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
         ctx.solana_wallet,
         ctx.deployed_interchain_token,
-        flow_limit,
+        Some(flow_limit),
     )
     .unwrap();
 
@@ -145,7 +145,7 @@ async fn test_flow_reset_upon_epoch_change(ctx: &mut ItsTestContext) {
     let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
         ctx.solana_wallet,
         ctx.deployed_interchain_token,
-        flow_limit,
+        Some(flow_limit),
     )
     .unwrap();
 
@@ -295,8 +295,11 @@ async fn test_outgoing_interchain_transfer_within_limit(
     let token_id = ctx.deployed_interchain_token;
     let flow_limit = 800;
 
-    let flow_limit_ix =
-        axelar_solana_its::instruction::set_flow_limit(ctx.solana_wallet, token_id, flow_limit)?;
+    let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
+        ctx.solana_wallet,
+        token_id,
+        Some(flow_limit),
+    )?;
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;
 
@@ -374,9 +377,12 @@ async fn test_outgoing_interchain_transfer_within_limit(
 async fn test_outgoing_interchain_transfer_outside_limit(ctx: &mut ItsTestContext) {
     let token_id = ctx.deployed_interchain_token;
     let flow_limit = 800;
-    let flow_limit_ix =
-        axelar_solana_its::instruction::set_flow_limit(ctx.solana_wallet, token_id, flow_limit)
-            .unwrap();
+    let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
+        ctx.solana_wallet,
+        token_id,
+        Some(flow_limit),
+    )
+    .unwrap();
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;
 
@@ -444,7 +450,7 @@ async fn test_flow_slot_initialization_incoming_transfer(
     let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
         ctx.solana_wallet,
         ctx.deployed_interchain_token,
-        flow_limit,
+        Some(flow_limit),
     )?;
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;
@@ -570,8 +576,11 @@ async fn test_flow_slot_initialization_outgoing_transfer(
     let transfer_amount = 300;
 
     // Set flow limit
-    let flow_limit_ix =
-        axelar_solana_its::instruction::set_flow_limit(ctx.solana_wallet, token_id, flow_limit)?;
+    let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
+        ctx.solana_wallet,
+        token_id,
+        Some(flow_limit),
+    )?;
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;
 
@@ -716,7 +725,7 @@ async fn test_flow_limit_max_u64_no_overflow(ctx: &mut ItsTestContext) -> anyhow
     let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
         ctx.solana_wallet,
         ctx.deployed_interchain_token,
-        flow_limit,
+        Some(flow_limit),
     )?;
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;
@@ -804,7 +813,7 @@ async fn test_net_flow_calculation_bidirectional(ctx: &mut ItsTestContext) -> an
     let flow_limit_ix = axelar_solana_its::instruction::set_flow_limit(
         ctx.solana_wallet,
         ctx.deployed_interchain_token,
-        flow_limit,
+        Some(flow_limit),
     )?;
 
     ctx.send_solana_tx(&[flow_limit_ix]).await;


### PR DESCRIPTION
While here, remove `flow_limit` parameter from `add_flow`, since this information is already part of  the state.