### PR TITLE
fix(gateway): avoid relying on the executable flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ name = "axelar-solana-its"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-sol-types",
  "anyhow",
  "axelar-message-primitives",
  "axelar-solana-encoding",


### PR DESCRIPTION
simply check whether a signing PDA is provided, as it means that the sender is a program, otherwise the sender itself should be a signer - thus is not a program.