### PR TITLE
chore(gas): remove the legacy `params` attribute

### DIFF
--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -34,8 +34,6 @@ pub struct NativeGasPaidForContractCallEvent {
     pub payload_hash: [u8; 32],
     /// The refund address
     pub refund_address: Pubkey,
-    /// Extra parameters to be passed
-    pub params: Vec<u8>,
     /// The amount of SOL to send
     pub gas_fee_amount: u64,
 }
@@ -72,8 +70,6 @@ impl NativeGasPaidForContractCallEvent {
         let refund_address =
             Pubkey::new_from_array(read_array::<32>("refund_address", &refund_address_data)?);
 
-        let params = data.next().ok_or(EventParseError::MissingData("params"))?;
-
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
@@ -85,7 +81,6 @@ impl NativeGasPaidForContractCallEvent {
             destination_address,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount,
         })
     }
@@ -217,8 +212,6 @@ pub struct SplGasPaidForContractCallEvent {
     pub payload_hash: [u8; 32],
     /// The refund address
     pub refund_address: Pubkey,
-    /// Extra parameters to be passed
-    pub params: Vec<u8>,
     /// The amount of SOL to send
     pub gas_fee_amount: u64,
 }
@@ -270,8 +263,6 @@ impl SplGasPaidForContractCallEvent {
         let refund_address =
             Pubkey::new_from_array(read_array::<32>("refund_address", &refund_address_data)?);
 
-        let params = data.next().ok_or(EventParseError::MissingData("params"))?;
-
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
@@ -286,7 +277,6 @@ impl SplGasPaidForContractCallEvent {
             destination_address,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount,
         })
     }

