### PR TITLE
fix: require verifier set hash during verification session initialization (C8)

### DIFF
--- a/bindings/anchor_lib/axelar-solana-gateway.rs
+++ b/bindings/anchor_lib/axelar-solana-gateway.rs
@@ -48,6 +48,7 @@ pub mod axelar_solana_gateway {
     pub fn initialize_payload_verification_session(
         ctx: Context<InitializePayloadVerificationSession>,
         payload_merkle_root: [u8; 32],
+        signing_verifier_set_hash: [u8; 32],
     ) -> Result<()> {
         Ok(())
     }

--- a/bindings/generated/axelar-solana-gateway/idl.json
+++ b/bindings/generated/axelar-solana-gateway/idl.json
@@ -238,6 +238,15 @@
               32
             ]
           }
+        },
+        {
+          "name": "signingVerifierSetHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
         }
       ]
     },

--- a/bindings/generated/axelar-solana-gateway/src/coder/accounts.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/accounts.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as B from "@native-to-anchor/buffer-layout";
-import { AccountsCoder, Idl } from "@project-serum/anchor";
-import { IdlTypeDef } from "@project-serum/anchor/dist/cjs/idl";
+import { AccountsCoder, Idl } from "@coral-xyz/anchor";
+import { IdlTypeDef } from "@coral-xyz/anchor/dist/cjs/idl";
 
 export class AxelarSolanaGatewayAccountsCoder<A extends string = string>
   implements AccountsCoder

