### PR TITLE
chore(gateway): clean up legacy code

### DIFF
--- a/helpers/event-cpi-macros/tests/account_struct.rs
+++ b/helpers/event-cpi-macros/tests/account_struct.rs
@@ -29,8 +29,8 @@ pub struct OperatorProposalExecuted {
     /// The target address represented as a 32-byte array. It represents the
     /// [`solana_program::pubkey::Pubkey`].
     target_address: [u8; 32],
-    /// The call data required to execute the target program. The rkyv
-    /// encoded [`crate::proposal::ExecuteProposalCallData`].
+    /// The call data required to execute the target program.
+    /// See [`crate::proposal::ExecuteProposalCallData`].
     call_data: Vec<u8>,
     /// This field represents how many native tokens (lamports) are being
     /// sent to the target program. It's a little-endian U256 value.

--- a/helpers/role-management/src/lib.rs
+++ b/helpers/role-management/src/lib.rs
@@ -48,19 +48,6 @@ pub fn user_roles_pda(
         })
 }
 
-/// Tries to create the PDA for `UserRoles` using the provided bump,
-/// falling back to `find_program_address` if the bump is invalid.
-#[inline]
-#[must_use]
-pub fn create_user_roles_pda(
-    program_id: &Pubkey,
-    resource: &Pubkey,
-    user: &Pubkey,
-    bump: u8,
-) -> (Pubkey, u8) {
-    user_roles_pda(program_id, resource, user, Some(bump))
-}
-
 /// Derives the PDA for a `UserRoles` account.
 #[inline]
 #[must_use]

--- a/helpers/role-management/src/state.rs
+++ b/helpers/role-management/src/state.rs
@@ -39,7 +39,6 @@ where
 
 /// Roles assigned to a user on a specific resource.
 #[derive(Debug, Eq, PartialEq, Clone, BorshSerialize, BorshDeserialize)]
