### PR TITLE
fix(gateway): do not check PDA lamports

### DIFF
--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -67,10 +67,6 @@ impl Processor {
             solana_program::msg!("Error: verification session account is not writable");
             return Err(ProgramError::InvalidAccountData);
         }
-        if verification_session_account.lamports() != 0 {
-            solana_program::msg!("Error: verification session account is not initialized");
-            return Err(ProgramError::AccountAlreadyInitialized);
-        }
 
         // Check system program
         if !system_program::check_id(system_program.key) {


### PR DESCRIPTION
We should not allow the initialization of the session to be stopped by just transferring lamports to the session PDA.