### PR TITLE
feat(gateway): require explicit signing verifier set hash for payload verification sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ name = "axelar-solana-its"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-sol-types",
  "anyhow",
  "axelar-message-primitives",
  "axelar-solana-encoding",

--- a/bindings/anchor_lib/axelar-solana-gateway.rs
+++ b/bindings/anchor_lib/axelar-solana-gateway.rs
@@ -48,6 +48,7 @@ pub mod axelar_solana_gateway {
     pub fn initialize_payload_verification_session(
         ctx: Context<InitializePayloadVerificationSession>,
         payload_merkle_root: [u8; 32],
+        signing_verifier_set_hash: [u8; 32],
     ) -> Result<()> {
         Ok(())
     }

--- a/bindings/generated/axelar-solana-gateway/idl.json
+++ b/bindings/generated/axelar-solana-gateway/idl.json
@@ -238,6 +238,15 @@
               32
             ]
           }
+        },
+        {
+          "name": "signingVerifierSetHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
         }
       ]
     },

--- a/bindings/generated/axelar-solana-gateway/src/coder/accounts.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/accounts.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as B from "@native-to-anchor/buffer-layout";
-import { AccountsCoder, Idl } from "@project-serum/anchor";
-import { IdlTypeDef } from "@project-serum/anchor/dist/cjs/idl";
+import { AccountsCoder, Idl } from "@coral-xyz/anchor";
+import { IdlTypeDef } from "@coral-xyz/anchor/dist/cjs/idl";
 
 export class AxelarSolanaGatewayAccountsCoder<A extends string = string>
   implements AccountsCoder

