### PR TITLE
refactor: deduplicate Message Payload PDA validation code (C15)

### DIFF
--- a/programs/axelar-solana-gateway/src/processor/initialize_config.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_config.rs
@@ -21,7 +21,7 @@ use crate::state::verifier_set_tracker::VerifierSetTracker;
 use crate::state::GatewayConfig;
 use crate::{
     assert_valid_gateway_root_pda, assert_valid_verifier_set_tracker_pda,
-    get_gateway_root_config_internal, get_verifier_set_tracker_pda, seed_prefixes,
+    get_gateway_root_config_pda, get_verifier_set_tracker_pda, seed_prefixes,
 };
 
 impl Processor {
@@ -107,7 +107,7 @@ impl Processor {
         // check that everything has been derived correctly
         assert_valid_verifier_set_tracker_pda(tracker, verifier_set_pda.key)?;
 
-        let (_, bump) = get_gateway_root_config_internal(program_id);
+        let (_, bump) = get_gateway_root_config_pda();
 
         // Check: Gateway Config account uses the canonical bump.
         assert_valid_gateway_root_pda(bump, gateway_root_pda.key)?;

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -3,7 +3,10 @@ use crate::state::incoming_message::IncomingMessage;
 use crate::state::message_payload::MutMessagePayload;
 
 use super::Processor;
-use program_utils::{pda::{init_pda_raw, BytemuckedPda, ValidPDA}, validate_system_account_key};
+use program_utils::{
+    pda::{init_pda_raw, BytemuckedPda, ValidPDA},
+    validate_system_account_key,
+};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
 use solana_program::program_error::ProgramError;

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -3,7 +3,7 @@ use crate::state::incoming_message::IncomingMessage;
 use crate::state::message_payload::MutMessagePayload;
 
 use super::Processor;
-use program_utils::pda::{init_pda_raw, BytemuckedPda, ValidPDA};
+use program_utils::{pda::{init_pda_raw, BytemuckedPda, ValidPDA}, validate_system_account_key};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
 use solana_program::program_error::ProgramError;
@@ -59,10 +59,7 @@ impl Processor {
         gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
 
         // Check: System Program
-        if !solana_program::system_program::check_id(system_program.key) {
-            solana_program::msg!("Error: invalid system program account");
-            return Err(ProgramError::InvalidAccountData);
-        }
+        validate_system_account_key(system_program.key)?;
 
         // Check: Message payload account is writable
         if !message_payload_account.is_writable {

--- a/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
@@ -43,7 +43,7 @@ impl Processor {
         }
 
         // Check: Gateway root PDA
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
+        gateway_root_pda.check_initialized_pda_without_deserialization(&crate::ID)?;
 
         // Check: Message Payload account is initialized
         message_payload_account.check_initialized_pda_without_deserialization(&crate::ID)?;


### PR DESCRIPTION
Standardizes PDA verification patterns across gateway processor files.

## Changes
- **`initialize_config.rs`**: Use `get_gateway_root_config_pda()` instead of `get_gateway_root_config_internal(program_id)`
- **`initialize_message_payload.rs`**: Replace manual system program check with `validate_system_account_key()` helper
- **`write_message_payload.rs`**: Use `&crate::ID` instead of `program_id` parameter
