### PR TITLE
fix: issue H91 - Split the payer and authority accounts for all ix and processors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ name = "axelar-solana-its"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-sol-types",
  "anyhow",
  "axelar-message-primitives",
  "axelar-solana-encoding",

--- a/helpers/role-management/src/processor.rs
+++ b/helpers/role-management/src/processor.rs
@@ -28,8 +28,8 @@ pub fn propose<F: RolesFlags>(
     ensure_signer_roles(
         program_id,
         accounts.resource,
-        accounts.payer,
-        accounts.payer_roles_account,
+        accounts.origin_user_account,
+        accounts.origin_roles_account,
         roles,
     )?;
 
@@ -113,8 +113,25 @@ pub fn accept<F: RolesFlags>(
     }
 
     let proposal_account = accounts.proposal_account;
-    let role_remove_accounts = RoleRemoveAccounts::from(accounts);
-    let role_add_accounts = RoleAddAccounts::from(accounts);
+    let role_remove_accounts = RoleRemoveAccounts {
+        system_account: accounts.system_account,
+        payer: accounts.payer,
+        authority_user_account: accounts.destination_user_account,
+        authority_roles_account: accounts.destination_roles_account,
+        target_user_account: accounts.origin_user_account,
+        target_roles_account: accounts.origin_roles_account,
+        resource: accounts.resource,
+    };
+
+    let role_add_accounts = RoleAddAccounts {
+        system_account: accounts.system_account,
+        payer: accounts.payer,
+        resource: accounts.resource,
+        authority_user_account: accounts.destination_user_account,
+        authority_roles_account: accounts.destination_roles_account,
+        target_user_account: accounts.destination_user_account,
+        target_roles_account: accounts.destination_roles_account,
+    };
 
     add(program_id, role_add_accounts, roles, F::empty())?;
     remove(program_id, role_remove_accounts, roles, F::empty())?;
@@ -133,38 +150,38 @@ pub fn add<F: RolesFlags>(
     program_id: &Pubkey,
     accounts: RoleAddAccounts<'_>,
     roles: F,
-    required_payer_roles: F,
+    required_adder_roles: F,
 ) -> ProgramResult {
     ensure_signer_roles(
         program_id,
         accounts.resource,
-        accounts.payer,
-        accounts.payer_roles_account,
-        required_payer_roles,
+        accounts.authority_user_account,
+        accounts.authority_roles_account,
+        required_adder_roles,
     )?;
 
     ensure_proper_account::<F>(
         program_id,
         accounts.resource,
-        accounts.destination_user_account,
-        accounts.destination_roles_account,
+        accounts.target_user_account,
+        accounts.target_roles_account,
     )?;
 
-    if let Ok(mut destination_user_roles) = UserRoles::load(accounts.destination_roles_account) {
+    if let Ok(mut destination_user_roles) = UserRoles::load(accounts.target_roles_account) {
         destination_user_roles.add(roles);
         destination_user_roles.store(
             accounts.payer,
-            accounts.destination_roles_account,
+            accounts.target_roles_account,
             accounts.system_account,
         )?;
     } else {
         let (destination_roles_pda, destination_roles_pda_bump) = crate::find_user_roles_pda(
             program_id,
             accounts.resource.key,
-            accounts.destination_user_account.key,
+            accounts.target_user_account.key,
         );
 
-        if destination_roles_pda != *accounts.destination_roles_account.key {
+        if destination_roles_pda != *accounts.target_roles_account.key {
             msg!("Derived PDA doesn't match given destination roles account address");
             return Err(ProgramError::InvalidArgument);
         }
@@ -172,7 +189,7 @@ pub fn add<F: RolesFlags>(
         let signer_seeds = &[
             seed_prefixes::USER_ROLES_SEED,
             accounts.resource.key.as_ref(),
-            accounts.destination_user_account.key.as_ref(),
+            accounts.target_user_account.key.as_ref(),
             &[destination_roles_pda_bump],
         ];
 
@@ -180,7 +197,7 @@ pub fn add<F: RolesFlags>(
             program_id,
             accounts.system_account,
             accounts.payer,
-            accounts.destination_roles_account,
+            accounts.target_roles_account,
             signer_seeds,
         )?;
     }
@@ -197,29 +214,29 @@ pub fn remove<F: RolesFlags>(
     program_id: &Pubkey,
     accounts: RoleRemoveAccounts<'_>,
     roles: F,
-    required_payer_roles: F,
+    authority_required_roles: F,
 ) -> ProgramResult {
     ensure_signer_roles(
         program_id,
         accounts.resource,
-        accounts.payer,
-        accounts.payer_roles_account,
-        required_payer_roles,
+        accounts.authority_user_account,
+        accounts.authority_roles_account,
+        authority_required_roles,
     )?;
 
     ensure_roles(
         program_id,
         accounts.resource,
-        accounts.origin_user_account,
-        accounts.origin_roles_account,
+        accounts.target_user_account,
+        accounts.target_roles_account,
         roles,
     )?;
 
-    if let Ok(mut origin_user_roles) = UserRoles::load(accounts.origin_roles_account) {
-        origin_user_roles.remove(roles);
-        origin_user_roles.store(
+    if let Ok(mut target_user_roles) = UserRoles::load(accounts.target_roles_account) {
+        target_user_roles.remove(roles);
+        target_user_roles.store(
             accounts.payer,
-            accounts.origin_roles_account,
+            accounts.target_roles_account,
             accounts.system_account,
         )?;
     } else {
@@ -364,7 +381,6 @@ pub fn ensure_proper_account<F: RolesFlags>(
 pub struct RoleTransferWithProposalAccounts<'a> {
     pub system_account: &'a AccountInfo<'a>,
     pub payer: &'a AccountInfo<'a>,
-    pub payer_roles_account: &'a AccountInfo<'a>,
     pub resource: &'a AccountInfo<'a>,
     pub destination_user_account: &'a AccountInfo<'a>,
     pub destination_roles_account: &'a AccountInfo<'a>,
@@ -372,51 +388,26 @@ pub struct RoleTransferWithProposalAccounts<'a> {
     pub origin_roles_account: &'a AccountInfo<'a>,
     pub proposal_account: &'a AccountInfo<'a>,
 }
-
-impl<'a> From<RoleTransferWithProposalAccounts<'a>> for RoleRemoveAccounts<'a> {
-    fn from(value: RoleTransferWithProposalAccounts<'a>) -> Self {
-        Self {
-            system_account: value.system_account,
-            payer: value.payer,
-            payer_roles_account: value.payer_roles_account,
-            resource: value.resource,
-            origin_user_account: value.origin_user_account,
-            origin_roles_account: value.origin_roles_account,
-        }
-    }
-}
-
-impl<'a> From<RoleTransferWithProposalAccounts<'a>> for RoleAddAccounts<'a> {
-    fn from(value: RoleTransferWithProposalAccounts<'a>) -> Self {
-        Self {
-            system_account: value.system_account,
-            payer: value.payer,
-            payer_roles_account: value.payer_roles_account,
-            resource: value.resource,
-            destination_user_account: value.destination_user_account,
-            destination_roles_account: value.destination_roles_account,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub struct RoleAddAccounts<'a> {
     pub system_account: &'a AccountInfo<'a>,
     pub payer: &'a AccountInfo<'a>,
-    pub payer_roles_account: &'a AccountInfo<'a>,
+    pub authority_user_account: &'a AccountInfo<'a>,
+    pub authority_roles_account: &'a AccountInfo<'a>,
     pub resource: &'a AccountInfo<'a>,
-    pub destination_user_account: &'a AccountInfo<'a>,
-    pub destination_roles_account: &'a AccountInfo<'a>,
+    pub target_user_account: &'a AccountInfo<'a>,
+    pub target_roles_account: &'a AccountInfo<'a>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct RoleRemoveAccounts<'a> {
     pub system_account: &'a AccountInfo<'a>,
     pub payer: &'a AccountInfo<'a>,
-    pub payer_roles_account: &'a AccountInfo<'a>,
+    pub authority_user_account: &'a AccountInfo<'a>,
+    pub authority_roles_account: &'a AccountInfo<'a>,
     pub resource: &'a AccountInfo<'a>,
-    pub origin_user_account: &'a AccountInfo<'a>,
-    pub origin_roles_account: &'a AccountInfo<'a>,
+    pub target_user_account: &'a AccountInfo<'a>,
+    pub target_roles_account: &'a AccountInfo<'a>,
 }
 
 #[cfg(test)]

--- a/helpers/role-management/src/processor.rs
+++ b/helpers/role-management/src/processor.rs
@@ -33,14 +33,6 @@ pub fn propose<F: RolesFlags>(
         roles,
     )?;
 
-    ensure_roles(
-        program_id,
-        accounts.resource,
-        accounts.origin_user_account,
-        accounts.origin_roles_account,
-        roles,
-    )?;
-
     ensure_proper_account::<F>(
         program_id,
         accounts.resource,

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -1120,6 +1120,7 @@ pub fn deploy_remote_canonical_interchain_token(
 /// [`ProgramError::BorshIoError`]: When instruction serialization fails.
 pub fn deploy_interchain_token(
     payer: Pubkey,
+    deployer: Pubkey,
     salt: [u8; 32],
     name: String,
     symbol: String,
@@ -1128,7 +1129,7 @@ pub fn deploy_interchain_token(
     minter: Option<Pubkey>,
 ) -> Result<Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
-    let token_id = crate::interchain_token_id(&payer, &salt);
+    let token_id = crate::interchain_token_id(&deployer, &salt);
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
     let (mint, _) = crate::find_interchain_token_pda(&its_root_pda, &token_id);
     let token_manager_ata = get_associated_token_address_with_program_id(
@@ -1136,14 +1137,15 @@ pub fn deploy_interchain_token(
         &mint,
         &spl_token_2022::ID,
     );
-    let payer_ata =
-        get_associated_token_address_with_program_id(&payer, &mint, &spl_token_2022::ID);
+    let deployer_ata =
+        get_associated_token_address_with_program_id(&deployer, &mint, &spl_token_2022::ID);
     let (its_user_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::ID, &token_manager_pda, &its_root_pda);
     let (metadata_account_key, _) = mpl_token_metadata::accounts::Metadata::find_pda(&mint);
 
     let mut accounts = vec![
         AccountMeta::new(payer, true),
+        AccountMeta::new(deployer, true),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(token_manager_pda, false),
@@ -1156,7 +1158,7 @@ pub fn deploy_interchain_token(
         AccountMeta::new_readonly(sysvar::instructions::ID, false),
         AccountMeta::new_readonly(mpl_token_metadata::ID, false),
         AccountMeta::new(metadata_account_key, false),
-        AccountMeta::new(payer_ata, false),
+        AccountMeta::new(deployer_ata, false),
     ];
 
     if let Some(minter) = minter {
@@ -1779,17 +1781,22 @@ pub fn execute(inputs: ExecuteInstructionInputs) -> Result<Instruction, ProgramE
 /// # Errors
 ///
 /// [`ProgramError::BorshIoError`]: When instruction serialization fails.
-pub fn transfer_operatorship(payer: Pubkey, to: Pubkey) -> Result<Instruction, ProgramError> {
+pub fn transfer_operatorship(
+    payer: Pubkey,
+    sender: Pubkey,
+    to: Pubkey,
+) -> Result<Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &payer);
+    let (sender_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &sender);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &to);
 
     let accounts = vec![
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new(payer_roles_pda, false),
+        AccountMeta::new(sender, true),
+        AccountMeta::new(sender_roles_pda, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(to, false),
         AccountMeta::new(destination_roles_pda, false),
@@ -1809,19 +1816,24 @@ pub fn transfer_operatorship(payer: Pubkey, to: Pubkey) -> Result<Instruction, P
 /// # Errors
 ///
 /// [`ProgramError::BorshIoError`]: When instruction serialization fails.
-pub fn propose_operatorship(payer: Pubkey, to: Pubkey) -> Result<Instruction, ProgramError> {
+pub fn propose_operatorship(
+    payer: Pubkey,
+    proposer: Pubkey,
+    to: Pubkey,
+) -> Result<Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &payer);
+    let (proposer_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &proposer);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &to);
     let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &its_root_pda, &payer, &to);
+        role_management::find_roles_proposal_pda(&crate::id(), &its_root_pda, &proposer, &to);
 
     let accounts = vec![
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(payer_roles_pda, false),
+        AccountMeta::new_readonly(proposer, false),
+        AccountMeta::new_readonly(proposer_roles_pda, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(to, false),
         AccountMeta::new_readonly(destination_roles_pda, false),
@@ -1842,19 +1854,28 @@ pub fn propose_operatorship(payer: Pubkey, to: Pubkey) -> Result<Instruction, Pr
 /// # Errors
 ///
 /// [`ProgramError::BorshIoError`]: When instruction serialization fails.
-pub fn accept_operatorship(payer: Pubkey, from: Pubkey) -> Result<Instruction, ProgramError> {
+pub fn accept_operatorship(
+    payer: Pubkey,
+    role_receiver: Pubkey,
+    from: Pubkey,
+) -> Result<Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &payer);
+    let (role_receiver_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &role_receiver);
     let (origin_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &from);
-    let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &its_root_pda, &from, &payer);
+    let (proposal_pda, _) = role_management::find_roles_proposal_pda(
+        &crate::id(),
+        &its_root_pda,
+        &from,
+        &role_receiver,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new(payer_roles_pda, false),
+        AccountMeta::new(role_receiver, true),
+        AccountMeta::new(role_receiver_roles_pda, false),
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(from, false),
         AccountMeta::new(origin_roles_pda, false),

--- a/programs/axelar-solana-its/src/instruction/interchain_token.rs
+++ b/programs/axelar-solana-its/src/instruction/interchain_token.rs
@@ -48,6 +48,7 @@ pub fn mint(
 /// If serialization fails.
 pub fn transfer_mintership(
     payer: Pubkey,
+    sender: Pubkey,
     token_id: [u8; 32],
     to: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
@@ -55,14 +56,15 @@ pub fn transfer_mintership(
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &to);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (sender_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &sender);
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new(payer_roles_pda, false),
+        AccountMeta::new(sender, true),
+        AccountMeta::new(sender_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(to, false),
         AccountMeta::new(destination_roles_pda, false),
@@ -84,23 +86,25 @@ pub fn transfer_mintership(
 /// If serialization fails.
 pub fn propose_mintership(
     payer: Pubkey,
+    proposer: Pubkey,
     token_id: [u8; 32],
     to: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (origin_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &proposer);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &to);
     let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &payer, &to);
+        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &proposer, &to);
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(payer_roles_pda, false),
+        AccountMeta::new(proposer, true),
+        AccountMeta::new_readonly(origin_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(to, false),
         AccountMeta::new(destination_roles_pda, false),
@@ -124,23 +128,29 @@ pub fn propose_mintership(
 /// If serialization fails.
 pub fn accept_mintership(
     payer: Pubkey,
+    accepter: Pubkey,
     token_id: [u8; 32],
     from: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (accepter_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &accepter);
     let (origin_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &from);
-    let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &from, &payer);
+    let (proposal_pda, _) = role_management::find_roles_proposal_pda(
+        &crate::id(),
+        &token_manager_pda,
+        &from,
+        &accepter,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new(payer_roles_pda, false),
+        AccountMeta::new(accepter, true),
+        AccountMeta::new(accepter_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new(from, false),
         AccountMeta::new(origin_roles_pda, false),

--- a/programs/axelar-solana-its/src/instruction/token_manager.rs
+++ b/programs/axelar-solana-its/src/instruction/token_manager.rs
@@ -51,13 +51,14 @@ pub fn set_flow_limit(
 /// If serialization fails.
 pub fn add_flow_limiter(
     payer: Pubkey,
+    adder: Pubkey,
     token_id: [u8; 32],
     flow_limiter: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (adder_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &adder);
     let (flow_limiter_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &flow_limiter);
 
@@ -65,7 +66,8 @@ pub fn add_flow_limiter(
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(payer_roles_pda, false),
+        AccountMeta::new(adder, true),
+        AccountMeta::new_readonly(adder_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(flow_limiter, false),
         AccountMeta::new(flow_limiter_roles_pda, false),
@@ -87,13 +89,14 @@ pub fn add_flow_limiter(
 /// If serialization fails.
 pub fn remove_flow_limiter(
     payer: Pubkey,
+    remover: Pubkey,
     token_id: [u8; 32],
     flow_limiter: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (remover_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &remover);
     let (flow_limiter_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &flow_limiter);
 
@@ -101,7 +104,8 @@ pub fn remove_flow_limiter(
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(payer_roles_pda, false),
+        AccountMeta::new(remover, true),
+        AccountMeta::new_readonly(remover_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(flow_limiter, false),
         AccountMeta::new(flow_limiter_roles_pda, false),
@@ -123,6 +127,7 @@ pub fn remove_flow_limiter(
 /// If serialization fails.
 pub fn transfer_operatorship(
     payer: Pubkey,
+    sender: Pubkey,
     token_id: [u8; 32],
     to: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
@@ -130,14 +135,15 @@ pub fn transfer_operatorship(
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &to);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (sender_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &sender);
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new(payer_roles_pda, false),
+        AccountMeta::new(sender, true),
+        AccountMeta::new(sender_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(to, false),
         AccountMeta::new(destination_roles_pda, false),
@@ -159,23 +165,25 @@ pub fn transfer_operatorship(
 /// If serialization fails.
 pub fn propose_operatorship(
     payer: Pubkey,
+    proposer: Pubkey,
     token_id: [u8; 32],
     to: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (proposer_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &proposer);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &to);
     let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &payer, &to);
+        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &proposer, &to);
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(payer_roles_pda, false),
+        AccountMeta::new(proposer, true),
+        AccountMeta::new_readonly(proposer_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(to, false),
         AccountMeta::new(destination_roles_pda, false),
@@ -198,23 +206,29 @@ pub fn propose_operatorship(
 /// If serialization fails.
 pub fn accept_operatorship(
     payer: Pubkey,
+    accepter: Pubkey,
     token_id: [u8; 32],
     from: Pubkey,
 ) -> Result<solana_program::instruction::Instruction, ProgramError> {
     let (its_root_pda, _) = crate::find_its_root_pda();
     let (token_manager_pda, _) = crate::find_token_manager_pda(&its_root_pda, &token_id);
-    let (payer_roles_pda, _) =
-        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &payer);
+    let (accepter_roles_pda, _) =
+        role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &accepter);
     let (origin_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &from);
-    let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &from, &payer);
+    let (proposal_pda, _) = role_management::find_roles_proposal_pda(
+        &crate::id(),
+        &token_manager_pda,
+        &from,
+        &accepter,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
         AccountMeta::new(payer, true),
-        AccountMeta::new(payer_roles_pda, false),
+        AccountMeta::new(accepter, true),
+        AccountMeta::new(accepter_roles_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(from, false),
         AccountMeta::new(origin_roles_pda, false),

--- a/programs/axelar-solana-its/src/processor/interchain_token.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_token.rs
@@ -46,6 +46,7 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct DeployInterchainTokenAccounts<'a> {
     pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) deployer: &'a AccountInfo<'a>,
     pub(crate) system_account: &'a AccountInfo<'a>,
     pub(crate) its_root_pda: &'a AccountInfo<'a>,
     pub(crate) token_manager_pda: &'a AccountInfo<'a>,
@@ -58,7 +59,7 @@ pub(crate) struct DeployInterchainTokenAccounts<'a> {
     pub(crate) sysvar_instructions: &'a AccountInfo<'a>,
     pub(crate) mpl_token_metadata_program: &'a AccountInfo<'a>,
     pub(crate) mpl_token_metadata_account: &'a AccountInfo<'a>,
-    pub(crate) payer_ata: &'a AccountInfo<'a>,
+    pub(crate) deployer_ata: &'a AccountInfo<'a>,
     pub(crate) minter: Option<&'a AccountInfo<'a>>,
     pub(crate) minter_roles_pda: Option<&'a AccountInfo<'a>>,
 }
@@ -73,12 +74,12 @@ impl Validate for DeployInterchainTokenAccounts<'_> {
         spl_token_2022::check_program_account(self.token_program.key)?;
 
         // If it's a cross-chain message, payer_ata is not set (i.e., is set to program id)
-        if *self.payer_ata.key != crate::id() {
+        if *self.deployer_ata.key != crate::id() {
             crate::assert_valid_ata(
-                self.payer_ata.key,
+                self.deployer_ata.key,
                 self.token_program.key,
                 self.token_mint.key,
-                self.payer.key,
+                self.deployer.key,
             )?;
         }
 
@@ -103,14 +104,18 @@ impl<'a> FromAccountInfoSlice<'a> for DeployInterchainTokenAccounts<'a> {
         Self: Sized + Validate,
     {
         let accounts_iter = &mut accounts.iter();
-        let payer = if let Some(payer) = maybe_payer {
-            payer
+        let (payer, deployer) = if let Some(payer) = maybe_payer {
+            (*payer, *payer)
         } else {
-            next_account_info(accounts_iter)?
+            (
+                next_account_info(accounts_iter)?,
+                next_account_info(accounts_iter)?,
+            )
         };
 
         Ok(Self {
             payer,
+            deployer,
             system_account: next_account_info(accounts_iter)?,
             its_root_pda: next_account_info(accounts_iter)?,
             token_manager_pda: next_account_info(accounts_iter)?,
@@ -123,7 +128,7 @@ impl<'a> FromAccountInfoSlice<'a> for DeployInterchainTokenAccounts<'a> {
             sysvar_instructions: next_account_info(accounts_iter)?,
             mpl_token_metadata_program: next_account_info(accounts_iter)?,
             mpl_token_metadata_account: next_account_info(accounts_iter)?,
-            payer_ata: next_account_info(accounts_iter)?,
+            deployer_ata: next_account_info(accounts_iter)?,
             minter: next_account_info(accounts_iter).ok(),
             minter_roles_pda: next_account_info(accounts_iter).ok(),
         })
@@ -158,7 +163,7 @@ pub(crate) fn process_deploy<'a>(
     initial_supply: u64,
 ) -> ProgramResult {
     let parsed_accounts = DeployInterchainTokenAccounts::from_account_info_slice(accounts, &None)?;
-    let deploy_salt = crate::interchain_token_deployer_salt(parsed_accounts.payer.key, &salt);
+    let deploy_salt = crate::interchain_token_deployer_salt(parsed_accounts.deployer.key, &salt);
     let token_id = crate::interchain_token_id_internal(&deploy_salt);
 
     if initial_supply.is_zero() && parsed_accounts.minter.is_none() {
@@ -174,7 +179,7 @@ pub(crate) fn process_deploy<'a>(
 
     event::InterchainTokenIdClaimed {
         token_id,
-        deployer: *parsed_accounts.payer.key,
+        deployer: *parsed_accounts.deployer.key,
         salt: deploy_salt,
     }
     .emit();
@@ -599,8 +604,8 @@ fn setup_mint<'a>(
         crate::create_associated_token_account_idempotent(
             accounts.payer,
             accounts.token_mint,
-            accounts.payer_ata,
-            accounts.payer,
+            accounts.deployer_ata,
+            accounts.deployer,
             accounts.system_account,
             accounts.token_program,
         )?;
@@ -609,15 +614,16 @@ fn setup_mint<'a>(
             &spl_token_2022::instruction::mint_to(
                 accounts.token_program.key,
                 accounts.token_mint.key,
-                accounts.payer_ata.key,
+                accounts.deployer_ata.key,
                 accounts.token_manager_pda.key,
                 &[],
                 initial_supply,
             )?,
             &[
                 accounts.payer.clone(),
+                accounts.deployer.clone(),
                 accounts.token_mint.clone(),
-                accounts.payer_ata.clone(),
+                accounts.deployer_ata.clone(),
                 accounts.token_manager_pda.clone(),
                 accounts.token_program.clone(),
             ],
@@ -810,14 +816,15 @@ pub(crate) fn process_transfer_mintership<'a>(accounts: &'a [AccountInfo<'a>]) -
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let sender_user_account = next_account_info(accounts_iter)?;
+    let sender_roles_account = next_account_info(accounts_iter)?;
     let token_manager_account = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
 
     validate_system_account_key(system_account.key)?;
 
-    if payer.key == destination_user_account.key {
+    if sender_user_account.key == destination_user_account.key {
         msg!("Source and destination accounts are the same");
         return Err(ProgramError::InvalidArgument);
     }
@@ -836,19 +843,21 @@ pub(crate) fn process_transfer_mintership<'a>(accounts: &'a [AccountInfo<'a>]) -
     let role_add_accounts = RoleAddAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: sender_user_account,
+        authority_roles_account: sender_roles_account,
         resource: token_manager_account,
-        destination_user_account,
-        destination_roles_account,
+        target_user_account: destination_user_account,
+        target_roles_account: destination_roles_account,
     };
 
     let role_remove_accounts = RoleRemoveAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: sender_user_account,
+        authority_roles_account: sender_roles_account,
         resource: token_manager_account,
-        origin_user_account: payer,
-        origin_roles_account: payer_roles_account,
+        target_user_account: sender_user_account,
+        target_roles_account: sender_roles_account,
     };
 
     role_management::processor::add(
@@ -873,7 +882,8 @@ pub(crate) fn process_propose_mintership<'a>(accounts: &'a [AccountInfo<'a>]) ->
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let origin_user_account = next_account_info(accounts_iter)?;
+    let origin_roles_account = next_account_info(accounts_iter)?;
     let token_manager_account = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
@@ -895,12 +905,11 @@ pub(crate) fn process_propose_mintership<'a>(accounts: &'a [AccountInfo<'a>]) ->
     let role_management_accounts = RoleTransferWithProposalAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        origin_user_account,
+        origin_roles_account,
         resource: token_manager_account,
         destination_user_account,
         destination_roles_account,
-        origin_user_account: payer,
-        origin_roles_account: payer_roles_account,
         proposal_account,
     };
 
@@ -914,7 +923,8 @@ pub(crate) fn process_accept_mintership<'a>(accounts: &'a [AccountInfo<'a>]) -> 
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let destination_user_account = next_account_info(accounts_iter)?;
+    let destination_roles_account = next_account_info(accounts_iter)?;
     let token_manager_account = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
@@ -935,10 +945,9 @@ pub(crate) fn process_accept_mintership<'a>(accounts: &'a [AccountInfo<'a>]) -> 
     let role_management_accounts = RoleTransferWithProposalAccounts {
         system_account,
         payer,
-        payer_roles_account,
         resource: token_manager_account,
-        destination_user_account: payer,
-        destination_roles_account: payer_roles_account,
+        destination_user_account,
+        destination_roles_account,
         origin_user_account,
         origin_roles_account,
         proposal_account,

--- a/programs/axelar-solana-its/src/processor/mod.rs
+++ b/programs/axelar-solana-its/src/processor/mod.rs
@@ -372,7 +372,8 @@ fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> Program
 
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let origin_user_account = next_account_info(accounts_iter)?;
+    let origin_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
@@ -392,19 +393,21 @@ fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> Program
     let role_add_accounts = RoleAddAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: origin_user_account,
+        authority_roles_account: origin_roles_account,
         resource,
-        destination_user_account,
-        destination_roles_account,
+        target_user_account: destination_user_account,
+        target_roles_account: destination_roles_account,
     };
 
     let role_remove_accounts = RoleRemoveAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: origin_user_account,
+        authority_roles_account: origin_roles_account,
         resource,
-        origin_user_account: payer,
-        origin_roles_account: payer_roles_account,
+        target_user_account: origin_user_account,
+        target_roles_account: origin_roles_account,
     };
 
     role_management::processor::add(
@@ -427,7 +430,8 @@ fn process_propose_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramR
 
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let proposer_user_account = next_account_info(accounts_iter)?;
+    let proposer_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
@@ -443,12 +447,11 @@ fn process_propose_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramR
     let role_management_accounts = RoleTransferWithProposalAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        origin_user_account: proposer_user_account,
+        origin_roles_account: proposer_roles_account,
         resource,
         destination_user_account,
         destination_roles_account,
-        origin_user_account: payer,
-        origin_roles_account: payer_roles_account,
         proposal_account,
     };
 
@@ -459,7 +462,8 @@ fn process_accept_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramRe
     let accounts_iter = &mut accounts.iter();
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let role_receiver_account = next_account_info(accounts_iter)?;
+    let role_receiver_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
@@ -472,10 +476,9 @@ fn process_accept_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramRe
     let role_management_accounts = RoleTransferWithProposalAccounts {
         system_account,
         payer,
-        payer_roles_account,
         resource,
-        destination_user_account: payer,
-        destination_roles_account: payer_roles_account,
+        destination_user_account: role_receiver_account,
+        destination_roles_account: role_receiver_roles_account,
         origin_user_account,
         origin_roles_account,
         proposal_account,

--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -507,7 +507,8 @@ pub(crate) fn process_add_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -> P
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let adder_user_account = next_account_info(accounts_iter)?;
+    let adder_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
@@ -531,10 +532,11 @@ pub(crate) fn process_add_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -> P
     let role_management_accounts = RoleAddAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: adder_user_account,
+        authority_roles_account: adder_roles_account,
         resource,
-        destination_user_account,
-        destination_roles_account,
+        target_user_account: destination_user_account,
+        target_roles_account: destination_roles_account,
     };
 
     role_management::processor::add(
@@ -552,7 +554,8 @@ pub(crate) fn process_remove_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let remover_user_account = next_account_info(accounts_iter)?;
+    let remover_roles_account = next_account_info(accounts_iter)?;
     let resource = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
@@ -576,10 +579,11 @@ pub(crate) fn process_remove_flow_limiter<'a>(accounts: &'a [AccountInfo<'a>]) -
     let role_management_accounts = RoleRemoveAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: remover_user_account,
+        authority_roles_account: remover_roles_account,
         resource,
-        origin_user_account,
-        origin_roles_account,
+        target_user_account: origin_user_account,
+        target_roles_account: origin_roles_account,
     };
 
     role_management::processor::remove(
@@ -611,7 +615,8 @@ pub(crate) fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>])
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let origin_user_account = next_account_info(accounts_iter)?;
+    let origin_roles_account = next_account_info(accounts_iter)?;
     let token_manager_account = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
@@ -637,18 +642,20 @@ pub(crate) fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>])
     let role_add_accounts = RoleAddAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: origin_user_account,
+        authority_roles_account: origin_roles_account,
         resource: token_manager_account,
-        destination_user_account,
-        destination_roles_account,
+        target_user_account: destination_user_account,
+        target_roles_account: destination_roles_account,
     };
     let role_remove_accounts = RoleRemoveAccounts {
         system_account,
         payer,
-        payer_roles_account,
+        authority_user_account: origin_user_account,
+        authority_roles_account: origin_roles_account,
         resource: token_manager_account,
-        origin_user_account: payer,
-        origin_roles_account: payer_roles_account,
+        target_user_account: origin_user_account,
+        target_roles_account: origin_roles_account,
     };
 
     role_management::processor::add(
@@ -673,7 +680,8 @@ pub(crate) fn process_propose_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) 
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let origin_user_account = next_account_info(accounts_iter)?;
+    let origin_roles_account = next_account_info(accounts_iter)?;
     let token_manager_account = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
@@ -684,12 +692,11 @@ pub(crate) fn process_propose_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) 
     let role_management_accounts = RoleTransferWithProposalAccounts {
         system_account,
         payer,
-        payer_roles_account,
         resource: token_manager_account,
         destination_user_account,
         destination_roles_account,
-        origin_user_account: payer,
-        origin_roles_account: payer_roles_account,
+        origin_user_account,
+        origin_roles_account,
         proposal_account,
     };
 
@@ -713,7 +720,8 @@ pub(crate) fn process_accept_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -
     let its_config_pda = next_account_info(accounts_iter)?;
     let system_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
-    let payer_roles_account = next_account_info(accounts_iter)?;
+    let destination_user_account = next_account_info(accounts_iter)?;
+    let destination_roles_account = next_account_info(accounts_iter)?;
     let token_manager_account = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
@@ -729,10 +737,9 @@ pub(crate) fn process_accept_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -
     let role_management_accounts = RoleTransferWithProposalAccounts {
         system_account,
         payer,
-        payer_roles_account,
         resource: token_manager_account,
-        destination_user_account: payer,
-        destination_roles_account: payer_roles_account,
+        destination_user_account,
+        destination_roles_account,
         origin_user_account,
         origin_roles_account,
         proposal_account,

--- a/programs/axelar-solana-its/tests/module/deploy_manager_mismatch.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_manager_mismatch.rs
@@ -15,6 +15,7 @@ async fn deploy_interchain_token_for_user(
 ) -> anyhow::Result<[u8; 32]> {
     let deploy_token_ix = axelar_solana_its::instruction::deploy_interchain_token(
         user.pubkey(),
+        user.pubkey(),
         salt,
         name.to_owned(),
         symbol.to_owned(),

--- a/programs/axelar-solana-its/tests/module/deploy_remote.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_remote.rs
@@ -17,6 +17,7 @@ async fn test_deploy_remote_interchain_token_with_valid_metadata(
     let salt = solana_sdk::keccak::hash(b"ValidMetadataToken").0;
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         "Valid Metadata Token".to_owned(),
         "VMT".to_owned(),
@@ -137,6 +138,7 @@ async fn test_deploy_remote_interchain_token_with_mismatched_metadata(
     // Now deploy a local interchain token
     let salt = solana_sdk::keccak::hash(b"MismatchedMetadataToken").0;
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
         ctx.solana_wallet,
         salt,
         "Mismatched Token".to_owned(),
@@ -385,6 +387,7 @@ async fn test_deploy_remote_without_minter_with_mismatched_metadata(
     let salt = solana_sdk::keccak::hash(b"NoMinterMismatchedToken").0;
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         "No Minter Token".to_owned(),
         "NMT".to_owned(),
@@ -461,6 +464,7 @@ async fn test_deploy_remote_interchain_token_with_mismatched_token_manager(
     let salt1 = solana_sdk::keccak::hash(b"FirstToken").0;
     let deploy_local_ix1 = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt1,
         "First Token".to_owned(),
         "FIRST".to_owned(),
@@ -475,6 +479,7 @@ async fn test_deploy_remote_interchain_token_with_mismatched_token_manager(
 
     let salt2 = solana_sdk::keccak::hash(b"SecondToken").0;
     let deploy_local_ix2 = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
         ctx.solana_wallet,
         salt2,
         "Second Token".to_owned(),

--- a/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
+++ b/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
@@ -969,6 +969,7 @@ async fn test_source_address_stays_consistent_through_the_transfer(
     let salt = solana_sdk::keccak::hash(b"SourceAddressTestToken").0;
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         "Source Test Token".to_owned(),
         "STT".to_owned(),

--- a/programs/axelar-solana-its/tests/module/main.rs
+++ b/programs/axelar-solana-its/tests/module/main.rs
@@ -45,6 +45,7 @@ use solana_sdk::instruction::Instruction;
 use solana_sdk::program_error::ProgramError;
 use solana_sdk::program_pack::Pack as _;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::system_instruction;
 use test_context::AsyncTestContext;
@@ -203,6 +204,20 @@ impl ItsTestContext {
         ixs: &[Instruction],
     ) -> Result<BanksTransactionResultWithMetadata, BanksTransactionResultWithMetadata> {
         self.solana_chain.fixture.send_tx(ixs).await
+    }
+
+    pub async fn send_solana_tx_with(
+        &mut self,
+        payer: &Keypair,
+        ixs: &[Instruction],
+        signers: &[Keypair],
+    ) -> Result<BanksTransactionResultWithMetadata, BanksTransactionResultWithMetadata> {
+        self.solana_chain
+            .fixture
+            .send_tx_with_custom(&payer.pubkey(), ixs, signers)
+            .await
+            .map(|x| x.1)
+            .map_err(|x| x.1)
     }
 
     async fn relay_to_evm(&mut self, payload: &[u8]) {

--- a/programs/axelar-solana-its/tests/module/main.rs
+++ b/programs/axelar-solana-its/tests/module/main.rs
@@ -290,6 +290,7 @@ impl ItsTestContext {
         let salt = solana_sdk::keccak::hash(b"TestTokenSalt").0;
         let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
             self.solana_wallet,
+            self.solana_wallet,
             salt,
             "Test Token".to_owned(),
             "TT".to_owned(),

--- a/programs/axelar-solana-its/tests/module/metadata_length_validation.rs
+++ b/programs/axelar-solana-its/tests/module/metadata_length_validation.rs
@@ -15,6 +15,7 @@ async fn test_local_deployment_rejects_long_name(ctx: &mut ItsTestContext) -> an
 
     let deploy_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         long_name,
         valid_symbol.to_string(),
@@ -39,6 +40,7 @@ async fn test_local_deployment_rejects_long_symbol(ctx: &mut ItsTestContext) -> 
     let long_symbol = "ABCDEFGHIJK";
 
     let deploy_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
         ctx.solana_wallet,
         salt,
         valid_name.to_string(),
@@ -68,6 +70,7 @@ async fn test_local_deployment_rejects_long_name_and_symbol(
 
     let deploy_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         long_name.to_string(),
         long_symbol.to_string(),
@@ -95,6 +98,7 @@ async fn test_local_deployment_succeeds_with_valid_lengths(
     let valid_symbol = "VALID";
 
     let deploy_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
         ctx.solana_wallet,
         salt,
         valid_name.to_string(),
@@ -133,6 +137,7 @@ async fn test_local_deployment_succeeds_with_max_lengths(
     let max_symbol = "B".repeat(10);
 
     let deploy_ix = axelar_solana_its::instruction::deploy_interchain_token(
+        ctx.solana_wallet,
         ctx.solana_wallet,
         salt,
         max_name.clone(),

--- a/programs/axelar-solana-its/tests/module/metadata_retrieval.rs
+++ b/programs/axelar-solana-its/tests/module/metadata_retrieval.rs
@@ -26,6 +26,7 @@ async fn test_metadata_retrieval_with_metaplex_fallback(
     let salt = solana_sdk::keccak::hash(b"MetaplexFallbackToken").0;
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         "Metaplex Fallback Token".to_owned(),
         "MFT".to_owned(),

--- a/programs/axelar-solana-its/tests/module/pause_unpause.rs
+++ b/programs/axelar-solana-its/tests/module/pause_unpause.rs
@@ -273,6 +273,7 @@ async fn test_local_deploy_interchain_token_fails_when_paused(ctx: &mut ItsTestC
 
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         token_name.to_owned(),
         token_symbol.to_owned(),

--- a/programs/axelar-solana-its/tests/module/token_id_validation.rs
+++ b/programs/axelar-solana-its/tests/module/token_id_validation.rs
@@ -411,6 +411,7 @@ async fn test_self_remote_deployment_rejected(ctx: &mut ItsTestContext) -> anyho
     let salt = solana_sdk::keccak::hash(b"SelfDeployTest").0;
     let deploy_local_ix = axelar_solana_its::instruction::deploy_interchain_token(
         ctx.solana_wallet,
+        ctx.solana_wallet,
         salt,
         "Self Deploy Test Token".to_owned(),
         "SDT".to_owned(),


### PR DESCRIPTION
This PR solves an issue that prevents the current `payer` account at processors to carry some data. This is because internal functions like `system_instruction::transfer` do not allow the source account to have data on it. This might prevent external programs to use our processors.

Historically in our programs, the `payer` was also the `authority`, who was performing the actions such as roles transferring, token manager deployment, and so on .. Meaning this 2 aspects of the tx were coupled. This pr aims to break such coupling.

It affects all the ix/processor using [prepare_account_structure](https://github.com/eigerco/axelar-amplifier-solana/blob/31a6fcc24e69a47ed752d07d59119f9072637333/helpers/program-utils/src/pda.rs#L44) and [init_pda_raw_bytes](init_pda_raw_bytes).

**Reviewer tips**

* Two tests that uses the different code pathways explained above were included on this PR for both, demonstrating the issue is real + ensuring such paths they are covered. The later is not fully complete, as that would require us to add a test to every processor, which i just considered non practical. 
* Author left comments along the PR for signaling intentions and generate dicussion.