--- a/bindings/generated/axelar-solana-gateway/src/coder/events.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/events.ts
@@ -1,5 +1,5 @@
-import { Idl, Event, EventCoder } from "@project-serum/anchor";
-import { IdlEvent } from "@project-serum/anchor/dist/cjs/idl";
+import { Idl, Event, EventCoder } from "@coral-xyz/anchor";
+import { IdlEvent } from "@coral-xyz/anchor/dist/cjs/idl";
 
 export class AxelarSolanaGatewayEventsCoder implements EventCoder {
   constructor(_idl: Idl) {}

--- a/bindings/generated/axelar-solana-gateway/src/coder/index.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/index.ts
@@ -1,4 +1,4 @@
-import { Idl, Coder } from "@project-serum/anchor";
+import { Idl, Coder } from "@coral-xyz/anchor";
 
 import { AxelarSolanaGatewayAccountsCoder } from "./accounts";
 import { AxelarSolanaGatewayEventsCoder } from "./events";

--- a/bindings/generated/axelar-solana-gateway/src/coder/instructions.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/instructions.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import * as B from "@native-to-anchor/buffer-layout";
-import { Idl, InstructionCoder } from "@project-serum/anchor";
+import { Idl, InstructionCoder } from "@coral-xyz/anchor";
 
 export class AxelarSolanaGatewayInstructionCoder implements InstructionCoder {
   constructor(_idl: Idl) {}
@@ -136,10 +136,16 @@ function encodeInitializeConfig({
 
 function encodeInitializePayloadVerificationSession({
   payloadMerkleRoot,
+  signingVerifierSetHash,
 }: any): Buffer {
   return encodeData(
-    { initializePayloadVerificationSession: { payloadMerkleRoot } },
-    1 + 1 * 32
+    {
+      initializePayloadVerificationSession: {
+        payloadMerkleRoot,
+        signingVerifierSetHash,
+      },
+    },
+    1 + 1 * 32 + 1 * 32
   );
 }
 
@@ -286,7 +292,10 @@ LAYOUT.addVariant(
 );
 LAYOUT.addVariant(
   4,
-  B.struct([B.seq(B.u8(), 32, "payloadMerkleRoot")]),
+  B.struct([
+    B.seq(B.u8(), 32, "payloadMerkleRoot"),
+    B.seq(B.u8(), 32, "signingVerifierSetHash"),
+  ]),
   "initializePayloadVerificationSession"
 );
 LAYOUT.addVariant(

--- a/bindings/generated/axelar-solana-gateway/src/coder/state.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/state.ts
@@ -1,4 +1,4 @@
-import { Idl, StateCoder } from "@project-serum/anchor";
+import { Idl, StateCoder } from "@coral-xyz/anchor";
 
 export class AxelarSolanaGatewayStateCoder implements StateCoder {
   constructor(_idl: Idl) {}

--- a/bindings/generated/axelar-solana-gateway/src/coder/types.ts
+++ b/bindings/generated/axelar-solana-gateway/src/coder/types.ts
@@ -1,4 +1,4 @@
-import { Idl, TypesCoder } from "@project-serum/anchor";
+import { Idl, TypesCoder } from "@coral-xyz/anchor";
 
 export class AxelarSolanaGatewayTypesCoder implements TypesCoder {
   constructor(_idl: Idl) {}

--- a/bindings/generated/axelar-solana-gateway/src/program.ts
+++ b/bindings/generated/axelar-solana-gateway/src/program.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { Program, AnchorProvider } from "@project-serum/anchor";
+import { Program, AnchorProvider } from "@coral-xyz/anchor";
 
 import { AxelarSolanaGatewayCoder } from "./coder";
 
@@ -245,6 +245,12 @@ type AxelarSolanaGateway = {
       args: [
         {
           name: "payloadMerkleRoot";
+          type: {
+            array: ["u8", 32];
+          };
+        },
+        {
+          name: "signingVerifierSetHash";
           type: {
             array: ["u8", 32];
           };
@@ -1083,6 +1089,12 @@ const IDL: AxelarSolanaGateway = {
       args: [
         {
           name: "payloadMerkleRoot",
+          type: {
+            array: ["u8", 32],
+          },
+        },
+        {
+          name: "signingVerifierSetHash",
           type: {
             array: ["u8", 32],
           },

--- a/bindings/tests/gateway.ts
+++ b/bindings/tests/gateway.ts
@@ -133,7 +133,7 @@ describe("Ping Gateway", () => {
     const payer = await getKeypairFromFile();
     try {
       const tx = await program.methods
-        .initializePayloadVerificationSession([1, 2])
+        .initializePayloadVerificationSession([1, 2], [3, 4])
         .accounts({
           payer: payer.publicKey,
           gatewayConfigPda: payer.publicKey,

--- a/crates/axelar-solana-encoding/src/types/execute_data.rs
+++ b/crates/axelar-solana-encoding/src/types/execute_data.rs
@@ -22,7 +22,17 @@ pub struct ExecuteData {
     /// their signatures and Merkle proofs.
     pub signing_verifier_set_leaves: Vec<SigningVerifierSetInfo>,
 
-    /// The Merkle root of the payload data.
+    /// Dual-purpose field containing different hash types:
+    ///
+    /// - **For Message payloads**: Merkle root from a tree of message leaves.
+    ///
+    /// - **For VerifierSet payloads**: Constructed hash combining a static prefix (`b"new verifier
+    ///   set"`), the new verifier set Merkle root, and the signing verifier set Merkle root using
+    ///   `hashv()`. This is NOT a Merkle root after recent codebase changes.
+    ///
+    /// TODO: Rename field to `payload_hash` to accurately reflect its nature.  Previously this was
+    /// a Merkle root for both message and verifier set payloads, but verifier set handling was
+    /// changed to use composite instead.
     pub payload_merkle_root: [u8; 32],
 
     /// The payload items, which can either be new messages or a verifier set

--- a/crates/axelar-solana-encoding/src/types/execute_data.rs
+++ b/crates/axelar-solana-encoding/src/types/execute_data.rs
@@ -32,7 +32,7 @@ pub struct ExecuteData {
     ///
     /// TODO: Rename field to `payload_hash` to accurately reflect its nature.  Previously this was
     /// a Merkle root for both message and verifier set payloads, but verifier set handling was
-    /// changed to use composite instead.
+    /// changed to use a composite hash instead.
     pub payload_merkle_root: [u8; 32],
 
     /// The payload items, which can either be new messages or a verifier set

--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -155,6 +155,7 @@ impl SolanaAxelarIntegrationMetadata {
                 gateway_config_pda,
                 verifier_set_tracker_pda,
                 execute_data.payload_merkle_root,
+                execute_data.signing_verifier_set_merkle_root,
                 signature_leaves.clone(),
             )
             .unwrap();
@@ -168,8 +169,11 @@ impl SolanaAxelarIntegrationMetadata {
         }
 
         // Check that the PDA contains the expected data
-        let (verification_pda, _bump) = axelar_solana_gateway::get_signature_verification_pda(
+        let (verification_pda, _bump) = axelar_solana_gateway::get_signature_verification_pda::<
+            axelar_solana_encoding::hasher::SolanaSyscallHasher,
+        >(
             &execute_data.payload_merkle_root,
+            &execute_data.signing_verifier_set_merkle_root,
         );
         Ok(verification_pda)
     }

--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -131,6 +131,7 @@ impl SolanaAxelarIntegrationMetadata {
             self.payer.pubkey(),
             self.gateway_root_pda,
             execute_data.payload_merkle_root,
+            execute_data.signing_verifier_set_merkle_root,
         )
         .unwrap();
         self.fixture.send_tx(&[ix]).await

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -399,12 +399,15 @@ pub fn initialize_payload_verification_session(
     signing_verifier_set_hash: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
     let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_merkle_root);
+    let (verifier_set_tracker_pda, _) =
+        crate::get_verifier_set_tracker_pda(signing_verifier_set_hash);
 
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(gateway_config_pda, false),
         AccountMeta::new(verification_session_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        AccountMeta::new_readonly(verifier_set_tracker_pda, false),
     ];
 
     let data = to_vec(&GatewayInstruction::InitializePayloadVerificationSession {

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -86,6 +86,8 @@ pub enum GatewayInstruction {
     InitializePayloadVerificationSession {
         /// The Merkle root for the Payload being verified.
         payload_merkle_root: [u8; 32],
+        /// The hash of the verifier set that signed the payload.
+        signing_verifier_set_hash: [u8; 32],
     },
 
     /// Verifies a signature within a Payload verification session
@@ -394,6 +396,7 @@ pub fn initialize_payload_verification_session(
     payer: Pubkey,
     gateway_config_pda: Pubkey,
     payload_merkle_root: [u8; 32],
+    signing_verifier_set_hash: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
     let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_merkle_root);
 
@@ -406,6 +409,7 @@ pub fn initialize_payload_verification_session(
 
     let data = to_vec(&GatewayInstruction::InitializePayloadVerificationSession {
         payload_merkle_root,
+        signing_verifier_set_hash,
     })?;
 
     Ok(Instruction {

--- a/programs/axelar-solana-gateway/src/processor.rs
+++ b/programs/axelar-solana-gateway/src/processor.rs
@@ -97,12 +97,14 @@ impl Processor {
 
             GatewayInstruction::InitializePayloadVerificationSession {
                 payload_merkle_root,
+                signing_verifier_set_hash,
             } => {
                 msg!("Instruction: Initialize Verification Session");
                 Self::process_initialize_payload_verification_session(
                     program_id,
                     accounts,
                     payload_merkle_root,
+                    signing_verifier_set_hash,
                 )
             }
 

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -82,8 +82,9 @@ impl Processor {
         let data = verification_session_account.try_borrow_data()?;
         let session = SignatureVerificationSessionData::read(&data)
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
-        assert_valid_signature_verification_pda(
+        assert_valid_signature_verification_pda::<SolanaSyscallHasher>(
             &payload_merkle_root,
+            &session.signature_verification.signing_verifier_set_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -40,6 +40,7 @@ impl Processor {
         program_id: &Pubkey,
         accounts: &[AccountInfo<'_>],
         merkle_root: [u8; 32],
+        signing_verifier_set_hash: [u8; 32],
     ) -> ProgramResult {
         // Accounts
         let accounts_iter = &mut accounts.iter();
@@ -119,6 +120,7 @@ impl Processor {
         let session = SignatureVerificationSessionData::read_mut(&mut data)
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
         session.bump = bump;
+        session.signature_verification.signing_verifier_set_hash = signing_verifier_set_hash;
 
         Ok(())
     }

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -9,8 +9,12 @@ use solana_program::system_program;
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::signature_verification_pda::SignatureVerificationSessionData;
+use crate::state::verifier_set_tracker::VerifierSetTracker;
 use crate::state::GatewayConfig;
-use crate::{assert_valid_gateway_root_pda, seed_prefixes};
+use crate::{
+    assert_valid_gateway_root_pda, assert_valid_verifier_set_tracker_pda,
+    get_verifier_set_tracker_pda, seed_prefixes,
+};
 
 impl Processor {
     /// Initializes a signature verification session PDA account for a given Axelar payload (former
@@ -48,6 +52,7 @@ impl Processor {
         let gateway_root_pda = next_account_info(accounts_iter)?;
         let verification_session_account = next_account_info(accounts_iter)?;
         let system_program = next_account_info(accounts_iter)?;
+        let verifier_set_tracker_account = next_account_info(accounts_iter)?;
 
         // Check payer account requirements
         if !payer.is_signer {
@@ -81,6 +86,30 @@ impl Processor {
         let gateway_config =
             GatewayConfig::read(&data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
         assert_valid_gateway_root_pda(gateway_config.bump, gateway_root_pda.key)?;
+
+        // Check: Signing verifier set is valid and sufficiently recent
+        let (expected_verifier_set_tracker_pda, _) =
+            get_verifier_set_tracker_pda(signing_verifier_set_hash);
+        if *verifier_set_tracker_account.key != expected_verifier_set_tracker_pda {
+            return Err(GatewayError::InvalidVerifierSetTrackerProvided.into());
+        }
+
+        verifier_set_tracker_account.check_initialized_pda_without_deserialization(program_id)?;
+        let verifier_set_data = verifier_set_tracker_account.try_borrow_data()?;
+        let verifier_set_tracker = VerifierSetTracker::read(&verifier_set_data)
+            .ok_or(GatewayError::BytemuckDataLenInvalid)?;
+        assert_valid_verifier_set_tracker_pda(
+            verifier_set_tracker,
+            verifier_set_tracker_account.key,
+        )?;
+
+        // Check: Verifier set isn't expired
+        gateway_config.assert_valid_epoch(verifier_set_tracker.epoch)?;
+
+        // Check: Verifier set hash matches what we expect
+        if verifier_set_tracker.verifier_set_hash != signing_verifier_set_hash {
+            return Err(GatewayError::InvalidVerifierSetTrackerProvided.into());
+        }
 
         // Check: Verification PDA can be derived from provided seeds.
         // using canonical bump for the session account

--- a/programs/axelar-solana-gateway/src/processor/verify_signature.rs
+++ b/programs/axelar-solana-gateway/src/processor/verify_signature.rs
@@ -1,3 +1,4 @@
+use axelar_solana_encoding::hasher::SolanaSyscallHasher;
 use axelar_solana_encoding::types::execute_data::SigningVerifierSetInfo;
 use program_utils::pda::{BytemuckedPda, ValidPDA};
 use solana_program::account_info::{next_account_info, AccountInfo};
@@ -53,8 +54,9 @@ impl Processor {
         let mut data = verification_session_account.try_borrow_mut_data()?;
         let session = SignatureVerificationSessionData::read_mut(&mut data)
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
-        assert_valid_signature_verification_pda(
+        assert_valid_signature_verification_pda::<SolanaSyscallHasher>(
             &payload_merkle_root,
+            &session.signature_verification.signing_verifier_set_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/state/signature_verification.rs
+++ b/programs/axelar-solana-gateway/src/state/signature_verification.rs
@@ -91,23 +91,15 @@ impl SignatureVerification {
         // Update state
         self.accumulate_threshold(&verifier_info.leaf);
         self.mark_slot_done(&verifier_info.leaf)?;
-        self.verify_or_initialize_verifier_set(verifier_set_merkle_root)?;
+        self.verify_verifier_set(verifier_set_merkle_root)?;
 
         Ok(())
     }
 
-    /// Verifies or initializes the verifier set hash.
-    /// Returns an error if the hash is already set and doesn't match.
+    /// Verifies that the expected verifier set hash matches the session's verifier set hash.
+    /// Returns an error if the hashes don't match.
     #[inline]
-    fn verify_or_initialize_verifier_set(
-        &mut self,
-        expected_hash: &[u8; 32],
-    ) -> Result<(), GatewayError> {
-        if self.signing_verifier_set_hash == [0; 32] {
-            self.signing_verifier_set_hash = *expected_hash;
-            return Ok(());
-        }
-
+    fn verify_verifier_set(&self, expected_hash: &[u8; 32]) -> Result<(), GatewayError> {
         if self.signing_verifier_set_hash != *expected_hash {
             return Err(GatewayError::InvalidDigitalSignature);
         }
@@ -322,44 +314,30 @@ mod tests {
     use rand::Rng;
 
     #[test]
-    fn test_initialize_when_hash_is_zero() {
-        let mut verification = SignatureVerification::default();
-        let new_hash = [42_u8; 32];
-
-        let result = verification.verify_or_initialize_verifier_set(&new_hash);
-
-        assert!(result.is_ok());
-        assert_eq!(verification.signing_verifier_set_hash, new_hash);
-    }
-
-    #[test]
     fn test_verify_success_when_hashes_match() {
         let expected_hash = [42_u8; 32];
-        let mut verification = SignatureVerification {
+        let verification = SignatureVerification {
             signing_verifier_set_hash: expected_hash,
             ..Default::default()
         };
 
-        let result = verification.verify_or_initialize_verifier_set(&expected_hash);
+        let result = verification.verify_verifier_set(&expected_hash);
 
         assert!(result.is_ok());
-        assert_eq!(verification.signing_verifier_set_hash, expected_hash);
     }
 
     #[test]
     fn test_verify_fails_when_hashes_mismatch() {
         let initial_hash = [42_u8; 32];
         let different_hash = [24_u8; 32];
-        let mut verification = SignatureVerification {
+        let verification = SignatureVerification {
             signing_verifier_set_hash: initial_hash,
             ..Default::default()
         };
 
-        let result = verification.verify_or_initialize_verifier_set(&different_hash);
+        let result = verification.verify_verifier_set(&different_hash);
 
         assert_eq!(result, Err(GatewayError::InvalidDigitalSignature));
-        // Hash should remain unchanged after failure
-        assert_eq!(verification.signing_verifier_set_hash, initial_hash);
     }
 
     #[test]
@@ -442,7 +420,10 @@ mod tests {
             merkle_proof: proof_bytes,
         };
 
-        let mut verification = SignatureVerification::default();
+        let mut verification = SignatureVerification {
+            signing_verifier_set_hash: merkle_root,
+            ..Default::default()
+        };
 
         // First call should succeed and mark the slot as verified
         assert!(verification

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -1,5 +1,6 @@
-use axelar_solana_gateway::get_gateway_root_config_pda;
+use axelar_solana_encoding::hasher::NativeHasher;
 use axelar_solana_gateway::state::signature_verification::SignatureVerification;
+use axelar_solana_gateway::{get_gateway_root_config_pda, get_signature_verification_pda};
 use axelar_solana_gateway_test_fixtures::gateway::random_bytes;
 use axelar_solana_gateway_test_fixtures::SolanaAxelarIntegration;
 use bytemuck::Zeroable;
@@ -30,8 +31,10 @@ async fn test_initialize_payload_verification_session() {
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
 
     // Check PDA contains the expected data
-    let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_merkle_root);
+    let (verification_pda, bump) = get_signature_verification_pda::<NativeHasher>(
+        &payload_merkle_root,
+        &signing_verifier_set_hash,
+    );
 
     let verification_session_account = metadata
         .try_get_account_no_checks(&verification_pda)

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -100,23 +100,49 @@ async fn test_cannot_initialize_pda_twice() {
 }
 
 #[tokio::test]
-async fn test_same_payload_can_be_signed_by_multiple_verifier_sets_and_be_initialised() {
-    // Setup
+async fn test_different_verifier_sets_produce_different_verification_session_pdas() {
+    // Arrange: Set up test environment with two distinct verifier sets
     let mut metadata = SolanaAxelarIntegration::builder()
         .initial_signer_weights(vec![42])
         .build()
         .setup()
         .await;
 
-    let signers_a = make_verifier_set(&[500, 200], 1, metadata.domain_separator);
-    let signers_b = make_verifier_set(&[500, 23], 101, metadata.domain_separator);
+    // Create two different verifier sets with distinct weights and epochs
+    let verifier_set_a = make_verifier_set(&[500, 200], 1, metadata.domain_separator);
+    let verifier_set_b = make_verifier_set(&[500, 23], 101, metadata.domain_separator);
 
-    let messages = make_messages(5);
-    let payload = Payload::Messages(Messages(messages.clone()));
-    let execute_data_a = metadata.construct_execute_data(&signers_a, payload.clone());
-    let execute_data_b = metadata.construct_execute_data(&signers_b, payload);
+    // Use the same message payload for both verifier sets to demonstrate PDA isolation
+    let message_payload = Payload::Messages(Messages(make_messages(5)));
+
+    // Construct execution data - this will generate different payload merkle roots
+    // because the verifier set hash is included in the payload construction
+    let execute_data_a = metadata.construct_execute_data(&verifier_set_a, message_payload.clone());
+    let execute_data_b = metadata.construct_execute_data(&verifier_set_b, message_payload);
+
+    // Verify that different verifier sets produce different payload hashes
+    assert_ne!(
+        execute_data_a.payload_merkle_root, execute_data_b.payload_merkle_root,
+        "Different verifier sets must produce different payload merkle roots"
+    );
+
+    assert_ne!(
+        execute_data_a.signing_verifier_set_merkle_root,
+        execute_data_b.signing_verifier_set_merkle_root,
+        "Verifier sets should have different hashes"
+    );
+
+    // Act & Assert: Initialize verification sessions for both verifier sets
+    let mut verification_pdas = Vec::new();
 
     for execute_data in [execute_data_a, execute_data_b] {
+        // Derive the expected PDA for this payload
+        let (expected_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+            &execute_data.payload_merkle_root,
+        );
+        verification_pdas.push(expected_pda);
+
+        // Initialize the verification session
         let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
             metadata.payer.pubkey(),
             metadata.gateway_root_pda,
@@ -124,6 +150,25 @@ async fn test_same_payload_can_be_signed_by_multiple_verifier_sets_and_be_initia
             execute_data.signing_verifier_set_merkle_root,
         )
         .unwrap();
+
         let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
+
+        // Verify the verification session was created successfully
+        let verification_session = metadata.signature_verification_session(expected_pda).await;
+
+        // Ensure the session has the correct verifier set hash
+        assert_eq!(
+            verification_session
+                .signature_verification
+                .signing_verifier_set_hash,
+            execute_data.signing_verifier_set_merkle_root,
+            "Verification session must store the correct signing verifier set hash"
+        );
     }
+
+    // Assert: Verify that both verifier sets produced unique PDAs
+    assert_ne!(
+        verification_pdas[0], verification_pdas[1],
+        "Different verifier sets must produce distinct verification session PDAs"
+    );
 }

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -56,10 +56,7 @@ async fn test_initialize_payload_verification_session() {
     assert_eq!(session.bump, bump);
     let mut expected_verification = SignatureVerification::zeroed();
     expected_verification.signing_verifier_set_hash = signing_verifier_set_hash;
-    assert_eq!(
-        session.signature_verification,
-        expected_verification
-    );
+    assert_eq!(session.signature_verification, expected_verification);
 }
 
 #[tokio::test]

--- a/programs/axelar-solana-its/tests/module/deploy_remote.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_remote.rs
@@ -3,6 +3,7 @@ use mpl_token_metadata::accounts::Metadata;
 use mpl_token_metadata::instructions::CreateV1Builder;
 use mpl_token_metadata::types::TokenStandard;
 use solana_program_test::tokio;
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::instruction::Instruction;
 use test_context::test_context;
 
@@ -146,7 +147,10 @@ async fn test_deploy_remote_interchain_token_with_mismatched_metadata(
         Some(ctx.solana_wallet),
     )?;
 
-    ctx.send_solana_tx(&[deploy_local_ix])
+    // Add compute budget instruction to handle complex deployment
+    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(400_000);
+
+    ctx.send_solana_tx(&[compute_budget_ix, deploy_local_ix])
         .await
         .expect("InterchainToken deployment failed");
 


### PR DESCRIPTION
Supersedes #236

This PR offers a lighter approach to fix both C8 and C11 audit topics.

### Description

Changes the `initialize_payload_verification_session` instruction to need an explicit `signing_verifier_set_hash` parameter. This makes sure the verifier set hash is provided up front during session setup rather than being determined later during signature verification.

### Key changes:
- Added `signing_verifier_set_hash` parameter to `InitializePayloadVerificationSession` instruction
- Updated gateway processor to store the provided hash during session initialization
- Changed signature verification logic to check against the stored hash instead of setting it dynamically
- Updated TypeScript bindings and IDL to match the new parameter requirement

### Notes
- <del>We don't validate the signing verifier set in the `initialize_payload_verification_session` processor method since that hash gets validated when used in downstream operations _(`verify_signature`, etc.)_</del>
  - Edit: this has been reviewed after: https://github.com/eigerco/axelar-amplifier-solana/pull/271/commits/75bebc5f58d4394a5a8b5d9f767a74ddbe6fcd6a
- The main issue in C8 was that different verifier sets could compete for the same PDA, letting a malicious verifier block legitimate signers. This doesn't apply because the `signing_verifier_set_merkle_root` was already tied to the original payload (which is part of the PDA seeds). so we didn't make changes on that front in this PR.

  Evidence:
  - https://github.com/eigerco/axelar-amplifier-solana/blob/13ce01801fa2e1cd1bc04b3c0a1e16f8851a20d6/crates/axelar-solana-encoding/src/types/verifier_set.rs#L49-L59
  - https://github.com/eigerco/axelar-amplifier-solana/blob/13ce01801fa2e1cd1bc04b3c0a1e16f8851a20d6/crates/axelar-solana-encoding/src/lib.rs#L175-L184

  We added a new test to prove this:
   - https://github.com/eigerco/axelar-amplifier-solana/blob/13ce01801fa2e1cd1bc04b3c0a1e16f8851a20d6/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs#L102-L103