### PR TITLE
test(its): source address test extension

### DIFF
--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -1652,6 +1652,7 @@ pub fn cpi_call_contract_with_interchain_token(
     source_program_id: Pubkey,
     pda_seeds: Vec<Vec<u8>>,
 ) -> Result<Instruction, ProgramError> {
+    let (gateway_root_pda, _) = axelar_solana_gateway::get_gateway_root_config_pda();
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
     let token_manager_ata =
@@ -1664,9 +1665,10 @@ pub fn cpi_call_contract_with_interchain_token(
         AccountMeta::new_readonly(sender, true),
         AccountMeta::new(source_account, false),
         AccountMeta::new(mint, false),
-        AccountMeta::new_readonly(token_manager_pda, false),
+        AccountMeta::new(token_manager_pda, false),
         AccountMeta::new(token_manager_ata, false),
         AccountMeta::new_readonly(token_program, false),
+        AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
         AccountMeta::new(gas_config_pda, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),

--- a/programs/axelar-solana-its/tests/module/memo_cpi_transfer.rs
+++ b/programs/axelar-solana-its/tests/module/memo_cpi_transfer.rs
@@ -1,4 +1,7 @@
-use axelar_solana_gateway_test_fixtures::{assert_msg_present_in_logs, gateway::{get_gateway_events, ProgramInvocationState}};
+use axelar_solana_gateway_test_fixtures::{
+    assert_msg_present_in_logs,
+    gateway::{get_gateway_events, ProgramInvocationState},
+};
 use axelar_solana_its::state::token_manager::Type;
 use axelar_solana_memo_program::get_counter_pda;
 use evm_contracts_test_suite::ethers::signers::Signer as EvmSigner;
@@ -26,19 +29,24 @@ struct TestSetup {
 }
 
 /// Initialize common test components and PDAs
-async fn setup_test_environment(ctx: &mut ItsTestContext) -> TestSetup {
+fn setup_test_environment(ctx: &ItsTestContext) -> TestSetup {
     let payer = ctx.solana_wallet;
     let token_id = ctx.deployed_interchain_token;
-    
+
     let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
     let token_manager_pda = axelar_solana_its::find_token_manager_pda(&its_root_pda, &token_id).0;
     let token_mint = axelar_solana_its::find_interchain_token_pda(&its_root_pda, &token_id).0;
-    
+
     let (counter_pda, _) = get_counter_pda();
     let token_program = spl_token_2022::id();
-    let counter_pda_ata = get_associated_token_address_with_program_id(&counter_pda, &token_mint, &token_program);
-    let token_manager_ata = get_associated_token_address_with_program_id(&token_manager_pda, &token_mint, &token_program);
-    
+    let counter_pda_ata =
+        get_associated_token_address_with_program_id(&counter_pda, &token_mint, &token_program);
+    let token_manager_ata = get_associated_token_address_with_program_id(
+        &token_manager_pda,
+        &token_mint,
+        &token_program,
+    );
+
     TestSetup {
         payer,
         token_id,
@@ -68,7 +76,7 @@ async fn setup_counter_pda_with_tokens(
         &setup.token_program,
     );
     ctx.send_solana_tx(&[create_ata_ix]).await.unwrap();
-    
+
     // Mint tokens to the counter PDA's account
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
         setup.token_id,
@@ -77,7 +85,8 @@ async fn setup_counter_pda_with_tokens(
         setup.payer,
         setup.token_program,
         mint_amount,
-    ).unwrap();
+    )
+    .unwrap();
     ctx.send_solana_tx(&[mint_ix]).await.unwrap();
 }
 
@@ -92,7 +101,7 @@ async fn verify_token_manager_type(ctx: &mut ItsTestContext, token_manager_pda: 
     let token_manager = token_manager_account
         .deserialize::<axelar_solana_its::state::token_manager::TokenManager>(token_manager_pda)
         .unwrap();
-    
+
     let Type::NativeInterchainToken = token_manager.ty else {
         panic!("Expected NativeInterchainToken type")
     };
@@ -108,7 +117,7 @@ fn verify_gateway_event_and_source(
     let ProgramInvocationState::Succeeded(vec_events) = &events[0] else {
         panic!("Expected successful program invocation");
     };
-    
+
     let call_contract_event = vec_events
         .iter()
         .find(|(_, event)| {
@@ -118,36 +127,32 @@ fn verify_gateway_event_and_source(
             )
         })
         .expect("CallContract event not found");
-    
+
     let (_, axelar_solana_gateway::processor::GatewayEvent::CallContract(event)) =
         call_contract_event
     else {
         panic!("Expected CallContract event");
     };
-    
+
     let gmp_payload = GMPPayload::decode(&event.payload).unwrap();
     let GMPPayload::SendToHub(hub_message) = &gmp_payload else {
         panic!("Expected SendToHub payload");
     };
-    
+
     let GMPPayload::InterchainTransfer(transfer_message) =
         GMPPayload::decode(hub_message.payload.as_ref()).unwrap()
     else {
         panic!("Expected InterchainTransfer payload in hub message");
     };
-    
+
     let source_address = transfer_message.source_address.0.as_ref();
-    assert_eq!(
-        source_address,
-        expected_source,
-        "Source address mismatch"
-    );
-    
+    assert_eq!(source_address, expected_source, "Source address mismatch");
+
     assert_eq!(
         transfer_message.amount,
         alloy_primitives::U256::from(expected_amount)
     );
-    
+
     gmp_payload
 }
 
@@ -155,15 +160,15 @@ fn verify_gateway_event_and_source(
 #[test_context(ItsTestContext)]
 #[tokio::test]
 async fn test_memo_cpi_transfer(ctx: &mut ItsTestContext) {
-    let setup = setup_test_environment(ctx).await;
+    let setup = setup_test_environment(ctx);
     verify_token_manager_type(ctx, &setup.token_manager_pda).await;
     setup_counter_pda_with_tokens(ctx, &setup, 1000u64).await;
-    
+
     let destination_chain = ctx.evm_chain_name.clone();
     let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
     let transfer_amount = 100u64;
     let gas_value = 0u128;
-    
+
     let send_transfer = axelar_solana_memo_program::instruction::send_interchain_transfer(
         &setup.counter_pda,
         &setup.its_root_pda,
@@ -180,9 +185,9 @@ async fn test_memo_cpi_transfer(ctx: &mut ItsTestContext) {
         gas_value,
     )
     .unwrap();
-    
+
     let tx = ctx.send_solana_tx(&[send_transfer]).await.unwrap();
-    
+
     verify_gateway_event_and_source(
         &tx,
         &axelar_solana_memo_program::ID.to_bytes(),
@@ -196,21 +201,22 @@ async fn test_memo_cpi_transfer(ctx: &mut ItsTestContext) {
 async fn test_cpi_transfer_fails_with_non_pda_account(ctx: &mut ItsTestContext) {
     let payer = ctx.solana_wallet;
     let token_id = ctx.deployed_interchain_token;
-    
+
     let token_mint = axelar_solana_its::find_interchain_token_pda(
         &axelar_solana_its::find_its_root_pda().0,
         &token_id,
-    ).0;
-    
+    )
+    .0;
+
     let token_program = spl_token_2022::id();
-    
+
     // Use the payer's token account instead of a PDA
     let payer_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
         &payer,
         &token_mint,
         &token_program,
     );
-    
+
     let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
         &payer,
         &payer,
@@ -218,7 +224,7 @@ async fn test_cpi_transfer_fails_with_non_pda_account(ctx: &mut ItsTestContext) 
         &token_program,
     );
     ctx.send_solana_tx(&[create_ata_ix]).await.unwrap();
-    
+
     let mint_amount = 1000u64;
     let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
         token_id,
@@ -227,9 +233,10 @@ async fn test_cpi_transfer_fails_with_non_pda_account(ctx: &mut ItsTestContext) 
         payer,
         token_program,
         mint_amount,
-    ).unwrap();
+    )
+    .unwrap();
     ctx.send_solana_tx(&[mint_ix]).await.unwrap();
-    
+
     let cpi_transfer_ix = axelar_solana_its::instruction::cpi_interchain_transfer(
         payer,
         payer_ata,
@@ -242,11 +249,12 @@ async fn test_cpi_transfer_fails_with_non_pda_account(ctx: &mut ItsTestContext) 
         0u64,
         axelar_solana_memo_program::ID,
         vec![vec![]],
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     let result = ctx.send_solana_tx(&[cpi_transfer_ix]).await;
     assert!(result.is_err());
-    
+
     assert_msg_present_in_logs(
         result.unwrap_err(),
         "Sender account must be owned by the source program",
@@ -258,41 +266,40 @@ async fn test_cpi_transfer_fails_with_non_pda_account(ctx: &mut ItsTestContext) 
 #[test_context(ItsTestContext)]
 #[tokio::test]
 async fn test_cpi_transfer_fails_with_inconsistent_seeds(ctx: &mut ItsTestContext) {
-    let setup = setup_test_environment(ctx).await;
-    
+    let setup = setup_test_environment(ctx);
+
     // Setup counter PDA with tokens
     setup_counter_pda_with_tokens(ctx, &setup, 1000u64).await;
-    
+
     // Prepare transfer parameters
     let destination_chain = ctx.evm_chain_name.clone();
     let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
     let transfer_amount = 100u64;
     let gas_value = 0u128;
-    
+
     // Use the special memo instruction that provides wrong seeds
-    let transfer_with_wrong_seeds = axelar_solana_memo_program::instruction::send_interchain_transfer_with_wrong_seeds(
-        &setup.counter_pda,
-        &setup.its_root_pda,
-        &setup.token_manager_pda,
-        &setup.token_manager_ata,
-        &setup.gateway_root_pda,
-        &setup.gas_service_root_pda,
-        &setup.token_mint,
-        &setup.token_program,
-        setup.token_id,
-        destination_chain,
-        destination_address,
-        transfer_amount,
-        gas_value,
-    ).unwrap();
-    
+    let transfer_with_wrong_seeds =
+        axelar_solana_memo_program::instruction::send_interchain_transfer_with_wrong_seeds(
+            &setup.counter_pda,
+            &setup.its_root_pda,
+            &setup.token_manager_pda,
+            &setup.token_manager_ata,
+            &setup.gateway_root_pda,
+            &setup.gas_service_root_pda,
+            &setup.token_mint,
+            &setup.token_program,
+            setup.token_id,
+            destination_chain,
+            destination_address,
+            transfer_amount,
+            gas_value,
+        )
+        .unwrap();
+
     let result = ctx.send_solana_tx(&[transfer_with_wrong_seeds]).await;
     assert!(result.is_err());
-    
-    assert_msg_present_in_logs(
-        result.unwrap_err(),
-        "PDA derivation mismatch",
-    );
+
+    assert_msg_present_in_logs(result.unwrap_err(), "PDA derivation mismatch");
 }
 
 /// Test that demonstrates the memo program can initiate CallContractWithInterchainToken through its PDA
@@ -300,59 +307,59 @@ async fn test_cpi_transfer_fails_with_inconsistent_seeds(ctx: &mut ItsTestContex
 #[test_context(ItsTestContext)]
 #[tokio::test]
 async fn test_memo_cpi_call_contract_with_interchain_token(ctx: &mut ItsTestContext) {
-    let setup = setup_test_environment(ctx).await;
+    let setup = setup_test_environment(ctx);
     verify_token_manager_type(ctx, &setup.token_manager_pda).await;
     setup_counter_pda_with_tokens(ctx, &setup, 1000u64).await;
-    
+
     let destination_chain = ctx.evm_chain_name.clone();
     let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
     let transfer_amount = 100u64;
     let gas_value = 0u128;
     let custom_data = b"execute_special_function_with_params".to_vec();
-    
+
     // Create the CallContractWithInterchainToken instruction through memo program
-    let call_contract_transfer = axelar_solana_memo_program::instruction::call_contract_with_interchain_token(
-        &setup.payer,
-        &setup.counter_pda,
-        &setup.its_root_pda,
-        &setup.token_manager_pda,
-        &setup.token_manager_ata,
-        &setup.gateway_root_pda,
-        &setup.gas_service_root_pda,
-        &setup.token_mint,
-        &setup.token_program,
-        setup.token_id,
-        destination_chain,
-        destination_address,
-        transfer_amount,
-        custom_data.clone(),
-        gas_value,
-    )
-    .unwrap();
-    
+    let call_contract_transfer =
+        axelar_solana_memo_program::instruction::call_contract_with_interchain_token(
+            &setup.counter_pda,
+            &setup.its_root_pda,
+            &setup.token_manager_pda,
+            &setup.token_manager_ata,
+            &setup.gateway_root_pda,
+            &setup.gas_service_root_pda,
+            &setup.token_mint,
+            &setup.token_program,
+            setup.token_id,
+            destination_chain,
+            destination_address,
+            transfer_amount,
+            custom_data.clone(),
+            gas_value,
+        )
+        .unwrap();
+
     let tx = ctx.send_solana_tx(&[call_contract_transfer]).await.unwrap();
-    
+
     let gmp_payload = verify_gateway_event_and_source(
         &tx,
         &axelar_solana_memo_program::ID.to_bytes(),
         transfer_amount,
     );
-    
+
     let GMPPayload::SendToHub(hub_message) = gmp_payload else {
         panic!("Expected SendToHub payload");
     };
-    
+
     let GMPPayload::InterchainTransfer(transfer_message) =
         GMPPayload::decode(hub_message.payload.as_ref()).unwrap()
     else {
         panic!("Expected InterchainTransfer payload in hub message");
     };
-    
+
     assert!(
         !transfer_message.data.is_empty(),
         "Transfer should include custom data"
     );
-    
+
     assert_eq!(
         transfer_message.data.as_ref(),
         custom_data.as_slice(),

--- a/programs/axelar-solana-its/tests/module/memo_cpi_transfer.rs
+++ b/programs/axelar-solana-its/tests/module/memo_cpi_transfer.rs
@@ -290,4 +290,160 @@ async fn test_cpi_transfer_fails_with_inconsistent_seeds(ctx: &mut ItsTestContex
     );
 }
 
-// TODO Write a scenario for the CpiCallContractWithInterchainToken instruction
+/// Test that demonstrates the memo program can initiate CallContractWithInterchainToken through its PDA
+/// This sends tokens along with additional data to execute on the destination contract
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_memo_cpi_call_contract_with_interchain_token(ctx: &mut ItsTestContext) {
+    let payer = ctx.solana_wallet;
+
+    let token_id = ctx.deployed_interchain_token;
+    let token_manager_pda = axelar_solana_its::find_token_manager_pda(
+        &axelar_solana_its::find_its_root_pda().0,
+        &token_id,
+    )
+    .0;
+    let mut token_manager_account = ctx
+        .solana_chain
+        .try_get_account_no_checks(&token_manager_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let token_manager = token_manager_account
+        .deserialize::<axelar_solana_its::state::token_manager::TokenManager>(&token_manager_pda)
+        .unwrap();
+
+    let Type::NativeInterchainToken = token_manager.ty else {
+        panic!("Expected NativeInterchainToken type")
+    };
+
+    let token_mint = axelar_solana_its::find_interchain_token_pda(
+        &axelar_solana_its::find_its_root_pda().0,
+        &token_id,
+    )
+    .0;
+
+    let (counter_pda, _) = get_counter_pda();
+
+    let token_program = spl_token_2022::id();
+    let counter_pda_ata =
+        get_associated_token_address_with_program_id(&counter_pda, &token_mint, &token_program);
+
+    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
+        &payer,
+        &counter_pda,
+        &token_mint,
+        &token_program,
+    );
+    ctx.send_solana_tx(&[create_ata_ix]).await.unwrap();
+
+    // Mint some tokens to the counter PDA's account
+    let mint_amount = 1000u64;
+    let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        token_id,
+        token_mint,
+        counter_pda_ata,
+        payer,
+        token_program,
+        mint_amount,
+    )
+    .unwrap();
+    ctx.send_solana_tx(&[mint_ix]).await.unwrap();
+
+    let destination_chain = ctx.evm_chain_name.clone();
+    let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
+    let transfer_amount = 100u64;
+    let gas_value = 0u128;
+    
+    // Create custom data to send along with the tokens
+    // This could be any arbitrary data that the destination contract needs
+    let custom_data = b"execute_special_function_with_params".to_vec();
+
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let token_manager_ata = get_associated_token_address_with_program_id(
+        &token_manager_pda,
+        &token_mint,
+        &token_program,
+    );
+    let gas_service_root_pda = ctx.solana_gas_utils.config_pda;
+
+    // Create the CallContractWithInterchainToken instruction through memo program
+    let call_contract_transfer = axelar_solana_memo_program::instruction::call_contract_with_interchain_token(
+        &payer,
+        &counter_pda,
+        &its_root_pda,
+        &token_manager_pda,
+        &token_manager_ata,
+        &ctx.solana_chain.gateway_root_pda,
+        &gas_service_root_pda,
+        &token_mint,
+        &token_program,
+        token_id,
+        destination_chain.clone(),
+        destination_address.clone(),
+        transfer_amount,
+        custom_data.clone(),
+        gas_value,
+    )
+    .unwrap();
+
+    let tx = ctx.send_solana_tx(&[call_contract_transfer]).await.unwrap();
+
+    // Verify the gateway event was emitted
+    let events = get_gateway_events(&tx);
+    let ProgramInvocationState::Succeeded(vec_events) = &events[0] else {
+        panic!("Expected successful program invocation");
+    };
+
+    // Find the CallContract event
+    let call_contract_event = vec_events
+        .iter()
+        .find(|(_, event)| {
+            matches!(
+                event,
+                axelar_solana_gateway::processor::GatewayEvent::CallContract(_)
+            )
+        })
+        .expect("CallContract event not found");
+
+    let (_, axelar_solana_gateway::processor::GatewayEvent::CallContract(event)) =
+        call_contract_event
+    else {
+        panic!("Expected CallContract event");
+    };
+
+    let gmp_payload = GMPPayload::decode(&event.payload).unwrap();
+    let GMPPayload::SendToHub(hub_message) = gmp_payload else {
+        panic!("Expected SendToHub payload");
+    };
+
+    let GMPPayload::InterchainTransfer(transfer_message) =
+        GMPPayload::decode(hub_message.payload.as_ref()).unwrap()
+    else {
+        panic!("Expected InterchainTransfer payload in hub message");
+    };
+
+    let source_address = transfer_message.source_address.0.as_ref();
+    assert_eq!(
+        source_address,
+        &axelar_solana_memo_program::ID.to_bytes(),
+        "Source address should be the memo program ID with CpiCallContractWithInterchainToken"
+    );
+
+    assert_eq!(
+        transfer_message.amount,
+        alloy_primitives::U256::from(transfer_amount)
+    );
+    
+    // Verify the custom data was included in the transfer
+    assert!(
+        !transfer_message.data.is_empty(),
+        "Transfer should include custom data"
+    );
+    
+    assert_eq!(
+        transfer_message.data.as_ref(),
+        custom_data.as_slice(),
+        "Custom data should match what was sent"
+    );
+}

--- a/programs/axelar-solana-its/tests/module/memo_cpi_transfer.rs
+++ b/programs/axelar-solana-its/tests/module/memo_cpi_transfer.rs
@@ -3,112 +3,112 @@ use axelar_solana_its::state::token_manager::Type;
 use axelar_solana_memo_program::get_counter_pda;
 use evm_contracts_test_suite::ethers::signers::Signer as EvmSigner;
 use interchain_token_transfer_gmp::GMPPayload;
-use solana_program_test::tokio;
+use solana_program::pubkey::Pubkey;
+use solana_program_test::{tokio, BanksTransactionResultWithMetadata};
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use test_context::test_context;
 
 use crate::{BorshPdaAccount, ItsTestContext};
 
-/// Test that demonstrates the memo program can initiate interchain transfers through its PDA
-#[test_context(ItsTestContext)]
-#[tokio::test]
-async fn test_memo_cpi_transfer(ctx: &mut ItsTestContext) {
-    let payer = ctx.solana_wallet;
+/// Common test setup data
+struct TestSetup {
+    payer: Pubkey,
+    token_id: [u8; 32],
+    token_mint: Pubkey,
+    token_program: Pubkey,
+    counter_pda: Pubkey,
+    counter_pda_ata: Pubkey,
+    its_root_pda: Pubkey,
+    token_manager_pda: Pubkey,
+    token_manager_ata: Pubkey,
+    gateway_root_pda: Pubkey,
+    gas_service_root_pda: Pubkey,
+}
 
+/// Initialize common test components and PDAs
+async fn setup_test_environment(ctx: &mut ItsTestContext) -> TestSetup {
+    let payer = ctx.solana_wallet;
     let token_id = ctx.deployed_interchain_token;
-    let token_manager_pda = axelar_solana_its::find_token_manager_pda(
-        &axelar_solana_its::find_its_root_pda().0,
-        &token_id,
-    )
-    .0;
+    
+    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
+    let token_manager_pda = axelar_solana_its::find_token_manager_pda(&its_root_pda, &token_id).0;
+    let token_mint = axelar_solana_its::find_interchain_token_pda(&its_root_pda, &token_id).0;
+    
+    let (counter_pda, _) = get_counter_pda();
+    let token_program = spl_token_2022::id();
+    let counter_pda_ata = get_associated_token_address_with_program_id(&counter_pda, &token_mint, &token_program);
+    let token_manager_ata = get_associated_token_address_with_program_id(&token_manager_pda, &token_mint, &token_program);
+    
+    TestSetup {
+        payer,
+        token_id,
+        token_mint,
+        token_program,
+        counter_pda,
+        counter_pda_ata,
+        its_root_pda,
+        token_manager_pda,
+        token_manager_ata,
+        gateway_root_pda: ctx.solana_chain.gateway_root_pda,
+        gas_service_root_pda: ctx.solana_gas_utils.config_pda,
+    }
+}
+
+/// Create ATA and mint tokens to the counter PDA
+async fn setup_counter_pda_with_tokens(
+    ctx: &mut ItsTestContext,
+    setup: &TestSetup,
+    mint_amount: u64,
+) {
+    // Create the counter PDA's ATA
+    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
+        &setup.payer,
+        &setup.counter_pda,
+        &setup.token_mint,
+        &setup.token_program,
+    );
+    ctx.send_solana_tx(&[create_ata_ix]).await.unwrap();
+    
+    // Mint tokens to the counter PDA's account
+    let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
+        setup.token_id,
+        setup.token_mint,
+        setup.counter_pda_ata,
+        setup.payer,
+        setup.token_program,
+        mint_amount,
+    ).unwrap();
+    ctx.send_solana_tx(&[mint_ix]).await.unwrap();
+}
+
+/// Verify that a NativeInterchainToken type token manager exists
+async fn verify_token_manager_type(ctx: &mut ItsTestContext, token_manager_pda: &Pubkey) {
     let mut token_manager_account = ctx
         .solana_chain
-        .try_get_account_no_checks(&token_manager_pda)
+        .try_get_account_no_checks(token_manager_pda)
         .await
         .unwrap()
         .unwrap();
     let token_manager = token_manager_account
-        .deserialize::<axelar_solana_its::state::token_manager::TokenManager>(&token_manager_pda)
+        .deserialize::<axelar_solana_its::state::token_manager::TokenManager>(token_manager_pda)
         .unwrap();
-
+    
     let Type::NativeInterchainToken = token_manager.ty else {
         panic!("Expected NativeInterchainToken type")
     };
+}
 
-    let token_mint = axelar_solana_its::find_interchain_token_pda(
-        &axelar_solana_its::find_its_root_pda().0,
-        &token_id,
-    )
-    .0;
-
-    let (counter_pda, _) = get_counter_pda();
-
-    let token_program = spl_token_2022::id();
-    let counter_pda_ata =
-        get_associated_token_address_with_program_id(&counter_pda, &token_mint, &token_program);
-
-    // Create the counter PDA's ATA
-    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
-        &payer,
-        &counter_pda,
-        &token_mint,
-        &token_program,
-    );
-    ctx.send_solana_tx(&[create_ata_ix]).await.unwrap();
-
-    // Mint some tokens to the counter PDA's account
-    let mint_amount = 1000u64;
-    let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
-        token_id,
-        token_mint,
-        counter_pda_ata,
-        payer,
-        token_program,
-        mint_amount,
-    )
-    .unwrap();
-    ctx.send_solana_tx(&[mint_ix]).await.unwrap();
-
-    let destination_chain = ctx.evm_chain_name.clone();
-    let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
-    let transfer_amount = 100u64;
-    let gas_value = 0u128;
-
-    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
-    let token_manager_ata = get_associated_token_address_with_program_id(
-        &token_manager_pda,
-        &token_mint,
-        &token_program,
-    );
-    let gas_service_root_pda = ctx.solana_gas_utils.config_pda;
-
-    // Create the SendInterchainTransfer instruction through memo program
-    let send_transfer = axelar_solana_memo_program::instruction::send_interchain_transfer(
-        &counter_pda,
-        &its_root_pda,
-        &token_manager_pda,
-        &token_manager_ata,
-        &ctx.solana_chain.gateway_root_pda,
-        &gas_service_root_pda,
-        &token_mint,
-        &token_program,
-        token_id,
-        destination_chain.clone(),
-        destination_address.clone(),
-        transfer_amount,
-        gas_value,
-    )
-    .unwrap();
-
-    let tx = ctx.send_solana_tx(&[send_transfer]).await.unwrap();
-
-    // Verify the gateway event was emitted
-    let events = get_gateway_events(&tx);
+/// Extract and verify the CallContract event from a transaction
+fn verify_gateway_event_and_source(
+    tx: &BanksTransactionResultWithMetadata,
+    expected_source: &[u8; 32],
+    expected_amount: u64,
+) -> GMPPayload {
+    let events = get_gateway_events(tx);
     let ProgramInvocationState::Succeeded(vec_events) = &events[0] else {
         panic!("Expected successful program invocation");
     };
-
-    // Find the CallContract event
+    
     let call_contract_event = vec_events
         .iter()
         .find(|(_, event)| {
@@ -118,34 +118,82 @@ async fn test_memo_cpi_transfer(ctx: &mut ItsTestContext) {
             )
         })
         .expect("CallContract event not found");
-
+    
     let (_, axelar_solana_gateway::processor::GatewayEvent::CallContract(event)) =
         call_contract_event
     else {
         panic!("Expected CallContract event");
     };
-
+    
     let gmp_payload = GMPPayload::decode(&event.payload).unwrap();
-    let GMPPayload::SendToHub(hub_message) = gmp_payload else {
+    let GMPPayload::SendToHub(hub_message) = &gmp_payload else {
         panic!("Expected SendToHub payload");
     };
-
+    
     let GMPPayload::InterchainTransfer(transfer_message) =
         GMPPayload::decode(hub_message.payload.as_ref()).unwrap()
     else {
         panic!("Expected InterchainTransfer payload in hub message");
     };
-
+    
     let source_address = transfer_message.source_address.0.as_ref();
     assert_eq!(
         source_address,
-        &axelar_solana_memo_program::ID.to_bytes(),
-        "Source address should be the memo program ID with CpiInterchainTransfer"
+        expected_source,
+        "Source address mismatch"
     );
-
+    
     assert_eq!(
         transfer_message.amount,
-        alloy_primitives::U256::from(transfer_amount)
+        alloy_primitives::U256::from(expected_amount)
+    );
+    
+    gmp_payload
+}
+
+/// Test that demonstrates the memo program can initiate interchain transfers through its PDA
+#[test_context(ItsTestContext)]
+#[tokio::test]
+async fn test_memo_cpi_transfer(ctx: &mut ItsTestContext) {
+    let setup = setup_test_environment(ctx).await;
+    
+    // Verify token manager type
+    verify_token_manager_type(ctx, &setup.token_manager_pda).await;
+    
+    // Setup counter PDA with tokens
+    setup_counter_pda_with_tokens(ctx, &setup, 1000u64).await;
+    
+    // Prepare transfer parameters
+    let destination_chain = ctx.evm_chain_name.clone();
+    let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
+    let transfer_amount = 100u64;
+    let gas_value = 0u128;
+    
+    // Create the SendInterchainTransfer instruction through memo program
+    let send_transfer = axelar_solana_memo_program::instruction::send_interchain_transfer(
+        &setup.counter_pda,
+        &setup.its_root_pda,
+        &setup.token_manager_pda,
+        &setup.token_manager_ata,
+        &setup.gateway_root_pda,
+        &setup.gas_service_root_pda,
+        &setup.token_mint,
+        &setup.token_program,
+        setup.token_id,
+        destination_chain,
+        destination_address,
+        transfer_amount,
+        gas_value,
+    )
+    .unwrap();
+    
+    let tx = ctx.send_solana_tx(&[send_transfer]).await.unwrap();
+    
+    // Verify the event and source address
+    verify_gateway_event_and_source(
+        &tx,
+        &axelar_solana_memo_program::ID.to_bytes(),
+        transfer_amount,
     );
 }
 
@@ -295,147 +343,61 @@ async fn test_cpi_transfer_fails_with_inconsistent_seeds(ctx: &mut ItsTestContex
 #[test_context(ItsTestContext)]
 #[tokio::test]
 async fn test_memo_cpi_call_contract_with_interchain_token(ctx: &mut ItsTestContext) {
-    let payer = ctx.solana_wallet;
-
-    let token_id = ctx.deployed_interchain_token;
-    let token_manager_pda = axelar_solana_its::find_token_manager_pda(
-        &axelar_solana_its::find_its_root_pda().0,
-        &token_id,
-    )
-    .0;
-    let mut token_manager_account = ctx
-        .solana_chain
-        .try_get_account_no_checks(&token_manager_pda)
-        .await
-        .unwrap()
-        .unwrap();
-    let token_manager = token_manager_account
-        .deserialize::<axelar_solana_its::state::token_manager::TokenManager>(&token_manager_pda)
-        .unwrap();
-
-    let Type::NativeInterchainToken = token_manager.ty else {
-        panic!("Expected NativeInterchainToken type")
-    };
-
-    let token_mint = axelar_solana_its::find_interchain_token_pda(
-        &axelar_solana_its::find_its_root_pda().0,
-        &token_id,
-    )
-    .0;
-
-    let (counter_pda, _) = get_counter_pda();
-
-    let token_program = spl_token_2022::id();
-    let counter_pda_ata =
-        get_associated_token_address_with_program_id(&counter_pda, &token_mint, &token_program);
-
-    let create_ata_ix = spl_associated_token_account::instruction::create_associated_token_account(
-        &payer,
-        &counter_pda,
-        &token_mint,
-        &token_program,
-    );
-    ctx.send_solana_tx(&[create_ata_ix]).await.unwrap();
-
-    // Mint some tokens to the counter PDA's account
-    let mint_amount = 1000u64;
-    let mint_ix = axelar_solana_its::instruction::interchain_token::mint(
-        token_id,
-        token_mint,
-        counter_pda_ata,
-        payer,
-        token_program,
-        mint_amount,
-    )
-    .unwrap();
-    ctx.send_solana_tx(&[mint_ix]).await.unwrap();
-
+    let setup = setup_test_environment(ctx).await;
+    
+    // Verify token manager type
+    verify_token_manager_type(ctx, &setup.token_manager_pda).await;
+    
+    // Setup counter PDA with tokens
+    setup_counter_pda_with_tokens(ctx, &setup, 1000u64).await;
+    
+    // Prepare transfer parameters
     let destination_chain = ctx.evm_chain_name.clone();
     let destination_address = ctx.evm_signer.wallet.address().as_bytes().to_vec();
     let transfer_amount = 100u64;
     let gas_value = 0u128;
-    
-    // Create custom data to send along with the tokens
-    // This could be any arbitrary data that the destination contract needs
     let custom_data = b"execute_special_function_with_params".to_vec();
-
-    let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
-    let token_manager_ata = get_associated_token_address_with_program_id(
-        &token_manager_pda,
-        &token_mint,
-        &token_program,
-    );
-    let gas_service_root_pda = ctx.solana_gas_utils.config_pda;
-
+    
     // Create the CallContractWithInterchainToken instruction through memo program
     let call_contract_transfer = axelar_solana_memo_program::instruction::call_contract_with_interchain_token(
-        &payer,
-        &counter_pda,
-        &its_root_pda,
-        &token_manager_pda,
-        &token_manager_ata,
-        &ctx.solana_chain.gateway_root_pda,
-        &gas_service_root_pda,
-        &token_mint,
-        &token_program,
-        token_id,
-        destination_chain.clone(),
-        destination_address.clone(),
+        &setup.payer,
+        &setup.counter_pda,
+        &setup.its_root_pda,
+        &setup.token_manager_pda,
+        &setup.token_manager_ata,
+        &setup.gateway_root_pda,
+        &setup.gas_service_root_pda,
+        &setup.token_mint,
+        &setup.token_program,
+        setup.token_id,
+        destination_chain,
+        destination_address,
         transfer_amount,
         custom_data.clone(),
         gas_value,
     )
     .unwrap();
-
+    
     let tx = ctx.send_solana_tx(&[call_contract_transfer]).await.unwrap();
-
-    // Verify the gateway event was emitted
-    let events = get_gateway_events(&tx);
-    let ProgramInvocationState::Succeeded(vec_events) = &events[0] else {
-        panic!("Expected successful program invocation");
-    };
-
-    // Find the CallContract event
-    let call_contract_event = vec_events
-        .iter()
-        .find(|(_, event)| {
-            matches!(
-                event,
-                axelar_solana_gateway::processor::GatewayEvent::CallContract(_)
-            )
-        })
-        .expect("CallContract event not found");
-
-    let (_, axelar_solana_gateway::processor::GatewayEvent::CallContract(event)) =
-        call_contract_event
-    else {
-        panic!("Expected CallContract event");
-    };
-
-    let gmp_payload = GMPPayload::decode(&event.payload).unwrap();
+    
+    // Verify the event and source address
+    let gmp_payload = verify_gateway_event_and_source(
+        &tx,
+        &axelar_solana_memo_program::ID.to_bytes(),
+        transfer_amount,
+    );
+    
+    // Additional verification for custom data
     let GMPPayload::SendToHub(hub_message) = gmp_payload else {
         panic!("Expected SendToHub payload");
     };
-
+    
     let GMPPayload::InterchainTransfer(transfer_message) =
         GMPPayload::decode(hub_message.payload.as_ref()).unwrap()
     else {
         panic!("Expected InterchainTransfer payload in hub message");
     };
-
-    let source_address = transfer_message.source_address.0.as_ref();
-    assert_eq!(
-        source_address,
-        &axelar_solana_memo_program::ID.to_bytes(),
-        "Source address should be the memo program ID with CpiCallContractWithInterchainToken"
-    );
-
-    assert_eq!(
-        transfer_message.amount,
-        alloy_primitives::U256::from(transfer_amount)
-    );
     
-    // Verify the custom data was included in the transfer
     assert!(
         !transfer_message.data.is_empty(),
         "Transfer should include custom data"

--- a/programs/axelar-solana-memo-program/src/instruction.rs
+++ b/programs/axelar-solana-memo-program/src/instruction.rs
@@ -251,13 +251,15 @@ pub fn send_interchain_transfer_with_wrong_seeds(
     amount: u64,
     gas_value: u128,
 ) -> Result<Instruction, ProgramError> {
-    let data = to_vec(&AxelarMemoInstruction::SendInterchainTransferWithWrongSeeds {
-        token_id,
-        destination_chain,
-        destination_address,
-        amount,
-        gas_value,
-    })?;
+    let data = to_vec(
+        &AxelarMemoInstruction::SendInterchainTransferWithWrongSeeds {
+            token_id,
+            destination_chain,
+            destination_address,
+            amount,
+            gas_value,
+        },
+    )?;
 
     // Derive the source ATA (counter PDA's token account)
     let source_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
@@ -301,7 +303,6 @@ pub fn send_interchain_transfer_with_wrong_seeds(
 /// This sends tokens along with additional data to call a contract on the destination
 #[allow(clippy::too_many_arguments)]
 pub fn call_contract_with_interchain_token(
-    payer: &Pubkey,
     memo_counter_pda: &Pubkey,
     its_root_pda: &Pubkey,
     token_manager_pda: &Pubkey,

--- a/programs/axelar-solana-memo-program/src/instruction.rs
+++ b/programs/axelar-solana-memo-program/src/instruction.rs
@@ -100,6 +100,23 @@ pub enum AxelarMemoInstruction {
         /// Gas value for the transfer
         gas_value: u128,
     },
+
+    /// Send an interchain token transfer with additional data to call a contract on the destination
+    /// This uses CpiCallContractWithInterchainToken to send tokens along with arbitrary data
+    CallContractWithInterchainToken {
+        /// Token ID for the transfer
+        token_id: [u8; 32],
+        /// Destination chain
+        destination_chain: String,
+        /// Destination address
+        destination_address: Vec<u8>,
+        /// Amount to transfer
+        amount: u64,
+        /// Additional data to pass to the destination contract
+        data: Vec<u8>,
+        /// Gas value for the transfer
+        gas_value: u128,
+    },
 }
 
 /// Creates a [`AxelarMemoInstruction::Initialize`] instruction.
@@ -277,6 +294,73 @@ pub fn send_interchain_transfer_with_wrong_seeds(
         program_id: crate::ID,
         accounts,
         data,
+    })
+}
+
+/// Creates a [`AxelarMemoInstruction::CallContractWithInterchainToken`] instruction.
+/// This sends tokens along with additional data to call a contract on the destination
+#[allow(clippy::too_many_arguments)]
+pub fn call_contract_with_interchain_token(
+    payer: &Pubkey,
+    memo_counter_pda: &Pubkey,
+    its_root_pda: &Pubkey,
+    token_manager_pda: &Pubkey,
+    token_manager_ata: &Pubkey,
+    gateway_root_pda: &Pubkey,
+    gas_service_root_pda: &Pubkey,
+    token_mint: &Pubkey,
+    token_program: &Pubkey,
+    token_id: [u8; 32],
+    destination_chain: String,
+    destination_address: Vec<u8>,
+    amount: u64,
+    data: Vec<u8>,
+    gas_value: u128,
+) -> Result<Instruction, ProgramError> {
+    let instruction_data = to_vec(&AxelarMemoInstruction::CallContractWithInterchainToken {
+        token_id,
+        destination_chain,
+        destination_address,
+        amount,
+        data,
+        gas_value,
+    })?;
+
+    // Derive the source ATA (counter PDA's token account)
+    let source_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
+        memo_counter_pda,
+        token_mint,
+        token_program,
+    );
+
+    // Additional required accounts for proper ITS instruction
+    let gateway_program = axelar_solana_gateway::id();
+    let gas_service_program = axelar_solana_gas_service::id();
+    let (call_contract_signing_pda, _) =
+        axelar_solana_gateway::get_call_contract_signing_pda(axelar_solana_its::id());
+    let its_program = axelar_solana_its::id();
+
+    let accounts = vec![
+        AccountMeta::new(*memo_counter_pda, false),
+        AccountMeta::new_readonly(*its_root_pda, false),
+        AccountMeta::new(*token_manager_pda, false),
+        AccountMeta::new(source_ata, false),
+        AccountMeta::new(*token_manager_ata, false),
+        AccountMeta::new_readonly(*gateway_root_pda, false),
+        AccountMeta::new_readonly(gateway_program, false),
+        AccountMeta::new(*gas_service_root_pda, false),
+        AccountMeta::new_readonly(gas_service_program, false),
+        AccountMeta::new(*token_mint, false),
+        AccountMeta::new_readonly(*token_program, false),
+        AccountMeta::new_readonly(call_contract_signing_pda, false),
+        AccountMeta::new_readonly(its_program, false),
+        AccountMeta::new_readonly(system_program::ID, false),
+    ];
+
+    Ok(Instruction {
+        program_id: crate::ID,
+        accounts,
+        data: instruction_data,
     })
 }
 

--- a/programs/axelar-solana-memo-program/src/processor.rs
+++ b/programs/axelar-solana-memo-program/src/processor.rs
@@ -179,6 +179,24 @@ pub fn process_native_ix(
                 gas_value,
             )?;
         }
+        AxelarMemoInstruction::SendInterchainTransferWithWrongSeeds {
+            token_id,
+            destination_chain,
+            destination_address,
+            amount,
+            gas_value,
+        } => {
+            msg!("Instruction: SendInterchainTransferWithWrongSeeds");
+            process_send_interchain_transfer_with_wrong_seeds(
+                program_id,
+                accounts,
+                token_id,
+                destination_chain,
+                destination_address,
+                amount,
+                gas_value,
+            )?;
+        }
         AxelarMemoInstruction::Initialize { counter_pda_bump } => {
             msg!("Instruction: Initialize");
             process_initialize_memo_program_counter(program_id, accounts, counter_pda_bump)?;
@@ -358,4 +376,92 @@ pub fn process_initialize_memo_program_counter(
         counter,
         &[&[bump]],
     )
+}
+
+/// Process SendInterchainTransferWithWrongSeeds instruction - identical to the regular transfer
+/// but uses wrong seeds to test validation logic
+pub fn process_send_interchain_transfer_with_wrong_seeds(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo<'_>],
+    token_id: [u8; 32],
+    destination_chain: String,
+    destination_address: Vec<u8>,
+    amount: u64,
+    gas_value: u128,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let counter_pda = next_account_info(accounts_iter)?;
+    let its_root_pda = next_account_info(accounts_iter)?;
+    let token_manager_pda = next_account_info(accounts_iter)?;
+    let source_ata = next_account_info(accounts_iter)?;
+    let token_manager_ata = next_account_info(accounts_iter)?;
+    let gateway_root_pda = next_account_info(accounts_iter)?;
+    let gateway_program_account = next_account_info(accounts_iter)?;
+    let gas_service_root_pda = next_account_info(accounts_iter)?;
+    let gas_service_program_account = next_account_info(accounts_iter)?;
+    let token_mint = next_account_info(accounts_iter)?;
+    let token_program = next_account_info(accounts_iter)?;
+    let call_contract_signing_account = next_account_info(accounts_iter)?;
+    let its_program_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    let counter_pda_account = counter_pda.check_initialized_pda::<Counter>(program_id)?;
+    assert_counter_pda_seeds(&counter_pda_account, counter_pda.key);
+    let counter_bump = counter_pda_account.bump;
+
+    let expected_source_ata =
+        spl_associated_token_account::get_associated_token_address_with_program_id(
+            counter_pda.key,
+            token_mint.key,
+            token_program.key,
+        );
+    if source_ata.key != &expected_source_ata {
+        msg!(
+            "Invalid source ATA. Expected: {}, Got: {}",
+            expected_source_ata,
+            source_ata.key
+        );
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let wrong_pda_seeds = vec![b"wrong_seed".to_vec()];
+    let transfer_ix = axelar_solana_its::instruction::cpi_interchain_transfer(
+        *counter_pda.key,
+        *source_ata.key,
+        token_id,
+        destination_chain.clone(),
+        destination_address,
+        amount,
+        *token_mint.key,
+        *token_program.key,
+        gas_value
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+        crate::ID,
+        wrong_pda_seeds,
+    )?;
+
+    invoke_signed(
+        &transfer_ix,
+        &[
+            counter_pda.clone(),
+            source_ata.clone(),
+            token_mint.clone(),
+            token_manager_pda.clone(),
+            token_manager_ata.clone(),
+            token_program.clone(),
+            gateway_root_pda.clone(),
+            gateway_program_account.clone(),
+            gas_service_root_pda.clone(),
+            gas_service_program_account.clone(),
+            system_program.clone(),
+            its_root_pda.clone(),
+            call_contract_signing_account.clone(),
+            its_program_account.clone(),
+        ],
+        &[&[&[counter_bump]]],
+    )?;
+
+    Ok(())
 }

--- a/programs/axelar-solana-memo-program/src/processor.rs
+++ b/programs/axelar-solana-memo-program/src/processor.rs
@@ -487,6 +487,7 @@ pub fn process_send_interchain_transfer_with_wrong_seeds(
 }
 
 /// Process CallContractWithInterchainToken instruction - sends tokens with additional data
+#[allow(clippy::too_many_arguments)]
 pub fn process_call_contract_with_interchain_token(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],

--- a/programs/axelar-solana-memo-program/src/processor.rs
+++ b/programs/axelar-solana-memo-program/src/processor.rs
@@ -197,6 +197,26 @@ pub fn process_native_ix(
                 gas_value,
             )?;
         }
+        AxelarMemoInstruction::CallContractWithInterchainToken {
+            token_id,
+            destination_chain,
+            destination_address,
+            amount,
+            data,
+            gas_value,
+        } => {
+            msg!("Instruction: CallContractWithInterchainToken");
+            process_call_contract_with_interchain_token(
+                program_id,
+                accounts,
+                token_id,
+                destination_chain,
+                destination_address,
+                amount,
+                data,
+                gas_value,
+            )?;
+        }
         AxelarMemoInstruction::Initialize { counter_pda_bump } => {
             msg!("Instruction: Initialize");
             process_initialize_memo_program_counter(program_id, accounts, counter_pda_bump)?;
@@ -462,6 +482,102 @@ pub fn process_send_interchain_transfer_with_wrong_seeds(
         ],
         &[&[&[counter_bump]]],
     )?;
+
+    Ok(())
+}
+
+/// Process CallContractWithInterchainToken instruction - sends tokens with additional data
+pub fn process_call_contract_with_interchain_token(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo<'_>],
+    token_id: [u8; 32],
+    destination_chain: String,
+    destination_address: Vec<u8>,
+    amount: u64,
+    data: Vec<u8>,
+    gas_value: u128,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let counter_pda = next_account_info(accounts_iter)?;
+    let its_root_pda = next_account_info(accounts_iter)?;
+    let token_manager_pda = next_account_info(accounts_iter)?;
+    let source_ata = next_account_info(accounts_iter)?;
+    let token_manager_ata = next_account_info(accounts_iter)?;
+    let gateway_root_pda = next_account_info(accounts_iter)?;
+    let gateway_program_account = next_account_info(accounts_iter)?;
+    let gas_service_root_pda = next_account_info(accounts_iter)?;
+    let gas_service_program_account = next_account_info(accounts_iter)?;
+    let token_mint = next_account_info(accounts_iter)?;
+    let token_program = next_account_info(accounts_iter)?;
+    let call_contract_signing_account = next_account_info(accounts_iter)?;
+    let its_program_account = next_account_info(accounts_iter)?;
+    let system_program = next_account_info(accounts_iter)?;
+
+    let counter_pda_account = counter_pda.check_initialized_pda::<Counter>(program_id)?;
+    assert_counter_pda_seeds(&counter_pda_account, counter_pda.key);
+    let counter_bump = counter_pda_account.bump;
+
+    let expected_source_ata =
+        spl_associated_token_account::get_associated_token_address_with_program_id(
+            counter_pda.key,
+            token_mint.key,
+            token_program.key,
+        );
+    if source_ata.key != &expected_source_ata {
+        msg!(
+            "Invalid source ATA. Expected: {}, Got: {}",
+            expected_source_ata,
+            source_ata.key
+        );
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Use correct seeds for the counter PDA (empty seeds)
+    let pda_seeds = vec![];
+    let transfer_ix = axelar_solana_its::instruction::cpi_call_contract_with_interchain_token(
+        *counter_pda.key,
+        *source_ata.key,
+        token_id,
+        destination_chain.clone(),
+        destination_address.clone(),
+        amount,
+        *token_mint.key,
+        data.clone(),
+        *token_program.key,
+        gas_value
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+        crate::ID,
+        pda_seeds,
+    )?;
+
+    invoke_signed(
+        &transfer_ix,
+        &[
+            counter_pda.clone(),
+            source_ata.clone(),
+            token_mint.clone(),
+            token_manager_pda.clone(),
+            token_manager_ata.clone(),
+            token_program.clone(),
+            gateway_root_pda.clone(),
+            gateway_program_account.clone(),
+            gas_service_root_pda.clone(),
+            gas_service_program_account.clone(),
+            system_program.clone(),
+            its_root_pda.clone(),
+            call_contract_signing_account.clone(),
+            its_program_account.clone(),
+        ],
+        &[&[&[counter_bump]]],
+    )?;
+
+    msg!("CallContractWithInterchainToken initiated from memo program PDA");
+    msg!("Token ID: {:?}", token_id);
+    msg!("Destination chain: {}", destination_chain);
+    msg!("Amount: {}", amount);
+    msg!("Data length: {}", data.len());
 
     Ok(())
 }


### PR DESCRIPTION
#235 made the source address depend on the nature of the sender, with the source address now being the program ID if the sender is a PDA.

This PRs adds three testing scenarios:

1. test_cpi_transfer_fails_with_non_pda_account
2. test_cpi_transfer_fails_with_inconsistent_seeds
3. test_memo_cpi_call_contract_with_interchain_token

A couple of instructions were added to the Memo program to make this possible:

1. SendInterchainTransferWithWrongSeeds
2. CallContractWithInterchainToken