### PR TITLE
fix(its): use chain name hash for deployment approval

### DIFF
--- a/programs/axelar-solana-its/src/lib.rs
+++ b/programs/axelar-solana-its/src/lib.rs
@@ -417,12 +417,15 @@ pub fn create_deployment_approval_pda(
     destination_chain: &str,
     bump: u8,
 ) -> Result<Pubkey, ProgramError> {
+    let destination_chain_hash =
+        solana_program::keccak::hashv(&[destination_chain.as_bytes()]).to_bytes();
+
     Ok(Pubkey::create_program_address(
         &[
             seed_prefixes::DEPLOYMENT_APPROVAL_SEED,
             minter.as_ref(),
             token_id,
-            destination_chain.as_bytes(),
+            destination_chain_hash.as_ref(),
             &[bump],
         ],
         &crate::id(),
@@ -437,12 +440,15 @@ pub fn find_deployment_approval_pda(
     token_id: &[u8],
     destination_chain: &str,
 ) -> (Pubkey, u8) {
+    let destination_chain_hash =
+        solana_program::keccak::hashv(&[destination_chain.as_bytes()]).to_bytes();
+
     Pubkey::find_program_address(
         &[
             seed_prefixes::DEPLOYMENT_APPROVAL_SEED,
             minter.as_ref(),
             token_id,
-            destination_chain.as_bytes(),
+            destination_chain_hash.as_ref(),
         ],
         &crate::id(),
     )

--- a/programs/axelar-solana-its/src/processor/interchain_token.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_token.rs
@@ -713,6 +713,8 @@ pub(crate) fn approve_deploy_remote_interchain_token(
         bump,
     };
 
+    let destination_chain_hash =
+        solana_program::keccak::hashv(&[destination_chain.as_bytes()]).to_bytes();
     approval.init(
         &crate::id(),
         system_account,
@@ -722,7 +724,7 @@ pub(crate) fn approve_deploy_remote_interchain_token(
             seed_prefixes::DEPLOYMENT_APPROVAL_SEED,
             payer.key.as_ref(),
             &token_id,
-            destination_chain.as_bytes(),
+            destination_chain_hash.as_ref(),
             &[bump],
         ],
     )?;


### PR DESCRIPTION
In case the chain name had more than 32 bytes, the PDA derivation would fail.