### PR TITLE
fix: correct misleading variable names and error messages (C23)

### DIFF
--- a/programs/axelar-solana-gateway/src/lib.rs
+++ b/programs/axelar-solana-gateway/src/lib.rs
@@ -207,7 +207,7 @@ pub fn assert_valid_verifier_set_tracker_pda(
         ],
         &crate::ID,
     )
-    .expect("invalid bump for the root pda");
+    .expect("invalid bump for the verifier set tracker pda");
     if &derived_pubkey != expected_pubkey {
         solana_program::msg!("Error: Invalid Verifier Set Root PDA ");
         return Err(ProgramError::IncorrectProgramId);

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -52,10 +52,11 @@ impl Processor {
     ///
     /// This function will panic if:
     /// * Converting `IncomingMessage::LEN` to u64 overflows.
+    #[allow(clippy::too_many_lines)]
     pub fn process_approve_message(
         program_id: &Pubkey,
         accounts: &[AccountInfo<'_>],
-        message: MerkleisedMessage,
+        merkleised_message: MerkleisedMessage,
         payload_merkle_root: [u8; 32],
     ) -> ProgramResult {
         // Accounts
@@ -97,34 +98,38 @@ impl Processor {
         }
 
         // Check: message signing verifier set matches the verification session verifier set
-        if message.leaf.signing_verifier_set
+        if merkleised_message.leaf.signing_verifier_set
             != session.signature_verification.signing_verifier_set_hash
         {
             return Err(GatewayError::InvalidVerificationSessionPDA.into());
         }
 
         // Check: message domain separator matches the gateway's domain separator
-        if message.leaf.domain_separator != gateway_config.domain_separator {
+        if merkleised_message.leaf.domain_separator != gateway_config.domain_separator {
             return Err(GatewayError::InvalidDomainSeparator.into());
         }
 
-        let leaf_hash = message.leaf.hash::<SolanaSyscallHasher>();
-        let message_hash = message.leaf.message.hash::<SolanaSyscallHasher>();
-        let proof = rs_merkle::MerkleProof::<SolanaSyscallHasher>::from_bytes(&message.proof)
-            .map_err(|_err| GatewayError::InvalidMerkleProof)?;
+        let leaf_hash = merkleised_message.leaf.hash::<SolanaSyscallHasher>();
+        let message_hash = merkleised_message
+            .leaf
+            .message
+            .hash::<SolanaSyscallHasher>();
+        let proof =
+            rs_merkle::MerkleProof::<SolanaSyscallHasher>::from_bytes(&merkleised_message.proof)
+                .map_err(|_err| GatewayError::InvalidMerkleProof)?;
 
         // Check: leaf node is part of the payload merkle root
         if !proof.verify(
             payload_merkle_root,
-            &[message.leaf.position.into()],
+            &[merkleised_message.leaf.position.into()],
             &[leaf_hash],
-            message.leaf.set_size.into(),
+            merkleised_message.leaf.set_size.into(),
         ) {
             return Err(GatewayError::LeafNodeNotPartOfMerkleRoot.into());
         }
 
         // crate a PDA where we write the message metadata contents
-        let message = message.leaf.message;
+        let message = merkleised_message.leaf.message;
         let cc_id = message.cc_id;
         let command_id = command_id(&cc_id.chain, &cc_id.id);
 

--- a/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
+++ b/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
@@ -87,7 +87,7 @@ impl Processor {
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
 
         // New verifier set merkle root can be transformed into the payload hash
-        let payload_merkle_root =
+        let rotate_verifier_set_hash =
             axelar_solana_encoding::types::verifier_set::construct_payload_hash::<
                 SolanaSyscallHasher,
             >(
@@ -98,7 +98,7 @@ impl Processor {
         // Check: Verification PDA can be derived from seeds stored into the account
         // data itself.
         assert_valid_signature_verification_pda(
-            &payload_merkle_root,
+            &rotate_verifier_set_hash,
             session.bump,
             verification_session_account.key,
         )?;


### PR DESCRIPTION
Fixes misleading and confusing terminology in Gateway program:
- Corrected error message in `assert_valid_verifier_set_tracker_pda`
- Renamed `message` parameter to `merkleised_message` in `process_approve_message`
- Renamed `payload_merkle_root` to `rotate_verifier_set_hash` in `process_rotate_verifier_set`

