### PR TITLE
feat(gateway): improving Signature Verification Session PDA Addresses

### DIFF
--- a/bindings/anchor_lib/axelar-solana-gateway.rs
+++ b/bindings/anchor_lib/axelar-solana-gateway.rs
@@ -351,7 +351,6 @@ pub struct MessageLeaf {
     pub position: u16,
     pub set_size: u16,
     pub domain_separator: [u8; 32],
-    pub signing_verifier_set: [u8; 32],
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize)]

--- a/crates/axelar-solana-encoding/src/lib.rs
+++ b/crates/axelar-solana-encoding/src/lib.rs
@@ -59,8 +59,7 @@ pub fn encode(
     let signing_verifier_set_merkle_root = signer_merkle_tree
         .root()
         .ok_or(EncodingError::CannotMerkeliseEmptyVerifierSet)?;
-    let (payload_merkle_root, payload_items) =
-        hash_payload_internal(payload, domain_separator, signing_verifier_set_merkle_root)?;
+    let (payload_merkle_root, payload_items) = hash_payload_internal(payload, domain_separator)?;
 
     let signing_verifier_set_leaves = leaves
         .into_iter()
@@ -114,27 +113,16 @@ fn estimate_size(execute_data: &ExecuteData) -> usize {
         )
 }
 
-/// Hashes a payload by constructing a Merkle tree for the verifier set,
-/// generating a unique root hash for payload validation.
+/// Hashes a payload, generating a unique root hash for payload validation.
 ///
 /// # Errors
 /// - When the verifier set is empty
 /// - When the verifier set is too large
 pub fn hash_payload(
     domain_separator: &[u8; 32],
-    signer_verifier_set: &VerifierSet,
     payload: Payload,
 ) -> Result<[u8; 32], EncodingError> {
-    let verifier_set_leaves =
-        types::verifier_set::merkle_tree_leaves(signer_verifier_set, domain_separator)?
-            .collect::<Vec<_>>();
-    let mt = merkle_tree::<NativeHasher, VerifierSetLeaf>(verifier_set_leaves.iter());
-    let signing_verifier_set_merkle_root = mt
-        .root()
-        .ok_or(EncodingError::CannotMerkeliseEmptyVerifierSet)?;
-    let (payload_hash, _merklesied_payload) =
-        hash_payload_internal(payload, *domain_separator, signing_verifier_set_merkle_root)?;
-
+    let (payload_hash, _merklesied_payload) = hash_payload_internal(payload, *domain_separator)?;
     Ok(payload_hash)
 }
 
