### PR TITLE
chore(its): remove not addressed TODOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ name = "axelar-solana-its"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-sol-types",
  "anyhow",
  "axelar-message-primitives",
  "axelar-solana-encoding",

--- a/helpers/axelar-message-primitives/src/payload/encoding/abi_encoding.rs
+++ b/helpers/axelar-message-primitives/src/payload/encoding/abi_encoding.rs
@@ -17,9 +17,6 @@ impl<'payload> DataPayload<'payload> {
     /// - single byte indicating the encoding scheme.
     /// - encoded: The first element is the payload without the accounts.
     /// - encoded: The second element is the list of Solana accounts.
-    ///
-    /// FIXME: this function is very inefficient because it allocates up to 5
-    /// vectors.
     pub(super) fn encode_abi_encoding(&self) -> Result<Vec<u8>, PayloadError> {
         let mut writer_vec = self.encoding_scheme_prefixed_array();
         let gateway_payload = SolanaGatewayPayload {

--- a/helpers/program-utils/src/pda.rs
+++ b/helpers/program-utils/src/pda.rs
@@ -16,7 +16,6 @@ use std::borrow::Borrow;
 use std::io::Write;
 
 /// Initialize a PDA by writing borsh serialisable data to the buffer
-// TODO add constraint that the T: IsInitialized + Pack + BorshSerialize
 pub fn init_pda<'a, 'b, T: solana_program::program_pack::Pack>(
     funder_info: &'a AccountInfo<'b>,
     to_create: &'a AccountInfo<'b>,
@@ -174,7 +173,6 @@ pub fn close_pda(
 /// PDA
 pub trait ValidPDA {
     /// Check if the account is an initialized PDA
-    // TODO add constraint that the T: IsInitialized + Pack + BorshSerialize
     fn check_initialized_pda<T: solana_program::program_pack::Pack>(
         &self,
         expected_owner_program_id: &Pubkey,


### PR DESCRIPTION
It's not trivial to remove the allocations. As for the TODOs within the pda.rs, those constraints are not really necessary.