### PR TITLE
refactor: deduplicate Message Payload PDA validation code (C19)

### DIFF
--- a/programs/axelar-solana-gateway/src/lib.rs
+++ b/programs/axelar-solana-gateway/src/lib.rs
@@ -170,6 +170,32 @@ pub fn assert_valid_incoming_message_pda(
     Ok(())
 }
 
+/// Assert that the message payload PDA has been derived correctly
+///
+/// # Errors
+///
+/// Returns [`ProgramError::InvalidSeeds`] if the derived PDA does not match the expected pubkey.
+///
+/// # Panics
+///
+/// Panics if the bump seed produces an invalid program derived address.
+#[inline]
+#[track_caller]
+pub fn assert_valid_message_payload_pda(
+    incoming_message_pda: Pubkey,
+    payer: Pubkey,
+    bump: u8,
+    expected_pubkey: &Pubkey,
+) -> Result<(), ProgramError> {
+    let derived_pubkey = create_message_payload_pda(incoming_message_pda, payer, bump)
+        .expect("invalid bump for the message payload PDA");
+    if &derived_pubkey != expected_pubkey {
+        solana_program::msg!("Error: Invalid message payload PDA ");
+        return Err(ProgramError::InvalidSeeds);
+    }
+    Ok(())
+}
+
 /// Get the PDA and bump seed for a given verifier set hash.
 /// This is used to calculate the PDA for `VerifierSetTracker`.
 #[inline]

--- a/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
@@ -71,15 +71,12 @@ impl Processor {
 
             // Check: Buffer PDA can be derived from provided seeds.
             let incoming_message_pda = *incoming_message_account.key;
-            let message_payload_pda = crate::create_message_payload_pda(
+            crate::assert_valid_message_payload_pda(
                 incoming_message_pda,
                 *payer.key,
                 *message_payload.bump,
+                message_payload_account.key,
             )?;
-            if &message_payload_pda != message_payload_account.key {
-                solana_program::msg!("Error: failed to derive message payload account address");
-                return Err(ProgramError::InvalidSeeds);
-            }
         } // Account data borrows are dropped here
 
         // Close the Buffer PDA account

--- a/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
@@ -65,16 +65,12 @@ impl Processor {
 
         // Check: Message Payload PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
-        let message_payload_pda = crate::create_message_payload_pda(
+        crate::assert_valid_message_payload_pda(
             incoming_message_pda,
             *payer.key,
             *message_payload.bump,
+            message_payload_account.key,
         )?;
-
-        if &message_payload_pda != message_payload_account.key {
-            solana_program::msg!("Error: failed to derive message payload account address");
-            return Err(ProgramError::InvalidSeeds);
-        }
 
         // Finally, calculate the hash check that it matches the incoming message hash.
         let payload_hash = message_payload.hash_raw_payload_bytes();

--- a/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
@@ -69,15 +69,12 @@ impl Processor {
 
         // Check: Message Payload PDA can be derived from provided seeds.
         let incoming_message_pda = *incoming_message_account.key;
-        let message_payload_pda = crate::create_message_payload_pda(
+        crate::assert_valid_message_payload_pda(
             incoming_message_pda,
             *payer.key,
             *message_payload.bump,
+            message_payload_account.key,
         )?;
-        if message_payload_account.key != &message_payload_pda {
-            solana_program::msg!("Error: failed to derive message payload account address");
-            return Err(ProgramError::InvalidArgument);
-        }
 
         // Check: Message payload PDA must not be committed
         message_payload.assert_uncommitted()?;


### PR DESCRIPTION

- Add `assert_valid_message_payload_pda` helper function to deduplicate Message Payload PDA validation
- Refactor three processor functions to use the new helper instead of inline validation
- Standardize error handling across all message payload PDA validations _(stick w/ `InvalidSeeds`)_

## Changes

**Added:**
- `assert_valid_message_payload_pda()` helper function in `lib.rs`

**Modified:**
- `process_write_message_payload()`
- `process_commit_message_payload()`
- `process_close_message_payload()`