### PR TITLE
fix: c12 ensure all initialization PDA checks deep inspect data

### DIFF
--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -11,6 +11,7 @@ use solana_program::instruction::{AccountMeta, Instruction};
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 
+use crate::get_gateway_root_config_pda;
 use crate::state::config::{RotationDelaySecs, VerifierSetEpoch};
 use crate::state::verifier_set_tracker::VerifierSetHash;
 
@@ -460,9 +461,13 @@ pub fn validate_message(
     signing_pda: &Pubkey,
     message: Message,
 ) -> Result<Instruction, ProgramError> {
+
+    let gateway_root_pda = get_gateway_root_config_pda().0;
+
     let accounts = vec![
         AccountMeta::new(*incoming_message_pda, false),
         AccountMeta::new_readonly(*signing_pda, true),
+        AccountMeta::new_readonly(gateway_root_pda, false),
     ];
 
     let data = borsh::to_vec(&GatewayInstruction::ValidateMessage { message })?;

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -461,7 +461,6 @@ pub fn validate_message(
     signing_pda: &Pubkey,
     message: Message,
 ) -> Result<Instruction, ProgramError> {
-
     let gateway_root_pda = get_gateway_root_config_pda().0;
 
     let accounts = vec![

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -70,8 +70,8 @@ impl Processor {
 
         validate_system_account_key(system_program.key)?;
 
-        // Check: Gateway Root PDA is initialized.
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
+        // Check: Gateway Root PDA is initialized and valid.
+        gateway_root_pda.check_initialized_pda_without_deserialization(&crate::ID)?;
         let gateway_data = gateway_root_pda.try_borrow_data()?;
         let gateway_config =
             GatewayConfig::read(&gateway_data).ok_or(GatewayError::BytemuckDataLenInvalid)?;

--- a/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/close_message_payload.rs
@@ -1,3 +1,4 @@
+use crate::assert_initialized_and_valid_gateway_root_pda;
 use crate::state::incoming_message::IncomingMessage;
 use crate::state::message_payload::MutMessagePayload;
 
@@ -42,7 +43,7 @@ impl Processor {
         }
 
         // Check: Gateway root PDA
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
+        assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: Message Payload account is initialized
         message_payload_account.check_initialized_pda_without_deserialization(&crate::ID)?;

--- a/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/commit_message_payload.rs
@@ -1,4 +1,5 @@
 use super::Processor;
+use crate::assert_initialized_and_valid_gateway_root_pda;
 use crate::state::incoming_message::IncomingMessage;
 use crate::state::message_payload::MutMessagePayload;
 use program_utils::pda::{BytemuckedPda, ValidPDA};
@@ -38,7 +39,7 @@ impl Processor {
             return Err(ProgramError::MissingRequiredSignature);
         }
         // Check: Gateway root PDA
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
+        assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: Message Payload account is initialized
         message_payload_account.check_initialized_pda_without_deserialization(&crate::ID)?;

--- a/programs/axelar-solana-gateway/src/processor/initialize_config.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_config.rs
@@ -109,6 +109,9 @@ impl Processor {
 
         let (_, bump) = get_gateway_root_config_pda();
 
+        // Check: Gateway Root PDA is uninitialized
+        gateway_root_pda.check_uninitialized_pda()?;
+
         // Check: Gateway Config account uses the canonical bump.
         assert_valid_gateway_root_pda(bump, gateway_root_pda.key)?;
 

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -58,7 +58,7 @@ impl Processor {
             return Err(ProgramError::InvalidAccountData);
         }
 
-            // Check: Gateway root PDA
+        // Check: Gateway root PDA
         assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: System Program

--- a/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_message_payload.rs
@@ -1,6 +1,6 @@
-use crate::error::GatewayError;
 use crate::state::incoming_message::IncomingMessage;
 use crate::state::message_payload::MutMessagePayload;
+use crate::{assert_initialized_and_valid_gateway_root_pda, error::GatewayError};
 
 use super::Processor;
 use program_utils::{
@@ -58,8 +58,8 @@ impl Processor {
             return Err(ProgramError::InvalidAccountData);
         }
 
-        // Check: Gateway root PDA
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
+            // Check: Gateway root PDA
+        assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: System Program
         validate_system_account_key(system_program.key)?;

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -9,8 +9,7 @@ use solana_program::system_program;
 use super::Processor;
 use crate::error::GatewayError;
 use crate::state::signature_verification_pda::SignatureVerificationSessionData;
-use crate::state::GatewayConfig;
-use crate::{assert_valid_gateway_root_pda, seed_prefixes};
+use crate::{assert_initialized_and_valid_gateway_root_pda, seed_prefixes};
 
 impl Processor {
     /// Initializes a signature verification session PDA account for a given Axelar payload (former
@@ -71,11 +70,7 @@ impl Processor {
         }
 
         // Check: Gateway Root PDA is initialized.
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
-        let data = gateway_root_pda.try_borrow_data()?;
-        let gateway_config =
-            GatewayConfig::read(&data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
-        assert_valid_gateway_root_pda(gateway_config.bump, gateway_root_pda.key)?;
+        assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: Verification PDA can be derived from provided seeds.
         // using canonical bump for the session account

--- a/programs/axelar-solana-gateway/src/processor/transfer_operatorship.rs
+++ b/programs/axelar-solana-gateway/src/processor/transfer_operatorship.rs
@@ -40,11 +40,11 @@ impl Processor {
         let programdata_account = next_account_info(&mut accounts_iter)?;
         let new_operator = next_account_info(&mut accounts_iter)?;
 
-        // Check: Gateway Root PDA is initialized.
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
-        let mut data = gateway_root_pda.try_borrow_mut_data()?;
-        let gateway_config =
-            GatewayConfig::read_mut(&mut data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
+        // Check: Gateway Root PDA is initialized and valid.
+        gateway_root_pda.check_initialized_pda_without_deserialization(&crate::ID)?;
+        let mut gateway_data = gateway_root_pda.try_borrow_mut_data()?;
+        let gateway_config = GatewayConfig::read_mut(&mut gateway_data)
+            .ok_or(GatewayError::BytemuckDataLenInvalid)?;
         assert_valid_gateway_root_pda(gateway_config.bump, gateway_root_pda.key)?;
 
         // Check: programdata account derived correctly (it holds the upgrade authority

--- a/programs/axelar-solana-gateway/src/processor/validate_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/validate_message.rs
@@ -44,7 +44,7 @@ impl Processor {
         let incoming_message_pda = next_account_info(accounts_iter)?;
         let caller = next_account_info(accounts_iter)?;
         let gateway_root_pda = next_account_info(accounts_iter)?;
-        
+
         // Check: Gateway Root PDA is initialized.
         assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 

--- a/programs/axelar-solana-gateway/src/processor/validate_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/validate_message.rs
@@ -15,7 +15,8 @@ use super::Processor;
 use crate::error::GatewayError;
 use crate::state::incoming_message::{command_id, IncomingMessage, MessageStatus};
 use crate::{
-    assert_valid_incoming_message_pda, create_validate_message_signing_pda, event_prefixes,
+    assert_initialized_and_valid_gateway_root_pda, assert_valid_incoming_message_pda,
+    create_validate_message_signing_pda, event_prefixes,
 };
 
 impl Processor {
@@ -42,6 +43,10 @@ impl Processor {
         let accounts_iter = &mut accounts.iter();
         let incoming_message_pda = next_account_info(accounts_iter)?;
         let caller = next_account_info(accounts_iter)?;
+        let gateway_root_pda = next_account_info(accounts_iter)?;
+        
+        // Check: Gateway Root PDA is initialized.
+        assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // compute the message hash
         let message_hash = message.hash::<SolanaSyscallHasher>();
@@ -49,7 +54,6 @@ impl Processor {
         // compute the command id
         let command_id = command_id(&message.cc_id.chain, &message.cc_id.id);
 
-        // Check: Gateway Root PDA is initialized.
         incoming_message_pda.check_initialized_pda_without_deserialization(program_id)?;
         let mut data = incoming_message_pda.try_borrow_mut_data()?;
         let incoming_message =

--- a/programs/axelar-solana-gateway/src/processor/verify_signature.rs
+++ b/programs/axelar-solana-gateway/src/processor/verify_signature.rs
@@ -41,11 +41,11 @@ impl Processor {
         let verification_session_account = next_account_info(accounts_iter)?;
         let verifier_set_tracker_account = next_account_info(accounts_iter)?;
 
-        // Check: Gateway Root PDA is initialized.
-        gateway_root_pda.check_initialized_pda_without_deserialization(program_id)?;
-        let data = gateway_root_pda.try_borrow_data()?;
+        // Check: Gateway Root PDA is initialized and valid.
+        gateway_root_pda.check_initialized_pda_without_deserialization(&crate::ID)?;
+        let gateway_data = gateway_root_pda.try_borrow_data()?;
         let gateway_config =
-            GatewayConfig::read(&data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
+            GatewayConfig::read(&gateway_data).ok_or(GatewayError::BytemuckDataLenInvalid)?;
         assert_valid_gateway_root_pda(gateway_config.bump, gateway_root_pda.key)?;
 
         // Check: Verification session PDA is initialized.

--- a/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
+++ b/programs/axelar-solana-gateway/src/processor/write_message_payload.rs
@@ -1,4 +1,5 @@
 use super::Processor;
+use crate::assert_initialized_and_valid_gateway_root_pda;
 use crate::state::incoming_message::IncomingMessage;
 use crate::state::message_payload::MutMessagePayload;
 use program_utils::pda::{BytemuckedPda, ValidPDA};
@@ -43,7 +44,7 @@ impl Processor {
         }
 
         // Check: Gateway root PDA
-        gateway_root_pda.check_initialized_pda_without_deserialization(&crate::ID)?;
+        assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: Message Payload account is initialized
         message_payload_account.check_initialized_pda_without_deserialization(&crate::ID)?;

--- a/programs/axelar-solana-governance/src/instructions.rs
+++ b/programs/axelar-solana-governance/src/instructions.rs
@@ -1132,11 +1132,13 @@ pub mod builder {
                 command_id,
             );
 
+        let gateway_root_pda = axelar_solana_gateway::get_gateway_root_config_pda().0;
         let mut new_accounts = vec![
             AccountMeta::new_readonly(payer, false),
             AccountMeta::new(gw_incoming_message, false),
             AccountMeta::new_readonly(gw_message_payload, false),
             AccountMeta::new_readonly(gateway_approved_message_signing_pda, false),
+            AccountMeta::new_readonly(gateway_root_pda, false),
             AccountMeta::new_readonly(axelar_solana_gateway::id(), false),
         ];
         // Append the new accounts to the existing ones.

--- a/programs/axelar-solana-governance/src/processor/gmp/approve_operator_proposal.rs
+++ b/programs/axelar-solana-governance/src/processor/gmp/approve_operator_proposal.rs
@@ -66,12 +66,12 @@ pub(crate) fn process(
         return Err(ProgramError::InvalidArgument);
     }
 
-    program_utils::pda::init_pda_raw(
+    program_utils::pda::init_pda_raw_bytes(
         payer,
         operator_proposal_pda,
         program_id,
         system_account,
-        1,
+        &[1], // We store a single non-zero byte to indicate initialization
         &[
             seed_prefixes::OPERATOR_MANAGED_PROPOSAL,
             &ctx.proposal_hash,

--- a/programs/axelar-solana-governance/src/processor/gmp/mod.rs
+++ b/programs/axelar-solana-governance/src/processor/gmp/mod.rs
@@ -48,7 +48,7 @@ pub use schedule_time_lock_proposal::ScheduleTimeLockProposalMeta;
 
 /// The index of the first account that is expected to be passed to the
 /// destination program.
-pub const PROGRAM_ACCOUNTS_SPLIT_AT: usize = 5;
+pub const PROGRAM_ACCOUNTS_SPLIT_AT: usize = 6;
 
 /// The index of the root PDA account in the accounts slice.
 const ROOT_PDA_ACCOUNT_INDEX: usize = 1;

--- a/programs/axelar-solana-governance/src/processor/gmp/mod.rs
+++ b/programs/axelar-solana-governance/src/processor/gmp/mod.rs
@@ -46,10 +46,6 @@ pub use cancel_operator_approval::CancelOperatorApprovalMeta;
 pub use cancel_time_lock_proposal::CancelTimeLockProposalMeta;
 pub use schedule_time_lock_proposal::ScheduleTimeLockProposalMeta;
 
-/// The index of the first account that is expected to be passed to the
-/// destination program.
-pub const PROGRAM_ACCOUNTS_SPLIT_AT: usize = 6;
-
 /// The index of the root PDA account in the accounts slice.
 const ROOT_PDA_ACCOUNT_INDEX: usize = 1;
 

--- a/programs/axelar-solana-governance/src/processor/mod.rs
+++ b/programs/axelar-solana-governance/src/processor/mod.rs
@@ -8,7 +8,7 @@
 //!    by other Solana addresses.
 
 use axelar_solana_gateway::executable::validate_with_gmp_metadata;
-use gmp::{ProcessGMPContext, PROGRAM_ACCOUNTS_SPLIT_AT};
+use gmp::ProcessGMPContext;
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
@@ -71,7 +71,7 @@ impl Processor {
                 let (gateway_accounts, gmp_accounts) = accounts
                     .iter()
                     .as_slice()
-                    .split_at(PROGRAM_ACCOUNTS_SPLIT_AT);
+                    .split_at(axelar_solana_gateway::executable::PROGRAM_ACCOUNTS_START_INDEX);
 
                 validate_with_gmp_metadata(gateway_accounts, &message)?;
 

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -1911,11 +1911,14 @@ fn prefix_accounts(
     let (gateway_approved_message_signing_pda, _) =
         axelar_solana_gateway::get_validate_message_signing_pda(crate::ID, command_id);
 
+    let gateway_root_pda = axelar_solana_gateway::get_gateway_root_config_pda().0;
+
     vec![
         AccountMeta::new(*payer, true),
         AccountMeta::new(*gateway_incoming_message_pda, false),
         AccountMeta::new_readonly(*gateway_message_payload_pda, false),
         AccountMeta::new_readonly(gateway_approved_message_signing_pda, false),
+        AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
     ]
 }

--- a/programs/axelar-solana-its/src/processor/gmp.rs
+++ b/programs/axelar-solana-its/src/processor/gmp.rs
@@ -36,6 +36,7 @@ pub(crate) fn process_execute<'a>(
     let _gateway_approved_message_pda = next_account_info(accounts_iter)?;
     let payload_account = next_account_info(accounts_iter)?;
     let _signing_pda = next_account_info(accounts_iter)?;
+    let _gateway_root_pda = next_account_info(accounts_iter)?;
     let _gateway_program_id = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
     let its_root_pda_account = next_account_info(accounts_iter)?;


### PR DESCRIPTION
Ensure when we check a PDA is initialised, we also check it's data is non zeroed. This way we ensure the owner is always the exp[ected one as well, as the Solana runtime do not allow an account owner change if there's non zeroed data on it. ([link](https://github.com/anza-xyz/agave/blob/master/transaction-context/src/lib.rs#L745-L747)) . 