--- a/bindings/generated/axelar-solana-gateway/src/coder/events.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/events.ts
@@ -1,5 +1,5 @@
-import { Idl, Event, EventCoder } from "@project-serum/anchor";
-import { IdlEvent } from "@project-serum/anchor/dist/cjs/idl";
+import { Idl, Event, EventCoder } from "@coral-xyz/anchor";
+import { IdlEvent } from "@coral-xyz/anchor/dist/cjs/idl";
 
 export class AxelarSolanaGatewayEventsCoder implements EventCoder {
   constructor(_idl: Idl) {}

--- a/bindings/generated/axelar-solana-gateway/src/coder/index.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/index.ts
@@ -1,4 +1,4 @@
-import { Idl, Coder } from "@project-serum/anchor";
+import { Idl, Coder } from "@coral-xyz/anchor";
 
 import { AxelarSolanaGatewayAccountsCoder } from "./accounts";
 import { AxelarSolanaGatewayEventsCoder } from "./events";

--- a/bindings/generated/axelar-solana-gateway/src/coder/instructions.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/instructions.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import * as B from "@native-to-anchor/buffer-layout";
-import { Idl, InstructionCoder } from "@project-serum/anchor";
+import { Idl, InstructionCoder } from "@coral-xyz/anchor";
 
 export class AxelarSolanaGatewayInstructionCoder implements InstructionCoder {
   constructor(_idl: Idl) {}
@@ -136,10 +136,16 @@ function encodeInitializeConfig({
 
 function encodeInitializePayloadVerificationSession({
   payloadMerkleRoot,
+  signingVerifierSetHash,
 }: any): Buffer {
   return encodeData(
-    { initializePayloadVerificationSession: { payloadMerkleRoot } },
-    1 + 1 * 32
+    {
+      initializePayloadVerificationSession: {
+        payloadMerkleRoot,
+        signingVerifierSetHash,
+      },
+    },
+    1 + 1 * 32 + 1 * 32
   );
 }
 
@@ -286,7 +292,10 @@ LAYOUT.addVariant(
 );
 LAYOUT.addVariant(
   4,
-  B.struct([B.seq(B.u8(), 32, "payloadMerkleRoot")]),
+  B.struct([
+    B.seq(B.u8(), 32, "payloadMerkleRoot"),
+    B.seq(B.u8(), 32, "signingVerifierSetHash"),
+  ]),
   "initializePayloadVerificationSession"
 );
 LAYOUT.addVariant(

--- a/bindings/generated/axelar-solana-gateway/src/coder/state.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/state.ts
@@ -1,4 +1,4 @@
-import { Idl, StateCoder } from "@project-serum/anchor";
+import { Idl, StateCoder } from "@coral-xyz/anchor";
 
 export class AxelarSolanaGatewayStateCoder implements StateCoder {
   constructor(_idl: Idl) {}

--- a/bindings/generated/axelar-solana-gateway/src/coder/types.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/types.ts
@@ -1,4 +1,4 @@
-import { Idl, TypesCoder } from "@project-serum/anchor";
+import { Idl, TypesCoder } from "@coral-xyz/anchor";
 
 export class AxelarSolanaGatewayTypesCoder implements TypesCoder {
   constructor(_idl: Idl) {}

--- a/bindings/generated/axelar-solana-gateway/src/program.ts
+++ b/bindings/generated/axelar-solana-gateway/src/program.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { Program, AnchorProvider } from "@project-serum/anchor";
+import { Program, AnchorProvider } from "@coral-xyz/anchor";
 
 import { AxelarSolanaGatewayCoder } from "./coder";
 
@@ -245,6 +245,12 @@ type AxelarSolanaGateway = {
       args: [
         {
           name: "payloadMerkleRoot";
+          type: {
+            array: ["u8", 32];
+          };
+        },
+        {
+          name: "signingVerifierSetHash";
           type: {
             array: ["u8", 32];
           };
@@ -1083,6 +1089,12 @@ const IDL: AxelarSolanaGateway = {
       args: [
         {
           name: "payloadMerkleRoot",
+          type: {
+            array: ["u8", 32],
+          },
+        },
+        {
+          name: "signingVerifierSetHash",
           type: {
             array: ["u8", 32],
           },

--- a/bindings/tests/gateway.ts
+++ b/bindings/tests/gateway.ts
@@ -133,7 +133,7 @@ describe("Ping Gateway", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods
-        .initializePayloadVerificationSession([1, 2])
+        .initializePayloadVerificationSession([1, 2], [3, 4])
         .accounts({
           payer: payer.publicKey,
           gatewayConfigPda: payer.publicKey,

--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -172,11 +172,11 @@ impl SolanaAxelarIntegrationMetadata {
 
         // Check that the PDA contains the expected data
         // Use the same derivation as the initialization to get the correct PDA
-        let payload_hash = construct_payload_hash::<NativeHasher>(
+        let combined_payload_hash = construct_payload_hash::<NativeHasher>(
             execute_data.payload_merkle_root,
             execute_data.signing_verifier_set_merkle_root,
         );
-        let (verification_pda, _bump) = get_signature_verification_pda(&payload_hash);
+        let (verification_pda, _bump) = get_signature_verification_pda(&combined_payload_hash);
         Ok(verification_pda)
     }
 

--- a/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/test_signer.rs
@@ -53,9 +53,15 @@ impl SigningVerifierSet {
     /// Get the verifier set tracket PDA and bump
     #[must_use]
     pub fn verifier_set_tracker(&self) -> (Pubkey, u8) {
-        let hash = verifier_set_hash::<NativeHasher>(&self.verifier_set(), &self.domain_separator)
-            .unwrap();
+        let hash = self.verifier_set_hash();
         axelar_solana_gateway::get_verifier_set_tracker_pda(hash)
+    }
+
+    /// Calculate the hash of this verifier set
+    #[must_use]
+    pub fn verifier_set_hash(&self) -> [u8; 32] {
+        verifier_set_hash::<NativeHasher>(&self.verifier_set(), &self.domain_separator)
+            .expect("hashing should not fail")
     }
 
     /// Transform into the verifier set that the gateway expects to operate on

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -400,10 +400,11 @@ pub fn initialize_payload_verification_session(
     payload_merkle_root: [u8; 32],
     signing_verifier_set_hash: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
-    let payload_hash =
+    let combined_payload_hash =
         construct_payload_hash::<NativeHasher>(payload_merkle_root, signing_verifier_set_hash);
 
-    let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_hash);
+    let (verification_session_pda, _) =
+        crate::get_signature_verification_pda(&combined_payload_hash);
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -437,10 +438,11 @@ pub fn verify_signature(
     signing_verifier_set_hash: [u8; 32],
     verifier_info: SigningVerifierSetInfo,
 ) -> Result<Instruction, ProgramError> {
-    let payload_hash =
+    let combined_payload_hash =
         construct_payload_hash::<NativeHasher>(payload_merkle_root, signing_verifier_set_hash);
 
-    let (verification_session_pda, _bump) = crate::get_signature_verification_pda(&payload_hash);
+    let (verification_session_pda, _bump) =
+        crate::get_signature_verification_pda(&combined_payload_hash);
 
     let accounts = vec![
         AccountMeta::new_readonly(gateway_config_pda, false),

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -2,8 +2,10 @@
 
 use core::fmt::Debug;
 
+use axelar_solana_encoding::hasher::NativeHasher;
 use axelar_solana_encoding::types::execute_data::{MerkleisedMessage, SigningVerifierSetInfo};
 use axelar_solana_encoding::types::messages::Message;
+use axelar_solana_encoding::types::verifier_set::construct_payload_hash;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use solana_program::bpf_loader_upgradeable;
 use solana_program::instruction::{AccountMeta, Instruction};
@@ -86,6 +88,8 @@ pub enum GatewayInstruction {
     InitializePayloadVerificationSession {
         /// The Merkle root for the Payload being verified.
         payload_merkle_root: [u8; 32],
+        /// Hash of the verifier set that should sign this payload
+        signing_verifier_set_hash: [u8; 32],
     },
 
     /// Verifies a signature within a Payload verification session
@@ -394,8 +398,12 @@ pub fn initialize_payload_verification_session(
     payer: Pubkey,
     gateway_config_pda: Pubkey,
     payload_merkle_root: [u8; 32],
+    signing_verifier_set_hash: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
-    let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_merkle_root);
+    let payload_hash =
+        construct_payload_hash::<NativeHasher>(payload_merkle_root, signing_verifier_set_hash);
+
+    let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_hash);
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -406,6 +414,7 @@ pub fn initialize_payload_verification_session(
 
     let data = to_vec(&GatewayInstruction::InitializePayloadVerificationSession {
         payload_merkle_root,
+        signing_verifier_set_hash,
     })?;
 
     Ok(Instruction {
@@ -425,10 +434,13 @@ pub fn verify_signature(
     gateway_config_pda: Pubkey,
     verifier_set_tracker_pda: Pubkey,
     payload_merkle_root: [u8; 32],
+    signing_verifier_set_hash: [u8; 32],
     verifier_info: SigningVerifierSetInfo,
 ) -> Result<Instruction, ProgramError> {
-    let (verification_session_pda, _bump) =
-        crate::get_signature_verification_pda(&payload_merkle_root);
+    let payload_hash =
+        construct_payload_hash::<NativeHasher>(payload_merkle_root, signing_verifier_set_hash);
+
+    let (verification_session_pda, _bump) = crate::get_signature_verification_pda(&payload_hash);
 
     let accounts = vec![
         AccountMeta::new_readonly(gateway_config_pda, false),

--- a/programs/axelar-solana-gateway/src/processor.rs
+++ b/programs/axelar-solana-gateway/src/processor.rs
@@ -97,12 +97,14 @@ impl Processor {
 
             GatewayInstruction::InitializePayloadVerificationSession {
                 payload_merkle_root,
+                signing_verifier_set_hash,
             } => {
                 msg!("Instruction: Initialize Verification Session");
                 Self::process_initialize_payload_verification_session(
                     program_id,
                     accounts,
                     payload_merkle_root,
+                    signing_verifier_set_hash,
                 )
             }
 

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -83,13 +83,13 @@ impl Processor {
         let session = SignatureVerificationSessionData::read(&session_data)
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
         // Construct the payload hash using the stored signing verifier set hash
-        let payload_hash = construct_payload_hash::<SolanaSyscallHasher>(
+        let combined_payload_hash = construct_payload_hash::<SolanaSyscallHasher>(
             payload_merkle_root,
             session.signature_verification.signing_verifier_set_hash,
         );
 
         assert_valid_signature_verification_pda(
-            &payload_hash,
+            &combined_payload_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -86,14 +86,15 @@ impl Processor {
             GatewayConfig::read(&data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
         assert_valid_gateway_root_pda(gateway_config.bump, gateway_root_pda.key)?;
 
-        // Construct the payload hash for PDA derivation
-        let payload_hash = construct_payload_hash::<SolanaSyscallHasher>(
+        // Construct the combined payload hash for PDA derivation
+        let combined_payload_hash = construct_payload_hash::<SolanaSyscallHasher>(
             payload_merkle_root,
             signing_verifier_set_hash,
         );
 
         // Check: Verification PDA can be derived from provided seeds.
-        let (verification_session_pda, bump) = crate::get_signature_verification_pda(&payload_hash);
+        let (verification_session_pda, bump) =
+            crate::get_signature_verification_pda(&combined_payload_hash);
         if verification_session_pda != *verification_session_account.key {
             return Err(GatewayError::InvalidVerificationSessionPDA.into());
         }
@@ -107,7 +108,7 @@ impl Processor {
         // bump seed.
         let signers_seeds = &[
             seed_prefixes::SIGNATURE_VERIFICATION_SEED,
-            &payload_hash,
+            &combined_payload_hash,
             &[bump],
         ];
 

--- a/programs/axelar-solana-gateway/src/processor/verify_signature.rs
+++ b/programs/axelar-solana-gateway/src/processor/verify_signature.rs
@@ -57,13 +57,13 @@ impl Processor {
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
 
         // Construct the payload hash using the stored signing verifier set hash
-        let payload_hash = construct_payload_hash::<SolanaSyscallHasher>(
+        let combined_payload_hash = construct_payload_hash::<SolanaSyscallHasher>(
             payload_merkle_root,
             session.signature_verification.signing_verifier_set_hash,
         );
 
         assert_valid_signature_verification_pda(
-            &payload_hash,
+            &combined_payload_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/state/signature_verification.rs
+++ b/programs/axelar-solana-gateway/src/state/signature_verification.rs
@@ -91,27 +91,18 @@ impl SignatureVerification {
         // Update state
         self.accumulate_threshold(&verifier_info.leaf);
         self.mark_slot_done(&verifier_info.leaf)?;
-        self.verify_or_initialize_verifier_set(verifier_set_merkle_root)?;
+        self.verify_verifier_set(verifier_set_merkle_root)?;
 
         Ok(())
     }
 
-    /// Verifies or initializes the verifier set hash.
-    /// Returns an error if the hash is already set and doesn't match.
+    /// Verifies that the provided verifier set hash matches the one set at initialization.
+    /// Returns an error if they don't match.
     #[inline]
-    fn verify_or_initialize_verifier_set(
-        &mut self,
-        expected_hash: &[u8; 32],
-    ) -> Result<(), GatewayError> {
-        if self.signing_verifier_set_hash == [0; 32] {
-            self.signing_verifier_set_hash = *expected_hash;
-            return Ok(());
-        }
-
+    fn verify_verifier_set(&self, expected_hash: &[u8; 32]) -> Result<(), GatewayError> {
         if self.signing_verifier_set_hash != *expected_hash {
             return Err(GatewayError::InvalidDigitalSignature);
         }
-
         Ok(())
     }
 
@@ -322,44 +313,30 @@ mod tests {
     use rand::Rng;
 
     #[test]
-    fn test_initialize_when_hash_is_zero() {
-        let mut verification = SignatureVerification::default();
-        let new_hash = [42_u8; 32];
-
-        let result = verification.verify_or_initialize_verifier_set(&new_hash);
-
-        assert!(result.is_ok());
-        assert_eq!(verification.signing_verifier_set_hash, new_hash);
-    }
-
-    #[test]
     fn test_verify_success_when_hashes_match() {
         let expected_hash = [42_u8; 32];
-        let mut verification = SignatureVerification {
+        let verification = SignatureVerification {
             signing_verifier_set_hash: expected_hash,
             ..Default::default()
         };
 
-        let result = verification.verify_or_initialize_verifier_set(&expected_hash);
-
-        assert!(result.is_ok());
-        assert_eq!(verification.signing_verifier_set_hash, expected_hash);
+        assert!(verification.verify_verifier_set(&expected_hash).is_ok());
     }
 
     #[test]
     fn test_verify_fails_when_hashes_mismatch() {
         let initial_hash = [42_u8; 32];
         let different_hash = [24_u8; 32];
-        let mut verification = SignatureVerification {
+        let verification = SignatureVerification {
             signing_verifier_set_hash: initial_hash,
             ..Default::default()
         };
 
-        let result = verification.verify_or_initialize_verifier_set(&different_hash);
+        let error = verification
+            .verify_verifier_set(&different_hash)
+            .unwrap_err();
 
-        assert_eq!(result, Err(GatewayError::InvalidDigitalSignature));
-        // Hash should remain unchanged after failure
-        assert_eq!(verification.signing_verifier_set_hash, initial_hash);
+        assert_eq!(error, GatewayError::InvalidDigitalSignature);
     }
 
     #[test]
@@ -442,7 +419,10 @@ mod tests {
             merkle_proof: proof_bytes,
         };
 
-        let mut verification = SignatureVerification::default();
+        let mut verification = SignatureVerification {
+            signing_verifier_set_hash: merkle_root,
+            ..Default::default()
+        };
 
         // First call should succeed and mark the slot as verified
         assert!(verification

--- a/programs/axelar-solana-gateway/tests/integration/approve_message.rs
+++ b/programs/axelar-solana-gateway/tests/integration/approve_message.rs
@@ -1,6 +1,6 @@
 use core::str::FromStr;
 
-use axelar_solana_encoding::hasher::SolanaSyscallHasher;
+use axelar_solana_encoding::hasher::NativeHasher;
 use axelar_solana_encoding::types::execute_data::{MerkleisedMessage, MerkleisedPayload};
 use axelar_solana_encoding::types::messages::Messages;
 use axelar_solana_encoding::types::payload::Payload;
@@ -41,7 +41,7 @@ async fn successfully_approves_messages() {
         unreachable!()
     };
     for message_info in messages {
-        let hash = message_info.leaf.message.hash::<SolanaSyscallHasher>();
+        let hash = message_info.leaf.message.hash::<NativeHasher>();
         let command_id = command_id(
             &message_info.leaf.message.cc_id.chain,
             &message_info.leaf.message.cc_id.id,
@@ -138,7 +138,7 @@ async fn fail_individual_approval_if_done_many_times() {
     let mut events_counter = 0;
     let mut message_counter = 0;
     for message_info in merkle_messages_batch_two {
-        let hash = message_info.leaf.message.hash::<SolanaSyscallHasher>();
+        let hash = message_info.leaf.message.hash::<NativeHasher>();
         let tx = metadata
             .approve_message(
                 execute_data_batch_two.payload_merkle_root,

--- a/programs/axelar-solana-gateway/tests/integration/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_message_payload.rs
@@ -1,4 +1,4 @@
-use axelar_solana_encoding::hasher::SolanaSyscallHasher;
+use axelar_solana_encoding::hasher::NativeHasher;
 use axelar_solana_encoding::types::execute_data::MerkleisedPayload;
 use axelar_solana_encoding::types::messages::{Message, Messages};
 use axelar_solana_encoding::types::payload::Payload;
@@ -102,7 +102,7 @@ pub async fn approve_message(runner: &mut SolanaAxelarIntegrationMetadata, messa
         incoming_message_pda_bump,
         signing_pda_bump,
         MessageStatus::approved(),
-        message.hash::<SolanaSyscallHasher>(),
+        message.hash::<NativeHasher>(),
         message.payload_hash,
     );
     assert_eq!(account, expected_message);

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -1,10 +1,8 @@
-use axelar_solana_encoding::types::messages::Messages;
-use axelar_solana_encoding::types::payload::Payload;
+use axelar_solana_encoding::hasher::NativeHasher;
+use axelar_solana_encoding::types::verifier_set::{construct_payload_hash, verifier_set_hash};
 use axelar_solana_gateway::get_gateway_root_config_pda;
 use axelar_solana_gateway::state::signature_verification::SignatureVerification;
-use axelar_solana_gateway_test_fixtures::gateway::{
-    make_messages, make_verifier_set, random_bytes,
-};
+use axelar_solana_gateway_test_fixtures::gateway::random_bytes;
 use axelar_solana_gateway_test_fixtures::SolanaAxelarIntegration;
 use bytemuck::Zeroable;
 use solana_program_test::tokio;
@@ -23,17 +21,27 @@ async fn test_initialize_payload_verification_session() {
     let payload_merkle_root = random_bytes();
     let gateway_config_pda = get_gateway_root_config_pda().0;
 
+    // Get the initial verifier set hash from the test setup
+    let signing_verifier_set_hash = verifier_set_hash::<NativeHasher>(
+        &metadata.signers.verifier_set(),
+        &metadata.signers.domain_separator,
+    )
+    .unwrap();
+
     let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
         metadata.payer.pubkey(),
         gateway_config_pda,
         payload_merkle_root,
+        signing_verifier_set_hash,
     )
     .unwrap();
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
 
     // Check PDA contains the expected data
+    let payload_hash =
+        construct_payload_hash::<NativeHasher>(payload_merkle_root, signing_verifier_set_hash);
     let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_merkle_root);
+        axelar_solana_gateway::get_signature_verification_pda(&payload_hash);
 
     let verification_session_account = metadata
         .try_get_account_no_checks(&verification_pda)
@@ -52,10 +60,14 @@ async fn test_initialize_payload_verification_session() {
         .await;
 
     assert_eq!(session.bump, bump);
-    assert_eq!(
-        session.signature_verification,
-        SignatureVerification::zeroed()
-    );
+
+    let expected_verification = {
+        let mut sig_verification = SignatureVerification::zeroed();
+        sig_verification.signing_verifier_set_hash = signing_verifier_set_hash;
+        sig_verification
+    };
+
+    assert_eq!(session.signature_verification, expected_verification);
 }
 
 #[tokio::test]
@@ -71,10 +83,14 @@ async fn test_cannot_initialize_pda_twice() {
     let payload_merkle_root = random_bytes();
     let gateway_config_pda = get_gateway_root_config_pda().0;
 
+    // Get the initial verifier set hash from the test setup
+    let signing_verifier_set_hash = metadata.signers.verifier_set_hash();
+
     let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
         metadata.payer.pubkey(),
         gateway_config_pda,
         payload_merkle_root,
+        signing_verifier_set_hash,
     )
     .unwrap();
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
@@ -84,6 +100,7 @@ async fn test_cannot_initialize_pda_twice() {
         metadata.payer.pubkey(),
         gateway_config_pda,
         payload_merkle_root,
+        signing_verifier_set_hash,
     )
     .unwrap();
     let tx_result_second = metadata.send_tx(&[ix_second]).await.unwrap_err();
@@ -93,32 +110,4 @@ async fn test_cannot_initialize_pda_twice() {
         tx_result_second.result.is_err(),
         "Second initialization should fail"
     );
-}
-
-#[tokio::test]
-async fn test_same_payload_can_be_signed_by_multiple_verifier_sets_and_be_initialised() {
-    // Setup
-    let mut metadata = SolanaAxelarIntegration::builder()
-        .initial_signer_weights(vec![42])
-        .build()
-        .setup()
-        .await;
-
-    let signers_a = make_verifier_set(&[500, 200], 1, metadata.domain_separator);
-    let signers_b = make_verifier_set(&[500, 23], 101, metadata.domain_separator);
-
-    let messages = make_messages(5);
-    let payload = Payload::Messages(Messages(messages.clone()));
-    let execute_data_a = metadata.construct_execute_data(&signers_a, payload.clone());
-    let execute_data_b = metadata.construct_execute_data(&signers_b, payload);
-
-    for execute_data in [execute_data_a, execute_data_b] {
-        let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
-            metadata.payer.pubkey(),
-            metadata.gateway_root_pda,
-            execute_data.payload_merkle_root,
-        )
-        .unwrap();
-        let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
-    }
 }

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -38,10 +38,10 @@ async fn test_initialize_payload_verification_session() {
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
 
     // Check PDA contains the expected data
-    let payload_hash =
+    let combined_payload_hash =
         construct_payload_hash::<NativeHasher>(payload_merkle_root, signing_verifier_set_hash);
     let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_hash);
+        axelar_solana_gateway::get_signature_verification_pda(&combined_payload_hash);
 
     let verification_session_account = metadata
         .try_get_account_no_checks(&verification_pda)

--- a/programs/axelar-solana-gateway/tests/integration/rotate_signers.rs
+++ b/programs/axelar-solana-gateway/tests/integration/rotate_signers.rs
@@ -6,6 +6,7 @@ use axelar_solana_encoding::types::payload::Payload;
 use axelar_solana_encoding::types::verifier_set::verifier_set_hash;
 use axelar_solana_gateway::error::GatewayError;
 use axelar_solana_gateway::get_verifier_set_tracker_pda;
+use axelar_solana_gateway::instructions::rotate_signers;
 use axelar_solana_gateway::processor::{GatewayEvent, VerifierSetRotated};
 use axelar_solana_gateway::state::verifier_set_tracker::VerifierSetTracker;
 use axelar_solana_gateway_test_fixtures::gateway::{
@@ -45,11 +46,13 @@ async fn successfully_rotates_signers() {
         .await
         .unwrap();
 
-    let rotate_signers_ix = axelar_solana_gateway::instructions::rotate_signers(
+    let (signing_verifier_set_tracker_pda, _) =
+        get_verifier_set_tracker_pda(execute_data.signing_verifier_set_merkle_root);
+    let rotate_signers_ix = rotate_signers(
         metadata.gateway_root_pda,
         verification_session_account,
-        metadata.signers.verifier_set_tracker().0,
-        axelar_solana_gateway::get_verifier_set_tracker_pda(new_verifier_set_merkle_root).0,
+        signing_verifier_set_tracker_pda,
+        get_verifier_set_tracker_pda(new_verifier_set_merkle_root).0,
         metadata.payer.pubkey(),
         None,
         new_verifier_set_hash,
@@ -119,11 +122,13 @@ async fn fail_when_approve_messages_payload_hash_is_used() {
     )
     .unwrap();
     let (new_vs_tracker_pda, _new_vs_tracker_bump) = get_verifier_set_tracker_pda(random_bytes());
+    let (signing_verifier_set_tracker_pda, _) =
+        get_verifier_set_tracker_pda(execute_data.signing_verifier_set_merkle_root);
 
-    let rotate_signers_ix = axelar_solana_gateway::instructions::rotate_signers(
+    let rotate_signers_ix = rotate_signers(
         metadata.gateway_root_pda,
         verification_session_account,
-        metadata.signers.verifier_set_tracker().0,
+        signing_verifier_set_tracker_pda,
         new_vs_tracker_pda,
         metadata.payer.pubkey(),
         None,
@@ -252,11 +257,13 @@ async fn succeed_if_verifier_set_signed_by_old_verifier_set_and_submitted_by_the
     )
     .unwrap();
     let (new_vs_tracker_pda, new_vs_tracker_bump) =
-        axelar_solana_gateway::get_verifier_set_tracker_pda(new_verifier_set_hash);
-    let rotate_signers_ix = axelar_solana_gateway::instructions::rotate_signers(
+        get_verifier_set_tracker_pda(new_verifier_set_hash);
+    let (signing_verifier_set_tracker_pda, _) =
+        get_verifier_set_tracker_pda(execute_data.signing_verifier_set_merkle_root);
+    let rotate_signers_ix = rotate_signers(
         metadata.gateway_root_pda,
         signing_session_pda,
-        metadata.signers.verifier_set_tracker().0,
+        signing_verifier_set_tracker_pda,
         new_vs_tracker_pda,
         metadata.payer.pubkey(),
         Some(metadata.operator.pubkey()),
@@ -340,11 +347,13 @@ async fn fail_if_provided_operator_is_not_the_real_operator_thats_stored_in_gate
     )
     .unwrap();
     let (new_vs_tracker_pda, _new_vs_tracker_bump) =
-        axelar_solana_gateway::get_verifier_set_tracker_pda(new_verifier_set_hash);
-    let rotate_signers_ix = axelar_solana_gateway::instructions::rotate_signers(
+        get_verifier_set_tracker_pda(new_verifier_set_hash);
+    let (signing_verifier_set_tracker_pda, _) =
+        get_verifier_set_tracker_pda(execute_data.signing_verifier_set_merkle_root);
+    let rotate_signers_ix = rotate_signers(
         metadata.gateway_root_pda,
         signing_session_pda,
-        metadata.signers.verifier_set_tracker().0,
+        signing_verifier_set_tracker_pda,
         new_vs_tracker_pda,
         metadata.payer.pubkey(),
         Some(fake_operator.pubkey()),
@@ -405,11 +414,13 @@ async fn fail_if_operator_only_passed_but_not_actual_signer() {
     )
     .unwrap();
     let (new_vs_tracker_pda, _new_vs_tracker_bump) =
-        axelar_solana_gateway::get_verifier_set_tracker_pda(new_verifier_set_hash);
-    let mut rotate_signers_ix = axelar_solana_gateway::instructions::rotate_signers(
+        get_verifier_set_tracker_pda(new_verifier_set_hash);
+    let (signing_verifier_set_tracker_pda, _) =
+        get_verifier_set_tracker_pda(execute_data.signing_verifier_set_merkle_root);
+    let mut rotate_signers_ix = rotate_signers(
         metadata.gateway_root_pda,
         signing_session_pda,
-        metadata.signers.verifier_set_tracker().0,
+        signing_verifier_set_tracker_pda,
         new_vs_tracker_pda,
         metadata.payer.pubkey(),
         Some(metadata.operator.pubkey()),

--- a/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
+++ b/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
@@ -529,10 +529,11 @@ async fn test_verify_all_signatures_when_session_pda_has_lamports() {
 
     for verifier_set_leaf in execute_data.signing_verifier_set_leaves {
         // Verify the signature
-        let ix = axelar_solana_gateway::instructions::verify_signature(
+        let ix = verify_signature(
             metadata.gateway_root_pda,
             verifier_set_tracker_pda,
             execute_data.payload_merkle_root,
+            execute_data.signing_verifier_set_merkle_root,
             verifier_set_leaf,
         )
         .unwrap();

--- a/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
+++ b/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
@@ -65,12 +65,12 @@ async fn test_verify_one_signature(
         .unwrap();
 
     // Check that the PDA contains the expected data
-    let payload_hash = construct_payload_hash::<NativeHasher>(
+    let combined_payload_hash = construct_payload_hash::<NativeHasher>(
         execute_data.payload_merkle_root,
         execute_data.signing_verifier_set_merkle_root,
     );
     let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_hash);
+        axelar_solana_gateway::get_signature_verification_pda(&combined_payload_hash);
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -130,12 +130,12 @@ async fn test_verify_all_signatures() {
     }
 
     // Check that the PDA contains the expected data
-    let payload_hash = construct_payload_hash::<NativeHasher>(
+    let combined_payload_hash = construct_payload_hash::<NativeHasher>(
         execute_data.payload_merkle_root,
         execute_data.signing_verifier_set_merkle_root,
     );
     let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_hash);
+        axelar_solana_gateway::get_signature_verification_pda(&combined_payload_hash);
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -324,12 +324,12 @@ async fn test_large_weight_will_validate_whole_batch() {
         .unwrap();
 
     // Check that the PDA contains the expected data
-    let payload_hash = construct_payload_hash::<NativeHasher>(
+    let combined_payload_hash = construct_payload_hash::<NativeHasher>(
         execute_data.payload_merkle_root,
         execute_data.signing_verifier_set_merkle_root,
     );
     let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_hash);
+        axelar_solana_gateway::get_signature_verification_pda(&combined_payload_hash);
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -507,12 +507,12 @@ async fn test_verify_all_signatures_when_session_pda_has_lamports() {
         .await;
     let execute_data = metadata.construct_execute_data(&metadata.signers.clone(), payload);
 
-    let payload_hash = construct_payload_hash::<NativeHasher>(
+    let combined_payload_hash = construct_payload_hash::<NativeHasher>(
         execute_data.payload_merkle_root,
         execute_data.signing_verifier_set_merkle_root,
     );
     let (verification_session_pda, verification_pda_bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_hash);
+        axelar_solana_gateway::get_signature_verification_pda(&combined_payload_hash);
     let payer = metadata.fixture.payer.pubkey();
 
     // Transfer lamports to the PDA to try to prevent its initialization


### PR DESCRIPTION
This PR fixes a critical issue where a single malicious verifier could prevent verifier set rotations by being the first to sign with an unexpected verifier set.

Previously, the verification session PDA was derived only from the payload merkle root, and the signing verifier set hash was recorded when the first verifier signed. This created a mismatch where the PDA key expected one verifier set but the session could record a different one.

Now the verification session PDA is derived from both the payload merkle root and the explicit signing verifier set hash, tying them together at initialization.

## Changes

- Modified `initialize_payload_verification_session` instruction to require explicit `signing_verifier_set_hash` parameter alongside `payload_merkle_root`
- Updated PDA derivation to use `construct_payload_hash(payload_merkle_root, signing_verifier_set_hash)` for verification session PDAs
- Set signing verifier set hash at initialization rather than deferring to first signature verification
- Modified test fixtures and integration tests to accommodate the new instruction signature
- *Minor changes*: 
  - use `NativeHasher` for off-chain computations, where `SolanaSyscallHasher` was being incorrectly used.
  - updated Anchor + JS/TS bindings

