### PR TITLE
fix(its): make role proposals independent

### DIFF
--- a/helpers/role-management/src/lib.rs
+++ b/helpers/role-management/src/lib.rs
@@ -58,13 +58,16 @@ pub fn find_user_roles_pda(program_id: &Pubkey, resource: &Pubkey, user: &Pubkey
 /// Tries to create the PDA for `RolesProposal` using the provided bump,
 /// falling back to `find_program_address` if the bump is `None` or invalid.
 #[must_use]
-pub fn roles_proposal_pda(
+pub fn roles_proposal_pda<F: crate::state::RolesFlags>(
     program_id: &Pubkey,
     resource: &Pubkey,
     from: &Pubkey,
     to: &Pubkey,
+    roles: F,
     maybe_bump: Option<u8>,
 ) -> (Pubkey, u8) {
+    let roles_bytes = borsh::to_vec(&roles.bits())
+        .expect("No obvious reason why serializing bits should fail. It's a bug.");
     maybe_bump
         .and_then(|bump| {
             Pubkey::create_program_address(
@@ -73,6 +76,7 @@ pub fn roles_proposal_pda(
                     resource.as_ref(),
                     from.as_ref(),
                     to.as_ref(),
+                    &roles_bytes,
                     &[bump],
                 ],
                 program_id,
@@ -87,6 +91,7 @@ pub fn roles_proposal_pda(
                     resource.as_ref(),
                     from.as_ref(),
                     to.as_ref(),
+                    &roles_bytes,
                 ],
                 program_id,
             )
@@ -97,24 +102,26 @@ pub fn roles_proposal_pda(
 /// falling back to `find_program_address` if the bump is invalid.
 #[inline]
 #[must_use]
-pub fn create_roles_proposal_pda(
+pub fn create_roles_proposal_pda<F: crate::state::RolesFlags>(
     program_id: &Pubkey,
     resource: &Pubkey,
     from: &Pubkey,
     to: &Pubkey,
+    roles: F,
     bump: u8,
 ) -> (Pubkey, u8) {
-    roles_proposal_pda(program_id, resource, from, to, Some(bump))
+    roles_proposal_pda(program_id, resource, from, to, roles, Some(bump))
 }
 
 /// Derives the PDA for a `RolesProposal` account.
 #[inline]
 #[must_use]
-pub fn find_roles_proposal_pda(
+pub fn find_roles_proposal_pda<F: crate::state::RolesFlags>(
     program_id: &Pubkey,
     resource: &Pubkey,
     from: &Pubkey,
     to: &Pubkey,
+    roles: F,
 ) -> (Pubkey, u8) {
-    roles_proposal_pda(program_id, resource, from, to, None)
+    roles_proposal_pda(program_id, resource, from, to, roles, None)
 }

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -1802,8 +1802,13 @@ pub fn propose_operatorship(
         role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &proposer);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &its_root_pda, &to);
-    let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &its_root_pda, &proposer, &to);
+    let (proposal_pda, _) = role_management::find_roles_proposal_pda(
+        &crate::id(),
+        &its_root_pda,
+        &proposer,
+        &to,
+        crate::Roles::OPERATOR,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
@@ -1845,6 +1850,7 @@ pub fn accept_operatorship(
         &its_root_pda,
         &from,
         &role_receiver,
+        crate::Roles::OPERATOR,
     );
 
     let accounts = vec![

--- a/programs/axelar-solana-its/src/instruction/interchain_token.rs
+++ b/programs/axelar-solana-its/src/instruction/interchain_token.rs
@@ -96,8 +96,13 @@ pub fn propose_mintership(
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &proposer);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &to);
-    let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &proposer, &to);
+    let (proposal_pda, _) = role_management::find_roles_proposal_pda(
+        &crate::id(),
+        &token_manager_pda,
+        &proposer,
+        &to,
+        crate::Roles::MINTER,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
@@ -143,6 +148,7 @@ pub fn accept_mintership(
         &token_manager_pda,
         &from,
         &accepter,
+        crate::Roles::MINTER,
     );
 
     let accounts = vec![

--- a/programs/axelar-solana-its/src/instruction/token_manager.rs
+++ b/programs/axelar-solana-its/src/instruction/token_manager.rs
@@ -175,8 +175,13 @@ pub fn propose_operatorship(
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &proposer);
     let (destination_roles_pda, _) =
         role_management::find_user_roles_pda(&crate::id(), &token_manager_pda, &to);
-    let (proposal_pda, _) =
-        role_management::find_roles_proposal_pda(&crate::id(), &token_manager_pda, &proposer, &to);
+    let (proposal_pda, _) = role_management::find_roles_proposal_pda(
+        &crate::id(),
+        &token_manager_pda,
+        &proposer,
+        &to,
+        crate::Roles::OPERATOR,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(its_root_pda, false),
@@ -221,6 +226,7 @@ pub fn accept_operatorship(
         &token_manager_pda,
         &from,
         &accepter,
+        crate::Roles::OPERATOR,
     );
 
     let accounts = vec![


### PR DESCRIPTION
Include the serialized roles in the PDA derivation to avoid collisions

This makes it possible to emit simultaneous proposals for different roles.