### PR TITLE
fix(gateway): reorganize error variants and fix misleading comments (C20)

### DIFF
--- a/programs/axelar-solana-gateway/src/error.rs
+++ b/programs/axelar-solana-gateway/src/error.rs
@@ -4,8 +4,8 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::ToPrimitive;
 use solana_program::program_error::ProgramError;
 
-// Error codes 0-499 are recoverable, 500+ are irrecoverable
-const IRRECOVERABLE_ERROR: u32 = 500;
+// Error codes 0-6 are recoverable, 7+ are irrecoverable
+const IRRECOVERABLE_ERROR: u32 = 7;
 
 /// Errors that may be returned by the Gateway program.
 ///
@@ -15,7 +15,7 @@ const IRRECOVERABLE_ERROR: u32 = 500;
 ///
 /// Because of this the errors are categorized as follows:
 /// "Already completed" errors (codes 0-6): Action has already been completed by another actor. Relayer can interpret as "assume that this action completed successfully".
-/// Irrecoverable errors (codes 500+): Action cannot be completed with the provided arguments.
+/// Irrecoverable errors (codes 7+): Action cannot be completed with the provided arguments.
 #[repr(u32)]
 #[derive(Clone, Debug, Eq, thiserror::Error, FromPrimitive, ToPrimitive, PartialEq)]
 pub enum GatewayError {
@@ -184,7 +184,7 @@ mod tests {
         assert_eq!(errors_to_proceed.len(), 7);
         assert_eq!(errors_to_not_proceed.len(), 23);
 
-        // Errors that should cause the relayer to proceed (error numbers < 500)
+        // Errors that should cause the relayer to proceed (error numbers < 7)
         for error in errors_to_proceed {
             assert!(
                 error.should_relayer_proceed(),
@@ -194,7 +194,7 @@ mod tests {
             );
         }
 
-        // Errors that should NOT cause the relayer to proceed (error numbers >= 500)
+        // Errors that should NOT cause the relayer to proceed (error numbers >= 7)
         for error in errors_to_not_proceed {
             assert!(
                 !error.should_relayer_proceed(),

--- a/programs/axelar-solana-gateway/src/error.rs
+++ b/programs/axelar-solana-gateway/src/error.rs
@@ -48,7 +48,6 @@ pub enum GatewayError {
     MessagePayloadAlreadyCommitted,
 
     // ========== IRRECOVERABLE ERRORS RANGE ==========
-
     /// Used when a signature index is too high.
     #[error("Slot is out of bounds")]
     // --- NOTICE ---

--- a/programs/axelar-solana-gateway/src/error.rs
+++ b/programs/axelar-solana-gateway/src/error.rs
@@ -4,7 +4,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::ToPrimitive;
 use solana_program::program_error::ProgramError;
 
-const IRRECOVERABLE_ERROR: u32 = 12;
+const IRRECOVERABLE_ERROR: u32 = 500;
 
 /// Errors that may be returned by the Gateway program.
 ///
@@ -12,9 +12,9 @@ const IRRECOVERABLE_ERROR: u32 = 12;
 /// This is because while some errors can be interpreted as "the argument / account / ix combo is unsuccessful",
 /// some other errors can be interpreted as "this action has already been executed".
 ///
-/// Because of this the errors are following the error numbers as follows:
-/// Range: 0..12  | Action has already been completed by another actor. Relayer can interpret as "assume that this action completed successfully".
-/// Range: 13..xx | Action cannot be completed with the provided arguments
+/// Because of this the errors are categorized as follows:
+/// "Already completed" errors (codes 0-6): Action has already been completed by another actor. Relayer can interpret as "assume that this action completed successfully".
+/// Irrecoverable errors (codes 500+): Action cannot be completed with the provided arguments.
 #[repr(u32)]
 #[derive(Clone, Debug, Eq, thiserror::Error, FromPrimitive, ToPrimitive, PartialEq)]
 pub enum GatewayError {
@@ -38,9 +38,20 @@ pub enum GatewayError {
     #[error("Verifier set tracker PDA already initialized")]
     VerifierSetTrackerAlreadyInitialised,
 
+    /// Message Payload PDA was already initialized.
+    #[error("Message Payload PDA was already initialized")]
+    MessagePayloadAlreadyInitialized,
+
+    /// Message Payload has already been committed.
+    #[error("Message Payload has already been committed")]
+    MessagePayloadAlreadyCommitted,
+
     /// Used when a signature index is too high.
     #[error("Slot is out of bounds")]
-    SlotIsOutOfBounds,
+    // --- NOTICE ---
+    // this bumps the error representation to start at 500
+    // Any error after this point is deemed irrecoverable
+    SlotIsOutOfBounds = 500,
 
     /// Used when the internal digital signature verification fails.
     #[error("Digital signature verification failed")]
@@ -58,19 +69,8 @@ pub enum GatewayError {
     #[error("Invalid destination address")]
     InvalidDestinationAddress,
 
-    /// Message Payload PDA was already initialized.
-    #[error("Message Payload PDA was already initialized")]
-    MessagePayloadAlreadyInitialized,
-
-    /// Message Payload has already been committed.
-    #[error("Message Payload has already been committed")]
-    MessagePayloadAlreadyCommitted,
-
     /// Error indicating an underflow occurred during epoch calculation.
     #[error("Epoch calculation resulted in an underflow")]
-    // --- NOTICE ---
-    // this bumps the error representation to start at 500
-    // Any error after this point is deemed irrecoverable
     EpochCalculationOverflow,
 
     /// Error indicating the provided verifier set is too old.
@@ -179,8 +179,8 @@ mod tests {
             .collect_vec();
 
         // confidence check that we derived the errors correctly
-        assert_eq!(errors_to_proceed.len(), 12);
-        assert_eq!(errors_to_not_proceed.len(), 18);
+        assert_eq!(errors_to_proceed.len(), 7);
+        assert_eq!(errors_to_not_proceed.len(), 23);
 
         // Errors that should cause the relayer to proceed (error numbers < 500)
         for error in errors_to_proceed {

--- a/programs/axelar-solana-gateway/src/error.rs
+++ b/programs/axelar-solana-gateway/src/error.rs
@@ -4,6 +4,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::ToPrimitive;
 use solana_program::program_error::ProgramError;
 
+// Error codes 0-499 are recoverable, 500+ are irrecoverable
 const IRRECOVERABLE_ERROR: u32 = 500;
 
 /// Errors that may be returned by the Gateway program.
@@ -46,12 +47,14 @@ pub enum GatewayError {
     #[error("Message Payload has already been committed")]
     MessagePayloadAlreadyCommitted,
 
+    // ========== IRRECOVERABLE ERRORS RANGE ==========
+
     /// Used when a signature index is too high.
     #[error("Slot is out of bounds")]
     // --- NOTICE ---
-    // this bumps the error representation to start at 500
-    // Any error after this point is deemed irrecoverable
-    SlotIsOutOfBounds = 500,
+    // This bumps the error representation to the irrecoverable threshold.
+    // Any error after this point is deemed irrecoverable.
+    SlotIsOutOfBounds = IRRECOVERABLE_ERROR,
 
     /// Used when the internal digital signature verification fails.
     #[error("Digital signature verification failed")]

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -21,11 +21,10 @@ pub enum GatewayInstruction {
     ///
     /// Accounts expected by this instruction:
     /// 0. [] Gateway Root Config PDA account
-    /// 1. [WRITE] Gateway `ExecuteData` PDA account
-    /// 2. [] Verifier Setr Tracker PDA account (the one that signed the
-    ///    `ExecuteData`)
-    /// 3..N [WRITE] Gateway `ApprovedCommand` PDA accounts. All commands needs to
-    ///         be `ApproveMessages`.
+    /// 1. [WRITE, SIGNER] Payer account
+    /// 2. [] Verification Session PDA account (should be valid)
+    /// 3. [WRITE] Incoming Message PDA account
+    /// 4. [] System Program account
     ApproveMessage {
         /// The message that's to be approved
         message: MerkleisedMessage,
@@ -35,14 +34,16 @@ pub enum GatewayInstruction {
 
     /// Rotate signers for the Gateway Root Config PDA account.
     ///
+    /// Accounts expected by this instruction:
     /// 0. [WRITE] Gateway Root Config PDA account
-    /// 1. [] Verificatoin Session PDA account (should be valid)
-    /// 2. [] The current verefier set tracker PDA (the one that signed the
+    /// 1. [] Verification Session PDA account (should be valid)
+    /// 2. [] The current verifier set tracker PDA (the one that signed the
     ///    verification payload)
     /// 3. [WRITE] The new verifier set tracker PDA (the one that needs to be
     ///    instantiated)
-    /// 4. [WRITE, SIGNER] The payer for creating a new PAD
+    /// 4. [WRITE, SIGNER] The payer for creating a new PDA
     /// 5. [] The system program
+    /// 6. [SIGNER] (Optional) Operator account
     RotateSigners {
         /// The merkle root of the new verifier set
         new_verifier_set_merkle_root: [u8; 32],

--- a/programs/axelar-solana-gateway/src/state/message_payload.rs
+++ b/programs/axelar-solana-gateway/src/state/message_payload.rs
@@ -82,7 +82,7 @@ impl<'a> RefType<'a> for Mut {
 impl<'a, R: RefType<'a>> MessagePayload<'a, R> {
     /// Prefix bytes
     ///
-    /// 1 byte for the bump plus 32 bytes for the payload hash
+    /// 1 byte for the bump plus 1 byte for committed flag plus 32 bytes for the payload hash
     const HEADER_SIZE: usize = size_of::<u8>() + size_of::<u8>() + size_of::<[u8; 32]>();
 
     /// Adds the header prefix space  the given offset.

--- a/programs/axelar-solana-its/tests/module/deploy_remote.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_remote.rs
@@ -3,7 +3,6 @@ use mpl_token_metadata::accounts::Metadata;
 use mpl_token_metadata::instructions::CreateV1Builder;
 use mpl_token_metadata::types::TokenStandard;
 use solana_program_test::tokio;
-use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::instruction::Instruction;
 use test_context::test_context;
 
@@ -147,10 +146,7 @@ async fn test_deploy_remote_interchain_token_with_mismatched_metadata(
         Some(ctx.solana_wallet),
     )?;
 
-    // Add compute budget instruction to handle complex deployment
-    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(400_000);
-
-    ctx.send_solana_tx(&[compute_budget_ix, deploy_local_ix])
+    ctx.send_solana_tx(&[deploy_local_ix])
         .await
         .expect("InterchainToken deployment failed");
 

--- a/programs/axelar-solana-its/tests/module/deploy_remote.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_remote.rs
@@ -3,6 +3,7 @@ use mpl_token_metadata::accounts::Metadata;
 use mpl_token_metadata::instructions::CreateV1Builder;
 use mpl_token_metadata::types::TokenStandard;
 use solana_program_test::tokio;
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::instruction::Instruction;
 use test_context::test_context;
 
@@ -146,7 +147,10 @@ async fn test_deploy_remote_interchain_token_with_mismatched_metadata(
         Some(ctx.solana_wallet),
     )?;
 
-    ctx.send_solana_tx(&[deploy_local_ix])
+    // Add compute budget instruction to handle complex deployment
+    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(400_000);
+
+    ctx.send_solana_tx(&[compute_budget_ix, deploy_local_ix])
         .await
         .expect("InterchainToken deployment failed");
 


### PR DESCRIPTION
Fixes misleading error categorization and improved docs in the Gateway program.

Main changes:
- Reorganized error variants to properly separate "already completed" actions (0-6) from validation failures (>6)
- Fixed instruction account descriptions and updated error system comments