@@ -143,7 +131,6 @@ pub fn hash_payload(
 fn hash_payload_internal(
     payload: Payload,
     domain_separator: [u8; 32],
-    signing_verifier_set_merkle_root: [u8; 32],
 ) -> Result<([u8; 32], MerkleisedPayload), EncodingError> {
     let (payload_merkle_root, payload_items) = match payload {
         Payload::Messages(messages) => {
@@ -174,12 +161,7 @@ fn hash_payload_internal(
             let payload = MerkleisedPayload::VerifierSetRotation {
                 new_verifier_set_merkle_root,
             };
-            let payload_hash_to_sign = types::verifier_set::construct_payload_hash::<NativeHasher>(
-                new_verifier_set_merkle_root,
-                signing_verifier_set_merkle_root,
-            );
-
-            (payload_hash_to_sign, payload)
+            (new_verifier_set_merkle_root, payload)
         }
     };
     Ok((payload_merkle_root, payload_items))

--- a/crates/axelar-solana-encoding/src/lib.rs
+++ b/crates/axelar-solana-encoding/src/lib.rs
@@ -147,12 +147,8 @@ fn hash_payload_internal(
 ) -> Result<([u8; 32], MerkleisedPayload), EncodingError> {
     let (payload_merkle_root, payload_items) = match payload {
         Payload::Messages(messages) => {
-            let leaves = types::messages::merkle_tree_leaves(
-                messages,
-                domain_separator,
-                signing_verifier_set_merkle_root,
-            )?
-            .collect::<Vec<_>>();
+            let leaves = types::messages::merkle_tree_leaves(messages, domain_separator)?
+                .collect::<Vec<_>>();
             let messages_merkle_tree = merkle_tree::<NativeHasher, MessageLeaf>(leaves.iter());
             let messages_merkle_root = messages_merkle_tree
                 .root()

--- a/crates/axelar-solana-encoding/src/types/messages.rs
+++ b/crates/axelar-solana-encoding/src/types/messages.rs
@@ -50,7 +50,6 @@ impl LeafHash for Message {}
 pub(crate) fn merkle_tree_leaves(
     messages: Messages,
     domain_separator: [u8; 32],
-    signing_verifier_set: [u8; 32],
 ) -> Result<impl Iterator<Item = MessageLeaf>, EncodingError> {
     let set_size = messages
         .0
@@ -68,7 +67,6 @@ pub(crate) fn merkle_tree_leaves(
                 .expect("position guaranteed to equal set size"),
             set_size,
             message,
-            signing_verifier_set,
         });
     Ok(iterator)
 }
@@ -77,8 +75,7 @@ pub(crate) fn merkle_tree_leaves(
 ///
 /// The `MessageLeaf` struct includes the message itself along with metadata
 /// required for Merkle tree operations, such as its position within the tree,
-/// the total size of the set, a domain separator, and the Merkle root of the
-/// signing verifier set.
+/// the total size of the set, and a domain separator.
 #[derive(
     Clone, PartialEq, Eq, Debug, udigest::Digestable, borsh::BorshDeserialize, borsh::BorshSerialize,
 )]
@@ -95,10 +92,6 @@ pub struct MessageLeaf {
     /// A domain separator used to ensure the uniqueness of hashes across
     /// different contexts.
     pub domain_separator: [u8; 32],
-
-    /// The Merkle root of the signing verifier set, used for verifying
-    /// signatures.
-    pub signing_verifier_set: [u8; 32],
 }
 
 impl LeafHash for MessageLeaf {}

--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -151,9 +151,15 @@ impl SolanaAxelarIntegrationMetadata {
 
         for signature_leaves in &execute_data.signing_verifier_set_leaves {
             // Verify the signature
+            let (verification_session_pda, _) =
+                axelar_solana_gateway::get_signature_verification_pda(
+                    &execute_data.payload_merkle_root,
+                    &execute_data.signing_verifier_set_merkle_root,
+                );
             let ix = axelar_solana_gateway::instructions::verify_signature(
                 gateway_config_pda,
                 verifier_set_tracker_pda,
+                verification_session_pda,
                 execute_data.payload_merkle_root,
                 signature_leaves.clone(),
             )
@@ -170,6 +176,7 @@ impl SolanaAxelarIntegrationMetadata {
         // Check that the PDA contains the expected data
         let (verification_pda, _bump) = axelar_solana_gateway::get_signature_verification_pda(
             &execute_data.payload_merkle_root,
+            &execute_data.signing_verifier_set_merkle_root,
         );
         Ok(verification_pda)
     }

--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -222,8 +222,7 @@ impl SolanaAxelarIntegrationMetadata {
         verifier_set: &VerifierSet,
         payload: Payload,
     ) -> ExecuteData {
-        let payload_hash =
-            hash_payload(&self.domain_separator, verifier_set, payload.clone()).unwrap();
+        let payload_hash = hash_payload(&self.domain_separator, payload.clone()).unwrap();
         let signatures = {
             signers
                 .signers

--- a/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
+++ b/crates/axelar-solana-gateway-test-fixtures/src/gateway.rs
@@ -131,6 +131,7 @@ impl SolanaAxelarIntegrationMetadata {
             self.payer.pubkey(),
             self.gateway_root_pda,
             execute_data.payload_merkle_root,
+            execute_data.signing_verifier_set_merkle_root,
         )
         .unwrap();
         self.fixture.send_tx(&[ix]).await

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -403,10 +403,14 @@ pub fn initialize_payload_verification_session(
     let (verification_session_pda, _) =
         crate::get_signature_verification_pda(&payload_merkle_root, &signing_verifier_set_hash);
 
+    let (verifier_set_tracker_pda, _) =
+        crate::get_verifier_set_tracker_pda(signing_verifier_set_hash);
+
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(gateway_config_pda, false),
         AccountMeta::new(verification_session_pda, false),
+        AccountMeta::new(verifier_set_tracker_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
 

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -400,7 +400,8 @@ pub fn initialize_payload_verification_session(
     payload_merkle_root: [u8; 32],
     signing_verifier_set_hash: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
-    let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_merkle_root);
+    let (verification_session_pda, _) =
+        crate::get_signature_verification_pda(&payload_merkle_root, &signing_verifier_set_hash);
 
     let accounts = vec![
         AccountMeta::new(payer, true),
@@ -430,12 +431,10 @@ pub fn initialize_payload_verification_session(
 pub fn verify_signature(
     gateway_config_pda: Pubkey,
     verifier_set_tracker_pda: Pubkey,
+    verification_session_pda: Pubkey,
     payload_merkle_root: [u8; 32],
     verifier_info: SigningVerifierSetInfo,
 ) -> Result<Instruction, ProgramError> {
-    let (verification_session_pda, _bump) =
-        crate::get_signature_verification_pda(&payload_merkle_root);
-
     let accounts = vec![
         AccountMeta::new_readonly(gateway_config_pda, false),
         AccountMeta::new(verification_session_pda, false),

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -88,6 +88,8 @@ pub enum GatewayInstruction {
     InitializePayloadVerificationSession {
         /// The Merkle root for the Payload being verified.
         payload_merkle_root: [u8; 32],
+        /// The hash of the verifier set that signed the payload.
+        signing_verifier_set_hash: [u8; 32],
     },
 
     /// Verifies a signature within a Payload verification session
@@ -396,6 +398,7 @@ pub fn initialize_payload_verification_session(
     payer: Pubkey,
     gateway_config_pda: Pubkey,
     payload_merkle_root: [u8; 32],
+    signing_verifier_set_hash: [u8; 32],
 ) -> Result<Instruction, ProgramError> {
     let (verification_session_pda, _) = crate::get_signature_verification_pda(&payload_merkle_root);
 
@@ -408,6 +411,7 @@ pub fn initialize_payload_verification_session(
 
     let data = to_vec(&GatewayInstruction::InitializePayloadVerificationSession {
         payload_merkle_root,
+        signing_verifier_set_hash,
     })?;
 
     Ok(Instruction {

--- a/programs/axelar-solana-gateway/src/lib.rs
+++ b/programs/axelar-solana-gateway/src/lib.rs
@@ -247,11 +247,15 @@ pub fn assert_valid_verifier_set_tracker_pda(
 /// Get the PDA and bump seed for a given payload hash.
 #[inline]
 #[must_use]
-pub fn get_signature_verification_pda(payload_merkle_root: &[u8; 32]) -> (Pubkey, u8) {
+pub fn get_signature_verification_pda(
+    payload_merkle_root: &[u8; 32],
+    signing_verifier_set: &[u8; 32],
+) -> (Pubkey, u8) {
     let (pubkey, bump) = Pubkey::find_program_address(
         &[
             seed_prefixes::SIGNATURE_VERIFICATION_SEED,
             payload_merkle_root,
+            signing_verifier_set,
         ],
         &crate::ID,
     );
@@ -272,6 +276,7 @@ pub fn get_signature_verification_pda(payload_merkle_root: &[u8; 32]) -> (Pubkey
 #[track_caller]
 pub fn assert_valid_signature_verification_pda(
     payload_merkle_root: &[u8; 32],
+    signing_verifier_set: &[u8; 32],
     bump: u8,
     expected_pubkey: &Pubkey,
 ) -> Result<(), ProgramError> {
@@ -279,6 +284,7 @@ pub fn assert_valid_signature_verification_pda(
         &[
             seed_prefixes::SIGNATURE_VERIFICATION_SEED,
             payload_merkle_root,
+            signing_verifier_set,
             &[bump],
         ],
         &crate::ID,
@@ -300,12 +306,14 @@ pub fn assert_valid_signature_verification_pda(
 #[inline]
 pub fn create_signature_verification_pda(
     payload_merkle_root: &[u8; 32],
+    signing_verifier_set: &[u8; 32],
     bump: u8,
 ) -> Result<Pubkey, PubkeyError> {
     Pubkey::create_program_address(
         &[
             seed_prefixes::SIGNATURE_VERIFICATION_SEED,
             payload_merkle_root,
+            signing_verifier_set,
             &[bump],
         ],
         &crate::ID,
@@ -433,8 +441,12 @@ mod tests {
     #[test]
     fn test_get_and_create_signature_verification_pda_bump_reuse() {
         let payload_merkle_root = rand::random();
-        let (found_pda, bump) = get_signature_verification_pda(&payload_merkle_root);
-        let created_pda = create_signature_verification_pda(&payload_merkle_root, bump).unwrap();
+        let signing_verifier_set = rand::random();
+        let (found_pda, bump) =
+            get_signature_verification_pda(&payload_merkle_root, &signing_verifier_set);
+        let created_pda =
+            create_signature_verification_pda(&payload_merkle_root, &signing_verifier_set, bump)
+                .unwrap();
         assert_eq!(found_pda, created_pda);
     }
 

--- a/programs/axelar-solana-gateway/src/processor.rs
+++ b/programs/axelar-solana-gateway/src/processor.rs
@@ -97,12 +97,14 @@ impl Processor {
 
             GatewayInstruction::InitializePayloadVerificationSession {
                 payload_merkle_root,
+                signing_verifier_set_hash,
             } => {
                 msg!("Instruction: Initialize Verification Session");
                 Self::process_initialize_payload_verification_session(
                     program_id,
                     accounts,
                     payload_merkle_root,
+                    signing_verifier_set_hash,
                 )
             }
 

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -84,6 +84,7 @@ impl Processor {
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
         assert_valid_signature_verification_pda(
             &payload_merkle_root,
+            &session.signature_verification.signing_verifier_set_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/processor/approve_message.rs
+++ b/programs/axelar-solana-gateway/src/processor/approve_message.rs
@@ -98,13 +98,6 @@ impl Processor {
             return Err(GatewayError::SigningSessionNotValid.into());
         }
 
-        // Check: message signing verifier set matches the verification session verifier set
-        if merkleised_message.leaf.signing_verifier_set
-            != session.signature_verification.signing_verifier_set_hash
-        {
-            return Err(GatewayError::InvalidVerificationSessionPDA.into());
-        }
-
         // Check: message domain separator matches the gateway's domain separator
         if merkleised_message.leaf.domain_separator != gateway_config.domain_separator {
             return Err(GatewayError::InvalidDomainSeparator.into());

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -80,7 +80,8 @@ impl Processor {
 
         // Check: Verification PDA can be derived from provided seeds.
         // using canonical bump for the session account
-        let (verification_session_pda, bump) = crate::get_signature_verification_pda(&merkle_root);
+        let (verification_session_pda, bump) =
+            crate::get_signature_verification_pda(&merkle_root, &signing_verifier_set_hash);
         if verification_session_pda != *verification_session_account.key {
             return Err(GatewayError::InvalidVerificationSessionPDA.into());
         }
@@ -95,6 +96,7 @@ impl Processor {
         let signers_seeds = &[
             seed_prefixes::SIGNATURE_VERIFICATION_SEED,
             &merkle_root,
+            &signing_verifier_set_hash,
             &[bump],
         ];
 

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -40,6 +40,7 @@ impl Processor {
         program_id: &Pubkey,
         accounts: &[AccountInfo<'_>],
         merkle_root: [u8; 32],
+        signing_verifier_set_hash: [u8; 32],
     ) -> ProgramResult {
         // Accounts
         let accounts_iter = &mut accounts.iter();
@@ -115,6 +116,7 @@ impl Processor {
         let session = SignatureVerificationSessionData::read_mut(&mut data)
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
         session.bump = bump;
+        session.signature_verification.signing_verifier_set_hash = signing_verifier_set_hash;
 
         Ok(())
     }

--- a/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
+++ b/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
@@ -89,6 +89,7 @@ impl Processor {
         // data itself. New verifier set merkle root is used directly as the payload hash.
         assert_valid_signature_verification_pda(
             &new_verifier_set_merkle_root,
+            &session.signature_verification.signing_verifier_set_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
+++ b/programs/axelar-solana-gateway/src/processor/rotate_signers.rs
@@ -2,7 +2,6 @@ use core::convert::TryInto;
 use core::mem::size_of;
 
 use axelar_message_primitives::U256;
-use axelar_solana_encoding::hasher::SolanaSyscallHasher;
 use event_utils::{read_array, EventParseError};
 use program_utils::{
     pda::{BytemuckedPda, ValidPDA},
@@ -86,19 +85,10 @@ impl Processor {
         let session = SignatureVerificationSessionData::read_mut(&mut session_data)
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
 
-        // New verifier set merkle root can be transformed into the payload hash
-        let rotate_verifier_set_hash =
-            axelar_solana_encoding::types::verifier_set::construct_payload_hash::<
-                SolanaSyscallHasher,
-            >(
-                new_verifier_set_merkle_root,
-                session.signature_verification.signing_verifier_set_hash,
-            );
-
         // Check: Verification PDA can be derived from seeds stored into the account
-        // data itself.
+        // data itself. New verifier set merkle root is used directly as the payload hash.
         assert_valid_signature_verification_pda(
-            &rotate_verifier_set_hash,
+            &new_verifier_set_merkle_root,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/src/processor/verify_signature.rs
+++ b/programs/axelar-solana-gateway/src/processor/verify_signature.rs
@@ -55,6 +55,7 @@ impl Processor {
             .ok_or(GatewayError::BytemuckDataLenInvalid)?;
         assert_valid_signature_verification_pda(
             &payload_merkle_root,
+            &session.signature_verification.signing_verifier_set_hash,
             session.bump,
             verification_session_account.key,
         )?;

--- a/programs/axelar-solana-gateway/tests/integration/approve_message.rs
+++ b/programs/axelar-solana-gateway/tests/integration/approve_message.rs
@@ -1,9 +1,11 @@
 use core::str::FromStr;
+use std::iter;
 
-use axelar_solana_encoding::hasher::SolanaSyscallHasher;
+use axelar_solana_encoding::hasher::{NativeHasher, SolanaSyscallHasher};
 use axelar_solana_encoding::types::execute_data::{MerkleisedMessage, MerkleisedPayload};
 use axelar_solana_encoding::types::messages::Messages;
 use axelar_solana_encoding::types::payload::Payload;
+use axelar_solana_encoding::types::verifier_set::verifier_set_hash;
 use axelar_solana_encoding::LeafHash;
 use axelar_solana_gateway::error::GatewayError;
 use axelar_solana_gateway::instructions::approve_message;
@@ -11,11 +13,13 @@ use axelar_solana_gateway::processor::GatewayEvent;
 use axelar_solana_gateway::state::incoming_message::{command_id, IncomingMessage, MessageStatus};
 use axelar_solana_gateway::{get_incoming_message_pda, get_validate_message_signing_pda};
 use axelar_solana_gateway_test_fixtures::gateway::{
-    get_gateway_events, make_messages, make_verifier_set, GetGatewayError, ProgramInvocationState,
+    get_gateway_events, make_messages, make_verifier_set, random_message, GetGatewayError,
+    ProgramInvocationState,
 };
 use axelar_solana_gateway_test_fixtures::SolanaAxelarIntegration;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
+use rand::Rng;
 use solana_program_test::tokio;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
@@ -422,4 +426,98 @@ async fn fails_to_approve_message_with_invalid_domain_separator() {
     // Should fail due to domain separator mismatch
     let gateway_error = tx_result.get_gateway_error().unwrap();
     assert_eq!(gateway_error, GatewayError::InvalidDomainSeparator);
+}
+
+/// Test that old (but still active) verifier sets can fully process a message approval cycle
+#[tokio::test]
+#[rstest::rstest]
+#[case(1)]
+#[case(3)]
+#[case(10)]
+async fn test_old_verifier_set_message_approval(#[case] rotation_count: usize) {
+    // Setup with sufficient retention to keep old verifier sets active
+    let mut metadata = SolanaAxelarIntegration::builder()
+        .initial_signer_weights(vec![42, 55, 33])
+        .previous_signers_retention(1 + rotation_count as u64) // Ensure old verifier sets remain active
+        .build()
+        .setup()
+        .await;
+
+    // Store the original verifier set for later testing
+    let original_verifier_set = metadata.signers.clone();
+    let mut current_verifier_set = original_verifier_set.clone();
+
+    // Perform the specified number of signer rotations
+    for i in 0..rotation_count {
+        let weights: Vec<u128> = iter::repeat_with(|| rand::thread_rng().gen_range(50..200))
+            .take(3)
+            .collect();
+        let new_verifier_set =
+            make_verifier_set(&weights, (i + 1) as u64, metadata.domain_separator);
+
+        // Perform signer rotation
+        let (_verification_session_pda, rotate_result) = metadata
+            .sign_session_and_rotate_signers(
+                &current_verifier_set,
+                &new_verifier_set.verifier_set(),
+            )
+            .await
+            .unwrap(); // init signing session succeeded
+
+        rotate_result.unwrap(); // signer rotation succeeded
+        current_verifier_set = new_verifier_set;
+    }
+
+    // Now test that the original (old) verifier set can still process message approval
+    let test_message = random_message();
+
+    // Step 1: Initialize verification session with old verifier set
+    let payload = Payload::Messages(Messages(vec![test_message.clone()]));
+    let execute_data = metadata.construct_execute_data(&original_verifier_set, payload);
+
+    // Step 2: Initialize and verify payload session manually
+    let verification_session_pda = metadata
+        .init_payload_session_and_verify(&execute_data)
+        .await
+        .expect("Should be able to initialize and verify with old verifier set");
+
+    // Step 3: Extract the message to approve
+    let MerkleisedPayload::NewMessages { messages } = execute_data.payload_items else {
+        unreachable!("we constructed a message batch");
+    };
+
+    let message_to_approve = messages.into_iter().next().unwrap();
+
+    // Step 4: Approve the message using the old verifier set
+    metadata
+        .approve_message(
+            execute_data.payload_merkle_root,
+            message_to_approve.clone(),
+            verification_session_pda,
+        )
+        .await
+        .expect("Old verifier set should be able to approve messages");
+
+    // Step 5: Verify the message was properly approved
+    let command_id = command_id(&test_message.cc_id.chain, &test_message.cc_id.id);
+    let (incoming_message_pda, _) = get_incoming_message_pda(&command_id);
+
+    let incoming_message = metadata.incoming_message(incoming_message_pda).await;
+    assert_eq!(incoming_message.status, MessageStatus::approved());
+    assert_eq!(incoming_message.payload_hash, test_message.payload_hash);
+
+    // Additional verification: check the message hash matches what was used in the approval
+    let expected_message_hash = message_to_approve.leaf.message.hash::<NativeHasher>();
+    assert_eq!(incoming_message.message_hash, expected_message_hash);
+
+    // Verify we used the correct (old) verifier set by checking the execute data
+    let original_verifier_set_hash = verifier_set_hash::<NativeHasher>(
+        &original_verifier_set.verifier_set(),
+        &metadata.domain_separator,
+    )
+    .unwrap();
+    assert_eq!(
+        execute_data.signing_verifier_set_merkle_root,
+        original_verifier_set_hash
+    );
 }

--- a/programs/axelar-solana-gateway/tests/integration/approve_message.rs
+++ b/programs/axelar-solana-gateway/tests/integration/approve_message.rs
@@ -319,53 +319,6 @@ async fn fails_to_approve_message_not_in_payload() {
     }
 }
 
-// cannot approve a message signed by a different verifier set
-#[tokio::test]
-async fn fails_to_approve_message_from_different_verifier_set() {
-    // Setup
-    let mut metadata = SolanaAxelarIntegration::builder()
-        .initial_signer_weights(vec![42, 42])
-        .build()
-        .setup()
-        .await;
-
-    // Create a payload with messages signed by the registered verifier set
-    let payload = Payload::Messages(Messages(make_messages(1)));
-    let execute_data = metadata.construct_execute_data(&metadata.signers.clone(), payload.clone());
-
-    // Initialize and sign the payload session with registered verifier set
-    let verification_session_pda = metadata
-        .init_payload_session_and_verify(&execute_data)
-        .await
-        .unwrap();
-
-    // Create a message signed byte a different verifier set (not registered with the gateway, but
-    // this shoulnd't affect this test)
-    let different_verifier_set = make_verifier_set(&[100, 200], 999, metadata.domain_separator);
-    let different_execute_data = metadata.construct_execute_data(&different_verifier_set, payload);
-    let MerkleisedPayload::NewMessages {
-        messages: different_messages,
-    } = different_execute_data.payload_items
-    else {
-        unreachable!();
-    };
-
-    // Attempt to approve message from different verifier set using the registered session
-    let different_message_info = different_messages.into_iter().next().unwrap();
-    let tx_result = metadata
-        .approve_message(
-            execute_data.payload_merkle_root, // Using registered payload merkle root
-            different_message_info,           // But message from different verifier set
-            verification_session_pda,
-        )
-        .await
-        .unwrap_err();
-
-    // Should fail due to verifier set hash mismatch
-    let gateway_error = tx_result.get_gateway_error().unwrap();
-    assert_eq!(gateway_error, GatewayError::InvalidVerificationSessionPDA);
-}
-
 // cannot approve a message using verifier set payload hash
 #[tokio::test]
 async fn fails_to_approve_message_using_verifier_set_as_the_root() {

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -34,8 +34,10 @@ async fn test_initialize_payload_verification_session() {
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
 
     // Check PDA contains the expected data
-    let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&payload_merkle_root);
+    let (verification_pda, bump) = axelar_solana_gateway::get_signature_verification_pda(
+        &payload_merkle_root,
+        &signing_verifier_set_hash,
+    );
 
     let verification_session_account = metadata
         .try_get_account_no_checks(&verification_pda)

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -1,10 +1,6 @@
-use axelar_solana_encoding::types::messages::Messages;
-use axelar_solana_encoding::types::payload::Payload;
 use axelar_solana_gateway::get_gateway_root_config_pda;
 use axelar_solana_gateway::state::signature_verification::SignatureVerification;
-use axelar_solana_gateway_test_fixtures::gateway::{
-    make_messages, make_verifier_set, random_bytes,
-};
+use axelar_solana_gateway_test_fixtures::gateway::random_bytes;
 use axelar_solana_gateway_test_fixtures::SolanaAxelarIntegration;
 use bytemuck::Zeroable;
 use solana_program_test::tokio;
@@ -99,33 +95,4 @@ async fn test_cannot_initialize_pda_twice() {
         tx_result_second.result.is_err(),
         "Second initialization should fail"
     );
-}
-
-#[tokio::test]
-async fn test_same_payload_can_be_signed_by_multiple_verifier_sets_and_be_initialised() {
-    // Setup
-    let mut metadata = SolanaAxelarIntegration::builder()
-        .initial_signer_weights(vec![42])
-        .build()
-        .setup()
-        .await;
-
-    let signers_a = make_verifier_set(&[500, 200], 1, metadata.domain_separator);
-    let signers_b = make_verifier_set(&[500, 23], 101, metadata.domain_separator);
-
-    let messages = make_messages(5);
-    let payload = Payload::Messages(Messages(messages.clone()));
-    let execute_data_a = metadata.construct_execute_data(&signers_a, payload.clone());
-    let execute_data_b = metadata.construct_execute_data(&signers_b, payload);
-
-    for execute_data in [execute_data_a, execute_data_b] {
-        let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
-            metadata.payer.pubkey(),
-            metadata.gateway_root_pda,
-            execute_data.payload_merkle_root,
-            execute_data.signing_verifier_set_merkle_root,
-        )
-        .unwrap();
-        let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
-    }
 }

--- a/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
+++ b/programs/axelar-solana-gateway/tests/integration/initialize_signature_verification.rs
@@ -22,11 +22,13 @@ async fn test_initialize_payload_verification_session() {
     // Action
     let payload_merkle_root = random_bytes();
     let gateway_config_pda = get_gateway_root_config_pda().0;
+    let signing_verifier_set_hash = metadata.init_gateway_config_verifier_set_data().hash;
 
     let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
         metadata.payer.pubkey(),
         gateway_config_pda,
         payload_merkle_root,
+        signing_verifier_set_hash,
     )
     .unwrap();
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
@@ -52,10 +54,9 @@ async fn test_initialize_payload_verification_session() {
         .await;
 
     assert_eq!(session.bump, bump);
-    assert_eq!(
-        session.signature_verification,
-        SignatureVerification::zeroed()
-    );
+    let mut expected_verification = SignatureVerification::zeroed();
+    expected_verification.signing_verifier_set_hash = signing_verifier_set_hash;
+    assert_eq!(session.signature_verification, expected_verification);
 }
 
 #[tokio::test]
@@ -70,11 +71,13 @@ async fn test_cannot_initialize_pda_twice() {
     // Action: First initialization
     let payload_merkle_root = random_bytes();
     let gateway_config_pda = get_gateway_root_config_pda().0;
+    let signing_verifier_set_hash = metadata.init_gateway_config_verifier_set_data().hash;
 
     let ix = axelar_solana_gateway::instructions::initialize_payload_verification_session(
         metadata.payer.pubkey(),
         gateway_config_pda,
         payload_merkle_root,
+        signing_verifier_set_hash,
     )
     .unwrap();
     let _tx_result = metadata.send_tx(&[ix]).await.unwrap();
@@ -84,6 +87,7 @@ async fn test_cannot_initialize_pda_twice() {
         metadata.payer.pubkey(),
         gateway_config_pda,
         payload_merkle_root,
+        signing_verifier_set_hash,
     )
     .unwrap();
     let tx_result_second = metadata.send_tx(&[ix_second]).await.unwrap_err();
@@ -117,6 +121,7 @@ async fn test_same_payload_can_be_signed_by_multiple_verifier_sets_and_be_initia
             metadata.payer.pubkey(),
             metadata.gateway_root_pda,
             execute_data.payload_merkle_root,
+            execute_data.signing_verifier_set_merkle_root,
         )
         .unwrap();
         let _tx_result = metadata.send_tx(&[ix]).await.unwrap();

--- a/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
+++ b/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
@@ -41,9 +41,14 @@ async fn test_verify_one_signature(
     let leaf_info = execute_data.signing_verifier_set_leaves.first().unwrap();
 
     // Verify the signature
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let ix = axelar_solana_gateway::instructions::verify_signature(
         metadata.gateway_root_pda,
         verifier_set_tracker_pda,
+        verification_session_pda,
         execute_data.payload_merkle_root,
         leaf_info.clone(),
     )
@@ -59,8 +64,10 @@ async fn test_verify_one_signature(
         .unwrap();
 
     // Check that the PDA contains the expected data
-    let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&execute_data.payload_merkle_root);
+    let (verification_pda, bump) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -101,9 +108,14 @@ async fn test_verify_all_signatures() {
 
     for verifier_set_leaf in execute_data.signing_verifier_set_leaves {
         // Verify the signature
+        let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+            &execute_data.payload_merkle_root,
+            &execute_data.signing_verifier_set_merkle_root,
+        );
         let ix = axelar_solana_gateway::instructions::verify_signature(
             metadata.gateway_root_pda,
             verifier_set_tracker_pda,
+            verification_session_pda,
             execute_data.payload_merkle_root,
             verifier_set_leaf,
         )
@@ -118,8 +130,10 @@ async fn test_verify_all_signatures() {
     }
 
     // Check that the PDA contains the expected data
-    let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&execute_data.payload_merkle_root);
+    let (verification_pda, bump) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -165,9 +179,14 @@ async fn test_fails_to_verify_bad_signature() {
     };
 
     // Verify the signature
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let ix = axelar_solana_gateway::instructions::verify_signature(
         metadata.gateway_root_pda,
         verifier_set_tracker_pda,
+        verification_session_pda,
         execute_data.payload_merkle_root,
         leaf_info.clone(),
     )
@@ -218,9 +237,14 @@ async fn test_fails_to_verify_signature_for_different_merkle_root() {
     };
 
     // Verify the signature
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &random_valid_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let ix = axelar_solana_gateway::instructions::verify_signature(
         metadata.gateway_root_pda,
         verifier_set_tracker_pda,
+        verification_session_pda,
         random_valid_merkle_root, // <- this is the failure culprit
         leaf_info.clone(),
     )
@@ -284,9 +308,14 @@ async fn test_large_weight_will_validate_whole_batch() {
         .expect("guaranteed to be in the set");
 
     // Verify the signature
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let ix = axelar_solana_gateway::instructions::verify_signature(
         metadata.gateway_root_pda,
         verifier_set_tracker_pda,
+        verification_session_pda,
         execute_data.payload_merkle_root,
         large_wetight_leaf.clone(),
     )
@@ -302,8 +331,10 @@ async fn test_large_weight_will_validate_whole_batch() {
         .unwrap();
 
     // Check that the PDA contains the expected data
-    let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&execute_data.payload_merkle_root);
+    let (verification_pda, bump) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -442,9 +473,14 @@ async fn fails_to_verify_signature_with_invalid_domain_separator() {
     leaf_info.leaf.domain_separator[0] = leaf_info.leaf.domain_separator[0].wrapping_add(1);
 
     // Attempt to verify the signature with different domain separator
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let ix = axelar_solana_gateway::instructions::verify_signature(
         metadata.gateway_root_pda,
         verifier_set_tracker_pda,
+        verification_session_pda,
         execute_data.payload_merkle_root,
         leaf_info,
     )
@@ -479,8 +515,10 @@ async fn test_verify_all_signatures_when_session_pda_has_lamports() {
         .await;
     let execute_data = metadata.construct_execute_data(&metadata.signers.clone(), payload);
 
-    let (verification_session_pda, _) =
-        axelar_solana_gateway::get_signature_verification_pda(&execute_data.payload_merkle_root);
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let payer = metadata.fixture.payer.pubkey();
 
     // Transfer lamports to the PDA to try to prevent its initialization
@@ -501,9 +539,14 @@ async fn test_verify_all_signatures_when_session_pda_has_lamports() {
 
     for verifier_set_leaf in execute_data.signing_verifier_set_leaves {
         // Verify the signature
+        let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+            &execute_data.payload_merkle_root,
+            &execute_data.signing_verifier_set_merkle_root,
+        );
         let ix = axelar_solana_gateway::instructions::verify_signature(
             metadata.gateway_root_pda,
             verifier_set_tracker_pda,
+            verification_session_pda,
             execute_data.payload_merkle_root,
             verifier_set_leaf,
         )
@@ -518,8 +561,10 @@ async fn test_verify_all_signatures_when_session_pda_has_lamports() {
     }
 
     // Check that the PDA contains the expected data
-    let (verification_pda, bump) =
-        axelar_solana_gateway::get_signature_verification_pda(&execute_data.payload_merkle_root);
+    let (verification_pda, bump) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
 
     let session = metadata
         .signature_verification_session(verification_pda)
@@ -557,9 +602,14 @@ async fn test_fails_when_verifier_submits_signature_twice() {
     let leaf_info = execute_data.signing_verifier_set_leaves.first().unwrap();
 
     // Create the verify signature instruction
+    let (verification_session_pda, _) = axelar_solana_gateway::get_signature_verification_pda(
+        &execute_data.payload_merkle_root,
+        &execute_data.signing_verifier_set_merkle_root,
+    );
     let ix = axelar_solana_gateway::instructions::verify_signature(
         metadata.gateway_root_pda,
         verifier_set_tracker_pda,
+        verification_session_pda,
         execute_data.payload_merkle_root,
         leaf_info.clone(),
     )


### PR DESCRIPTION
Supersedes #271 

## Goals
- Block bad actors from reserving Signature Verification Session PDAs to prevent message batch approvals
- Support multiple generations of active/valid verifier sets creating their own Signature Verification Session PDAs

## Implementation: Adding Verifier Set Hash to PDA Seeds

We've updated how Signature Verification Session PDA addresses are calculated by including the signing verifier set hash in the seed.

Previously, Signature Verification Session PDAs used only the payload merkle root as a seed: `[SIGNATURE_VERIFICATION_SEED, payload_merkle_root]`. This made it possible for anyone to claim PDA addresses for any message batch, blocking legitimate verifier sets.

Our fix adds the signing verifier set hash to the PDA creation: `[SIGNATURE_VERIFICATION_SEED, payload_merkle_root, signing_verifier_set_hash]`. This gives each verifier set its own unique address space that bad actors can't predict or take over without knowing which specific verifier set will sign.

This also lets multiple generations of verifier sets process messages concurrently, each with its own isolated account space.

### Code Changes

#### 1. Removed Signing Verifier Set from Hashed Content
- **Removed `signing_verifier_set` from `MessageLeaf`** - Took out verifier set field from message Merkle tree leaf structure
- **Changed payload hash construction** - Removed verifier set dependencies from RotateSigners message payload hashing
- **Simplified verifier set hash calculation** - Verifier set hash now only contains the Merkle root of verifier data

#### 2. Changed PDA Seed Calculation
- **Added signing verifier set hash to PDA seeds** - Signature Verification Session PDAs now include the signing verifier set hash when calculating addresses
- **Created separate addresses for each verifier set** - Different verifier sets now use distinct PDA addresses with their own verification session storage

#### 3. Updated Verification Session Initialization
- **Added signing verifier set parameter** - `initialize_payload_verification_session` now takes the signing verifier set hash as input and writes it to the verification session account immediately
- **Eliminated lazy initialization** - Verification session now stores the verifier set hash upfront instead of determining it later
- **Updated validation checks** - System now checks that the verifier set exists before allowing session initialization