--- a/crates/gateway-event-stack/src/lib.rs
+++ b/crates/gateway-event-stack/src/lib.rs
@@ -414,7 +414,7 @@ mod tests {
             "Program gasHQkvaC4jTD2MQpAuEN3RdNwde2Ym5E5QNDoh6m6G invoke [1]",
             "Program 11111111111111111111111111111111 invoke [2]",
             "Program 11111111111111111111111111111111 success",
-            "Program data: bmF0aXZlIGdhcyBwYWlkIGZvciBjb250cmFjdCBjYWxs uHuSGR4VBBCRNPjze8Y91JXLTJnrh8qv2IxFZAjnrfI= ZXZt MHhkZWFkYmVlZg== /Qd2xw7aQmd/4PP+LMP3Kwouwb8mAfoKYiWkSoTQv5E= AAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=  iBMAAAAAAAA=",
+            "Program data: bmF0aXZlIGdhcyBwYWlkIGZvciBjb250cmFjdCBjYWxs uHuSGR4VBBCRNPjze8Y91JXLTJnrh8qv2IxFZAjnrfI= ZXZt MHhkZWFkYmVlZg== /Qd2xw7aQmd/4PP+LMP3Kwouwb8mAfoKYiWkSoTQv5E= AAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= iBMAAAAAAAA=",
             "Program gasHQkvaC4jTD2MQpAuEN3RdNwde2Ym5E5QNDoh6m6G consumed 7199 of 400000 compute units",
             "Program gasHQkvaC4jTD2MQpAuEN3RdNwde2Ym5E5QNDoh6m6G success",
             "Program mem7LhKWbKydCPk1TwNzeCvVSpoVx2mqxNuvjGgWAbG invoke [1]",
@@ -442,7 +442,6 @@ mod tests {
                 193, 191, 38, 1, 250, 10, 98, 37, 164, 74, 132, 208, 191, 145,
             ],
             refund_address: "11111112D1oxKts8YPdTJRG5FzxTNpMtWmq8hkVx3".parse().unwrap(),
-            params: vec![],
             gas_fee_amount: 5000,
         };
         let expected = vec![ProgramInvocationState::Succeeded(vec![(

--- a/programs/axelar-solana-gas-service/src/instructions.rs
+++ b/programs/axelar-solana-gas-service/src/instructions.rs
@@ -50,8 +50,6 @@ pub enum PayWithSplToken {
         destination_address: String,
         /// A 32-byte hash representing the payload.
         payload_hash: [u8; 32],
-        /// Additional parameters for the contract call.
-        params: Vec<u8>,
         /// The amount of tokens to be paid as gas fees.
         gas_fee_amount: u64,
         /// The decimals for the mint
@@ -114,8 +112,6 @@ pub enum PayWithNativeToken {
         payload_hash: [u8; 32],
         /// Where refunds should be sent.
         refund_address: Pubkey,
-        /// Additional parameters for the contract call.
-        params: Vec<u8>,
         /// The amount of SOL to pay as gas fees.
         gas_fee_amount: u64,
     },
@@ -221,7 +217,6 @@ pub fn pay_native_for_contract_call_instruction(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: Vec<u8>,
     gas_fee_amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let ix_data = borsh::to_vec(&GasServiceInstruction::Native(
@@ -230,7 +225,6 @@ pub fn pay_native_for_contract_call_instruction(
             destination_address,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount,
         },
     ))?;
@@ -353,7 +347,6 @@ pub fn pay_spl_for_contract_call_instruction(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: Vec<u8>,
     gas_fee_amount: u64,
     signer_pubkeys: &[Pubkey],
     decimals: u8,
@@ -364,7 +357,6 @@ pub fn pay_spl_for_contract_call_instruction(
             destination_address,
             payload_hash,
             refund_address,
-            params,
             decimals,
             gas_fee_amount,
         },

--- a/programs/axelar-solana-gas-service/src/processor.rs
+++ b/programs/axelar-solana-gas-service/src/processor.rs
@@ -26,7 +26,6 @@ mod transfer_operatorship;
 ///
 /// # Errors
 /// - if the ix processing resulted in an error
-#[allow(clippy::todo)]
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
@@ -46,7 +45,6 @@ pub fn process_instruction(
                 destination_address,
                 payload_hash,
                 gas_fee_amount,
-                params,
                 decimals,
                 refund_address,
             } => process_pay_spl_for_contract_call(
@@ -56,7 +54,6 @@ pub fn process_instruction(
                 destination_address,
                 payload_hash,
                 refund_address,
-                &params,
                 gas_fee_amount,
                 decimals,
             ),
@@ -91,7 +88,6 @@ pub fn process_instruction(
                 destination_address,
                 payload_hash,
                 refund_address,
-                params,
                 gas_fee_amount,
             } => process_pay_native_for_contract_call(
                 program_id,
@@ -100,7 +96,6 @@ pub fn process_instruction(
                 destination_address,
                 payload_hash,
                 refund_address,
-                &params,
                 gas_fee_amount,
             ),
             PayWithNativeToken::AddGas {

--- a/programs/axelar-solana-gas-service/src/processor/native.rs
+++ b/programs/axelar-solana-gas-service/src/processor/native.rs
@@ -14,7 +14,6 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_instruction;
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn process_pay_native_for_contract_call(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
@@ -22,7 +21,6 @@ pub(crate) fn process_pay_native_for_contract_call(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: &[u8],
     gas_fee_amount: u64,
 ) -> ProgramResult {
     if gas_fee_amount == 0 {
@@ -52,7 +50,6 @@ pub(crate) fn process_pay_native_for_contract_call(
         &destination_address.into_bytes(),
         &payload_hash,
         &refund_address.to_bytes(),
-        params,
         &gas_fee_amount.to_le_bytes(),
     ]);
 
@@ -200,7 +197,6 @@ mod tests {
         let destination_address = "destination_address".to_owned();
         let payload_hash = [0; 32];
         let refund_address = Pubkey::new_unique();
-        let params = vec![1, 2, 3];
         let gas_fee_amount = 0;
 
         let result = process_pay_native_for_contract_call(
@@ -210,7 +206,6 @@ mod tests {
             destination_address,
             payload_hash,
             refund_address,
-            &params,
             gas_fee_amount,
         );
 

--- a/programs/axelar-solana-gas-service/src/processor/spl.rs
+++ b/programs/axelar-solana-gas-service/src/processor/spl.rs
@@ -73,7 +73,6 @@ pub(crate) fn process_pay_spl_for_contract_call(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: &[u8],
     gas_fee_amount: u64,
     decimals: u8,
 ) -> ProgramResult {
@@ -140,7 +139,6 @@ pub(crate) fn process_pay_spl_for_contract_call(
         &destination_address.into_bytes(),
         &payload_hash,
         &refund_address.to_bytes(),
-        params,
         &gas_fee_amount.to_le_bytes(),
     ]);
 
@@ -381,7 +379,6 @@ mod tests {
         let destination_address = "destination_address".to_owned();
         let payload_hash = [0; 32];
         let refund_address = Pubkey::new_unique();
-        let params = vec![];
         let gas_fee_amount = 0;
         let decimals = 0;
 
@@ -392,7 +389,6 @@ mod tests {
             destination_address,
             payload_hash,
             refund_address,
-            &params,
             gas_fee_amount,
             decimals,
         );

--- a/programs/axelar-solana-gas-service/tests/module/native/pay_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/pay_for_contract_call.rs
@@ -38,16 +38,12 @@ async fn test_pay_native_for_contract_call() {
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = "\u{1f42a}\u{1f42a}\u{1f42a}\u{1f42a}"
-        .to_string()
-        .into_bytes();
     let ix = axelar_solana_gas_service::instructions::pay_native_for_contract_call_instruction(
         &payer.pubkey(),
         destination_chain.clone(),
         destination_addr.clone(),
         payload_hash,
         refund_address,
-        params.clone(),
         gas_amount,
     )
     .unwrap();
@@ -82,7 +78,6 @@ async fn test_pay_native_for_contract_call() {
             destination_address: destination_addr,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount: gas_amount,
         }
     );
@@ -128,16 +123,12 @@ async fn fails_if_payer_not_signer() {
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = "\u{1f42a}\u{1f42a}\u{1f42a}\u{1f42a}"
-        .to_string()
-        .into_bytes();
     let mut ix = axelar_solana_gas_service::instructions::pay_native_for_contract_call_instruction(
         &payer.pubkey(),
         destination_chain.clone(),
         destination_addr.clone(),
         payload_hash,
         refund_address,
-        params.clone(),
         gas_amount,
     )
     .unwrap();

--- a/programs/axelar-solana-gas-service/tests/module/spl/pay_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/pay_for_contract_call.rs
@@ -55,7 +55,6 @@ async fn test_pay_spl_for_contract_call(#[case] token_program_id: Pubkey) {
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "0x destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = b"hello 123321".to_vec();
 
     // Create the instruction for paying gas fees with SPL tokens
     let ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
@@ -67,7 +66,6 @@ async fn test_pay_spl_for_contract_call(#[case] token_program_id: Pubkey) {
         destination_addr.clone(),
         payload_hash,
         refund_address,
-        params.clone(),
         gas_amount,
         &[],
         decimals,
@@ -113,7 +111,6 @@ async fn test_pay_spl_for_contract_call(#[case] token_program_id: Pubkey) {
             destination_address: destination_addr,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount: gas_amount
         }
     );
@@ -168,7 +165,6 @@ async fn test_pay_spl_for_contract_call_missing_signer(#[case] token_program_id:
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "0x destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = b"hello 123321".to_vec();
 
     let mut ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
         &payer.pubkey(),
@@ -179,7 +175,6 @@ async fn test_pay_spl_for_contract_call_missing_signer(#[case] token_program_id:
         destination_addr,
         payload_hash,
         refund_address,
-        params,
         gas_amount,
         &[],
         decimals,
@@ -255,7 +250,6 @@ async fn test_pay_spl_for_contract_call_invalid_sender_ata_wrong_mint(
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "0x destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = b"hello 123321".to_vec();
 
     let ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
         &payer.pubkey(),
@@ -266,7 +260,6 @@ async fn test_pay_spl_for_contract_call_invalid_sender_ata_wrong_mint(
         destination_addr,
         payload_hash,
         refund_address,
-        params,
         gas_amount,
         &[],
         decimals,
@@ -331,7 +324,6 @@ async fn test_pay_spl_for_contract_call_invalid_sender_ata_wrong_owner(
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "0x destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = b"hello 123321".to_vec();
 
     let ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
         &payer.pubkey(),  // Payer is the signer
@@ -342,7 +334,6 @@ async fn test_pay_spl_for_contract_call_invalid_sender_ata_wrong_owner(
         destination_addr,
         payload_hash,
         refund_address,
-        params,
         gas_amount,
         &[],
         decimals,
@@ -412,7 +403,6 @@ async fn test_pay_spl_for_contract_call_invalid_config_pda_ata_wrong_mint(
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "0x destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = b"hello 123321".to_vec();
 
     // Manually construct the instruction to use wrong config_pda_ata
     let mut ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
@@ -424,7 +414,6 @@ async fn test_pay_spl_for_contract_call_invalid_config_pda_ata_wrong_mint(
         destination_addr,
         payload_hash,
         refund_address,
-        params,
         gas_amount,
         &[],
         decimals,
@@ -492,7 +481,6 @@ async fn test_pay_spl_for_contract_call_invalid_config_pda_ata_wrong_owner(
     let destination_chain = "ethereum".to_owned();
     let destination_addr = "0x destination addr 123".to_owned();
     let payload_hash = [42; 32];
-    let params = b"hello 123321".to_vec();
 
     let mut ix = axelar_solana_gas_service::instructions::pay_spl_for_contract_call_instruction(
         &payer.pubkey(),
@@ -503,7 +491,6 @@ async fn test_pay_spl_for_contract_call_invalid_config_pda_ata_wrong_owner(
         destination_addr,
         payload_hash,
         refund_address,
-        params,
         gas_amount,
         &[],
         decimals,

--- a/programs/axelar-solana-its/src/processor/gmp.rs
+++ b/programs/axelar-solana-its/src/processor/gmp.rs
@@ -246,7 +246,6 @@ fn pay_gas<'a>(
             its_hub_address,
             payload_hash,
             *payer.key,
-            vec![],
             gas_value,
         )?;
 


### PR DESCRIPTION
Forced to be empty in [the reference implementation](https://github.com/axelarnetwork/axelar-cgp-solidity/blob/c208d84cd5681976240e7e94ce5a77cca71325c6/contracts/gas-service/AxelarGasService.sol/#L67-L68)