### PR TITLE
fix(gateway): properly close message payload PDA (C21)

### DIFF
--- a/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
@@ -78,11 +78,8 @@ impl Processor {
             return Err(ProgramError::InvalidSeeds);
         }
 
-        // Close the Buffer PDA account and reclaim its lamports
-        **payer.try_borrow_mut_lamports()? = payer
-            .lamports()
-            .saturating_add(message_payload_account.lamports());
-        **message_payload_account.try_borrow_mut_lamports()? = 0;
+        // Close the Buffer PDA account
+        program_utils::pda::close_pda(payer, message_payload_account, &crate::ID)?;
 
         Ok(())
     }


### PR DESCRIPTION
Fixes improper PDA closing in the `close_message_payload` processor that could lead to revival attacks.

Replaced manual lamport transfer with `program_utils::pda::close_pda()` utility, which now properly closes accounts completely: zeroes lamports, reassigns to System Program, and reallocates to 0 bytes

This follows the same pattern used in governance, ITS, and role management programs.