### PR TITLE
fix: add prefix seed for message signing PDAs and ensure consistent usage (C14)

### DIFF
--- a/helpers/axelar-message-primitives/src/destination_program_id.rs
+++ b/helpers/axelar-message-primitives/src/destination_program_id.rs
@@ -19,6 +19,7 @@ impl DestinationProgramId {
     /// validating that a message is being executed - this is reference to
     /// gateway.validateMessage.
     pub fn signing_pda(&self, command_id: &[u8; 32]) -> (Pubkey, u8) {
+        // This corresponds to `axelar_solana_gateway::seed_prefixes::VALIDATE_MESSAGE_SIGNING_SEED`
         Pubkey::find_program_address(&[b"gtw-validate-msg", command_id], &self.0)
     }
 }

--- a/helpers/axelar-message-primitives/src/destination_program_id.rs
+++ b/helpers/axelar-message-primitives/src/destination_program_id.rs
@@ -19,6 +19,6 @@ impl DestinationProgramId {
     /// validating that a message is being executed - this is reference to
     /// gateway.validateMessage.
     pub fn signing_pda(&self, command_id: &[u8; 32]) -> (Pubkey, u8) {
-        Pubkey::find_program_address(&[command_id], &self.0)
+        Pubkey::find_program_address(&[b"gtw-validate-msg", command_id], &self.0)
     }
 }

--- a/programs/axelar-solana-gateway/src/executable.rs
+++ b/programs/axelar-solana-gateway/src/executable.rs
@@ -221,7 +221,11 @@ fn validate_message_internal(
             message.clone(),
         )?,
         &[gateway_incoming_message.clone(), signing_pda.clone()],
-        &[&[&command_id, &[signing_pda_derived_bump]]],
+        &[&[
+            crate::seed_prefixes::VALIDATE_MESSAGE_SIGNING_SEED,
+            &command_id,
+            &[signing_pda_derived_bump],
+        ]],
     )?;
 
     Ok(())

--- a/programs/axelar-solana-gateway/src/lib.rs
+++ b/programs/axelar-solana-gateway/src/lib.rs
@@ -294,7 +294,10 @@ pub fn get_validate_message_signing_pda(
     command_id: [u8; 32],
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(
-        &[seed_prefixes::VALIDATE_MESSAGE_SIGNING_SEED, command_id.as_ref()],
+        &[
+            seed_prefixes::VALIDATE_MESSAGE_SIGNING_SEED,
+            command_id.as_ref(),
+        ],
         &destination_address,
     )
 }
@@ -436,7 +439,8 @@ mod tests {
         let destination_address = Pubkey::new_unique();
         let command_id: [u8; 32] = rand::random();
         let (found_pda, bump) = get_validate_message_signing_pda(destination_address, command_id);
-        let created_pda = create_validate_message_signing_pda(&destination_address, bump, &command_id).unwrap();
+        let created_pda =
+            create_validate_message_signing_pda(&destination_address, bump, &command_id).unwrap();
         assert_eq!(found_pda, created_pda);
     }
 

--- a/programs/axelar-solana-gateway/src/lib.rs
+++ b/programs/axelar-solana-gateway/src/lib.rs
@@ -47,6 +47,7 @@ pub mod seed_prefixes {
     /// The seed prefix for deriving message payload PDAs
     pub const MESSAGE_PAYLOAD_SEED: &[u8] = b"message-payload";
     /// The seed prefix for deriving validate message signing PDAs
+    /// This corresponds to the hardcoded value in `axelar_message_primitives::destination_program_id::DestinationProgramId::signing_pda`
     pub const VALIDATE_MESSAGE_SIGNING_SEED: &[u8] = b"gtw-validate-msg";
 }
 

--- a/programs/axelar-solana-governance/src/instructions.rs
+++ b/programs/axelar-solana-governance/src/instructions.rs
@@ -150,6 +150,7 @@ pub mod builder {
     use axelar_solana_encoding::types::messages::Message;
     use axelar_solana_gateway::state::incoming_message::command_id;
     use borsh::to_vec;
+    use core::str::FromStr;
     use governance_gmp::alloy_primitives::Uint;
     use governance_gmp::{GovernanceCommand, GovernanceCommandPayload};
     use program_utils::{checked_from_u256_le_bytes_to_u64, from_u64_to_u256_le_bytes};
@@ -1123,8 +1124,13 @@ pub mod builder {
         message: &Message,
     ) {
         let command_id = command_id(&message.cc_id.chain, &message.cc_id.id);
+        let destination_address = Pubkey::from_str(&message.destination_address)
+            .expect("Invalid destination address in message");
         let (gateway_approved_message_signing_pda, _) =
-            axelar_solana_gateway::get_validate_message_signing_pda(crate::id(), command_id);
+            axelar_solana_gateway::get_validate_message_signing_pda(
+                destination_address,
+                command_id,
+            );
 
         let mut new_accounts = vec![
             AccountMeta::new_readonly(payer, false),

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -3,7 +3,7 @@
 
 use std::borrow::Cow;
 
-use axelar_message_primitives::{DataPayload, DestinationProgramId};
+use axelar_message_primitives::DataPayload;
 use axelar_solana_encoding::types::messages::Message;
 use axelar_solana_gateway::state::incoming_message::command_id;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
@@ -1853,8 +1853,8 @@ fn prefix_accounts(
     message: &Message,
 ) -> Vec<AccountMeta> {
     let command_id = command_id(&message.cc_id.chain, &message.cc_id.id);
-    let destination_program = DestinationProgramId(crate::ID);
-    let (gateway_approved_message_signing_pda, _) = destination_program.signing_pda(&command_id);
+    let (gateway_approved_message_signing_pda, _) =
+        axelar_solana_gateway::get_validate_message_signing_pda(crate::ID, command_id);
 
     vec![
         AccountMeta::new(*payer, true),


### PR DESCRIPTION


This PR adds a seed prefix to message signing PDA derivation and updates all dependent components to use the new derivation consistently across the codebase.

## Changes Made

### Core Gateway Changes:
- Add `VALIDATE_MESSAGE_SIGNING_SEED = b"gtw-validate-msg"` constant to `seed_prefixes` module
- Update `get_validate_message_signing_pda()` and `create_validate_message_signing_pda()` to include prefix in seed array
- Update executable interface CPI calls to use new seed structure

### Component Updates:
- Helper crate: Update `axelar-message-primitives` to include that prefix in `signing_pda()` method
- Governance: Parse destination address from message instead of using program ID for PDA derivation
- ITS: Replace deprecated helper usage with official gateway function calls