-#[non_exhaustive]
 pub struct UserRoles<F: RolesFlags> {
     roles: F,
     bump: u8,

--- a/programs/axelar-solana-gateway/src/error.rs
+++ b/programs/axelar-solana-gateway/src/error.rs
@@ -19,13 +19,9 @@ const IRRECOVERABLE_ERROR: u32 = 7;
 #[repr(u32)]
 #[derive(Clone, Debug, Eq, thiserror::Error, FromPrimitive, ToPrimitive, PartialEq)]
 pub enum GatewayError {
-    /// Verifier set has already been initialized.
-    #[error("Verifier set already initialized")]
-    VerifierSetAlreadyInitialised = 0,
-
     /// Used when someone tries to verify a signature that has already been verified.
     #[error("Slot has been previously verified")]
-    SlotAlreadyVerified,
+    SlotAlreadyVerified = 0,
 
     /// The message has already been initialized.
     #[error("Message already initialized")]
@@ -181,7 +177,7 @@ mod tests {
             .collect_vec();
 
         // confidence check that we derived the errors correctly
-        assert_eq!(errors_to_proceed.len(), 7);
+        assert_eq!(errors_to_proceed.len(), 6);
         assert_eq!(errors_to_not_proceed.len(), 23);
 
         // Errors that should cause the relayer to proceed (error numbers < 7)

--- a/programs/axelar-solana-governance/src/events.rs
+++ b/programs/axelar-solana-governance/src/events.rs
@@ -9,7 +9,6 @@ use solana_program::program_error::ProgramError;
 /// Governance program logs.
 ///
 /// Following the [implementation](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/interfaces/IInterchainGovernance.sol#L20-L40)
-#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum GovernanceEvent {
     /// Logged when the governance program receives and successfully processes
@@ -22,8 +21,8 @@ pub enum GovernanceEvent {
         /// The target address represented as a 32-byte array. It represents the
         /// [`solana_program::pubkey::Pubkey`].
         target_address: [u8; 32],
-        /// The call data required to execute the target program. The rkyv
-        /// encoded [`crate::proposal::ExecuteProposalCallData`].
+        /// The call data required to execute the target program.
+        /// See [`crate::proposal::ExecuteProposalCallData`].
         call_data: Vec<u8>,
         /// This field represents how many native tokens (lamports) are being
         /// sent to the target program. It's a little-endian U256 value.
@@ -43,8 +42,8 @@ pub enum GovernanceEvent {
         /// The target address represented as a 32-byte array. It represents the
         /// [`solana_program::pubkey::Pubkey`].
         target_address: [u8; 32],
-        /// The call data required to execute the target program. The rkyv
-        /// encoded [`crate::proposal::ExecuteProposalCallData`].
+        /// The call data required to execute the target program.
+        /// See [`crate::proposal::ExecuteProposalCallData`].
         call_data: Vec<u8>,
         /// This field represents how many native tokens (lamports) are being
         /// sent to the target program. It's a little-endian U256 value.
@@ -63,8 +62,8 @@ pub enum GovernanceEvent {
         /// The target address represented as a 32-byte array. It represents the
         /// [`solana_program::pubkey::Pubkey`].
         target_address: [u8; 32],
-        /// The call data required to execute the target program. The rkyv
-        /// encoded [`crate::proposal::ExecuteProposalCallData`].
+        /// The call data required to execute the target program.
+        /// See [`crate::proposal::ExecuteProposalCallData`].
         call_data: Vec<u8>,
         /// This field represents how many native tokens (lamports) are being
         /// sent to the target program. It's a little-endian U256 value.
@@ -84,8 +83,8 @@ pub enum GovernanceEvent {
         /// The target address represented as a 32-byte array. It represents the
         /// [`solana_program::pubkey::Pubkey`].
         target_address: [u8; 32],
-        /// The call data required to execute the target program. The rkyv
-        /// encoded [`crate::proposal::ExecuteProposalCallData`].
+        /// The call data required to execute the target program.
+        /// See [`crate::proposal::ExecuteProposalCallData`].
         call_data: Vec<u8>,
         /// This field represents how many native tokens (lamports) are being
         /// sent to the target program. It's a little-endian U256 value.
@@ -102,8 +101,8 @@ pub enum GovernanceEvent {
         /// The target address represented as a 32-byte array. It represents the
         /// [`solana_program::pubkey::Pubkey`].
         target_address: [u8; 32],
-        /// The call data required to execute the target program. The rkyv
-        /// encoded [`crate::proposal::ExecuteProposalCallData`].
+        /// The call data required to execute the target program.
+        /// See [`crate::proposal::ExecuteProposalCallData`].
         call_data: Vec<u8>,
         /// This field represents how many native tokens (lamports) are being
         /// sent to the target program. It's a little-endian U256 value.
@@ -120,8 +119,8 @@ pub enum GovernanceEvent {
         /// The target address represented as a 32-byte array. It represents the
         /// [`solana_program::pubkey::Pubkey`].
         target_address: [u8; 32],
-        /// The call data required to execute the target program. The rkyv
-        /// encoded [`crate::proposal::ExecuteProposalCallData`].
+        /// The call data required to execute the target program.
+        /// See [`crate::proposal::ExecuteProposalCallData`].
         call_data: Vec<u8>,
         /// This field represents how many native tokens (lamports) are being
         /// sent to the target program. It's a little-endian U256 value.
@@ -156,7 +155,7 @@ impl GovernanceEvent {
         Ok(())
     }
 
-    /// Encode the [`GovernanceEvent`] into a [`Vec<u8>`] which satisfies rkyv
+    /// Encode the [`GovernanceEvent`] into a [`Vec<u8>`] which satisfies
     /// alignment requirements
     ///
     /// # Panics
@@ -180,14 +179,14 @@ impl GovernanceEvent {
     }
 }
 
-/// Wrapper around the rkyv encoded [`GovernanceEvent`]
+/// Wrapper around the encoded [`GovernanceEvent`]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EventContainer {
     buffer: Vec<u8>,
 }
 
 impl EventContainer {
-    /// Create a new [`EventContainer`] from an rkyv encoded [`GovernanceEvent`]
+    /// Create a new [`EventContainer`] from an encoded [`GovernanceEvent`]
     ///
     /// The method will return `None` if the buffer cannod be deserialised into
     /// a valid [`ArchivedGovernanceEvent`]

--- a/programs/axelar-solana-its/src/state/token_manager.rs
+++ b/programs/axelar-solana-its/src/state/token_manager.rs
@@ -18,7 +18,6 @@ use crate::state::flow_limit::FlowState;
 ///
 /// NOTE: The Gateway token manager type is not supported on Solana.
 #[derive(Debug, Eq, PartialEq, Clone, Copy, BorshSerialize, BorshDeserialize)]
-#[non_exhaustive]
 pub enum Type {
     /// For tokens that are deployed directly from ITS itself they use a native
     /// interchain token manager. Tokens that are deployed via the frontend


### PR DESCRIPTION
rkyv isn't in use in this project anymore
`create_user_roles_pda` was unused
`#[non_exhaustive]` may lead to unwanted side-effects 
`GatewayError::VerifierSetAlreadyInitialised` was unused