### PR TITLE
chore: replace log_index with ix_index and event_ix_index fields

### DIFF
--- a/programs/axelar-solana-gas-service/src/events.rs
+++ b/programs/axelar-solana-gas-service/src/events.rs
@@ -30,8 +30,10 @@ pub struct NativeGasAddedEvent {
     pub config_pda: Pubkey,
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
-    /// index of the log
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The refund address
     pub refund_address: Pubkey,
     /// amount of SOL
@@ -46,8 +48,10 @@ pub struct NativeGasRefundedEvent {
     pub tx_hash: [u8; 64],
     /// The Gas service config PDA
     pub config_pda: Pubkey,
-    /// The log index
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The receiver of the refund
     pub receiver: Pubkey,
     /// amount of SOL
@@ -92,8 +96,10 @@ pub struct SplGasAddedEvent {
     pub token_program_id: Pubkey,
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
-    /// index of the log
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The refund address
     pub refund_address: Pubkey,
     /// amount of tokens
@@ -114,8 +120,10 @@ pub struct SplGasRefundedEvent {
     pub tx_hash: [u8; 64],
     /// The Gas service config PDA
     pub config_pda: Pubkey,
-    /// The log index
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The receiver of the refund
     pub receiver: Pubkey,
     /// amount of tokens

--- a/programs/axelar-solana-gas-service/src/instructions.rs
+++ b/programs/axelar-solana-gas-service/src/instructions.rs
@@ -69,8 +69,10 @@ pub enum GasServiceInstruction {
     AddSplGas {
         /// A 64-byte unique transaction identifier.
         tx_hash: [u8; 64],
-        /// The index of the log entry in the transaction.
-        log_index: u64,
+        /// Index of the CallContract instruction
+        ix_index: u8,
+        /// Index of the CPI event inside inner instructions
+        event_ix_index: u8,
         /// The additional SPL tokens to add as gas.
         gas_fee_amount: u64,
         /// The decimals for the mint
@@ -107,8 +109,10 @@ pub enum GasServiceInstruction {
     RefundSplFees {
         /// A 64-byte unique transaction identifier
         tx_hash: [u8; 64],
-        /// The index of the log entry in the transaction
-        log_index: u64,
+        /// Index of the CallContract instruction
+        ix_index: u8,
+        /// Index of the CPI event inside inner instructions
+        event_ix_index: u8,
         /// The amount of SPL tokens to be refunded
         fees: u64,
         /// The decimals for the mint
@@ -143,8 +147,10 @@ pub enum GasServiceInstruction {
     AddNativeGas {
         /// A 64-byte unique transaction identifier.
         tx_hash: [u8; 64],
-        /// The index of the log entry in the transaction.
-        log_index: u64,
+        /// Index of the CallContract instruction
+        ix_index: u8,
+        /// Index of the CPI event inside inner instructions
+        event_ix_index: u8,
         /// The additional SOL to add as gas.
         gas_fee_amount: u64,
         /// Where refunds should be sent.
@@ -171,8 +177,10 @@ pub enum GasServiceInstruction {
     RefundNativeFees {
         /// A 64-byte unique transaction identifier.
         tx_hash: [u8; 64],
-        /// The index of the log entry in the transaction.
-        log_index: u64,
+        /// Index of the CallContract instruction
+        ix_index: u8,
+        /// Index of the CPI event inside inner instructions
+        event_ix_index: u8,
         /// The amount of SOL to be refunded.
         fees: u64,
     },
@@ -271,13 +279,15 @@ pub fn pay_native_for_contract_call_instruction(
 pub fn add_native_gas_instruction(
     sender: &Pubkey,
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     gas_fee_amount: u64,
     refund_address: Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let ix_data = borsh::to_vec(&GasServiceInstruction::AddNativeGas {
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_fee_amount,
         refund_address,
     })?;
@@ -334,12 +344,14 @@ pub fn refund_native_fees_instruction(
     operator: &Pubkey,
     receiver: &Pubkey,
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     fees: u64,
 ) -> Result<Instruction, ProgramError> {
     let ix_data = borsh::to_vec(&GasServiceInstruction::RefundNativeFees {
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         fees,
     })?;
     let (config_pda, _) = crate::get_config_pda();
@@ -433,14 +445,16 @@ pub fn add_spl_gas_instruction(
     token_program_id: &Pubkey,
     signer_pubkeys: &[Pubkey],
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     gas_fee_amount: u64,
     refund_address: Pubkey,
     decimals: u8,
 ) -> Result<Instruction, ProgramError> {
     let ix_data = borsh::to_vec(&GasServiceInstruction::AddSplGas {
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         decimals,
         gas_fee_amount,
         refund_address,
@@ -526,14 +540,16 @@ pub fn refund_spl_fees_instruction(
     mint: &Pubkey,
     receiver: &Pubkey,
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     fees: u64,
     decimals: u8,
 ) -> Result<Instruction, ProgramError> {
     let ix_data = borsh::to_vec(&GasServiceInstruction::RefundSplFees {
         decimals,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         fees,
     })?;
     let (config_pda, _bump) = crate::get_config_pda();

--- a/programs/axelar-solana-gas-service/src/processor.rs
+++ b/programs/axelar-solana-gas-service/src/processor.rs
@@ -24,6 +24,7 @@ mod transfer_operatorship;
 ///
 /// # Errors
 /// - if the ix processing resulted in an error
+#[allow(clippy::too_many_lines)]
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
@@ -84,7 +85,15 @@ pub fn process_instruction(
             event_ix_index,
             fees,
             decimals,
-        } => refund_spl(program_id, accounts, tx_hash, ix_index, event_ix_index, fees, decimals),
+        } => refund_spl(
+            program_id,
+            accounts,
+            tx_hash,
+            ix_index,
+            event_ix_index,
+            fees,
+            decimals,
+        ),
 
         // Native token instructions
         GasServiceInstruction::PayNativeForContractCall {
@@ -125,6 +134,13 @@ pub fn process_instruction(
             ix_index,
             event_ix_index,
             fees,
-        } => refund_native(program_id, accounts, tx_hash, ix_index, event_ix_index, fees),
+        } => refund_native(
+            program_id,
+            accounts,
+            tx_hash,
+            ix_index,
+            event_ix_index,
+            fees,
+        ),
     }
 }

--- a/programs/axelar-solana-gas-service/src/processor.rs
+++ b/programs/axelar-solana-gas-service/src/processor.rs
@@ -60,7 +60,8 @@ pub fn process_instruction(
         ),
         GasServiceInstruction::AddSplGas {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             decimals,
             refund_address,
@@ -68,7 +69,8 @@ pub fn process_instruction(
             program_id,
             accounts,
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
             decimals,
@@ -78,10 +80,11 @@ pub fn process_instruction(
         }
         GasServiceInstruction::RefundSplFees {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             fees,
             decimals,
-        } => refund_spl(program_id, accounts, tx_hash, log_index, fees, decimals),
+        } => refund_spl(program_id, accounts, tx_hash, ix_index, event_ix_index, fees, decimals),
 
         // Native token instructions
         GasServiceInstruction::PayNativeForContractCall {
@@ -101,14 +104,16 @@ pub fn process_instruction(
         ),
         GasServiceInstruction::AddNativeGas {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         } => add_native_gas(
             program_id,
             accounts,
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         ),
@@ -117,8 +122,9 @@ pub fn process_instruction(
         }
         GasServiceInstruction::RefundNativeFees {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             fees,
-        } => refund_native(program_id, accounts, tx_hash, log_index, fees),
+        } => refund_native(program_id, accounts, tx_hash, ix_index, event_ix_index, fees),
     }
 }

--- a/programs/axelar-solana-gas-service/src/processor/native.rs
+++ b/programs/axelar-solana-gas-service/src/processor/native.rs
@@ -74,7 +74,8 @@ pub(crate) fn add_native_gas(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     gas_fee_amount: u64,
     refund_address: Pubkey,
 ) -> ProgramResult {
@@ -102,7 +103,8 @@ pub(crate) fn add_native_gas(
     emit_cpi!(NativeGasAddedEvent {
         config_pda: *config_pda.key,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         refund_address,
         gas_fee_amount,
     });
@@ -124,7 +126,8 @@ pub(crate) fn refund_native(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     fees: u64,
 ) -> ProgramResult {
     send_native(program_id, accounts, fees)?;
@@ -139,7 +142,8 @@ pub(crate) fn refund_native(
     emit_cpi!(NativeGasRefundedEvent {
         tx_hash,
         config_pda: *config_pda.key,
-        log_index,
+        ix_index,
+        event_ix_index,
         receiver: *receiver.key,
         fees,
     });
@@ -210,7 +214,8 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let accounts = vec![];
         let tx_hash = [0; 64];
-        let log_index = 0;
+        let ix_index = 0;
+        let event_ix_index = 0;
         let gas_fee_amount = 0;
         let refund_address = Pubkey::new_unique();
 
@@ -218,7 +223,8 @@ mod tests {
             &program_id,
             &accounts,
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         );

--- a/programs/axelar-solana-gas-service/src/processor/spl.rs
+++ b/programs/axelar-solana-gas-service/src/processor/spl.rs
@@ -150,7 +150,8 @@ pub(crate) fn add_spl_gas(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     gas_fee_amount: u64,
     refund_address: Pubkey,
     decimals: u8,
@@ -215,7 +216,8 @@ pub(crate) fn add_spl_gas(
         mint: *mint.key,
         token_program_id: *token_program.key,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         refund_address,
         gas_fee_amount,
     });
@@ -238,7 +240,8 @@ pub(crate) fn refund_spl(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     fees: u64,
     decimals: u8,
 ) -> ProgramResult {
@@ -260,7 +263,8 @@ pub(crate) fn refund_spl(
         token_program_id: *token_program.key,
         tx_hash,
         config_pda: *config_pda.key,
-        log_index,
+        ix_index,
+        event_ix_index,
         receiver: *receiver_token_account.key,
         fees,
     });
@@ -367,7 +371,8 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let accounts = vec![];
         let tx_hash = [0; 64];
-        let log_index = 0;
+        let ix_index = 0;
+        let event_ix_index = 0;
         let gas_fee_amount = 0;
         let refund_address = Pubkey::new_unique();
         let decimals = 0;
@@ -376,7 +381,8 @@ mod tests {
             &program_id,
             &accounts,
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
             decimals,
@@ -402,11 +408,12 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let accounts = vec![];
         let tx_hash = [0; 64];
-        let log_index = 0;
+        let ix_index = 0;
+        let event_ix_index = 0;
         let fees = 0;
         let decimals = 0;
 
-        let result = refund_spl(&program_id, &accounts, tx_hash, log_index, fees, decimals);
+        let result = refund_spl(&program_id, &accounts, tx_hash, ix_index, event_ix_index, fees, decimals);
 
         assert_eq!(result, Err(ProgramError::InvalidInstructionData));
     }

--- a/programs/axelar-solana-gas-service/src/processor/spl.rs
+++ b/programs/axelar-solana-gas-service/src/processor/spl.rs
@@ -146,6 +146,7 @@ pub(crate) fn process_pay_spl_for_contract_call(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn add_spl_gas(
     program_id: &Pubkey,
     accounts: &[AccountInfo<'_>],
@@ -413,7 +414,15 @@ mod tests {
         let fees = 0;
         let decimals = 0;
 
-        let result = refund_spl(&program_id, &accounts, tx_hash, ix_index, event_ix_index, fees, decimals);
+        let result = refund_spl(
+            &program_id,
+            &accounts,
+            tx_hash,
+            ix_index,
+            event_ix_index,
+            fees,
+            decimals,
+        );
 
         assert_eq!(result, Err(ProgramError::InvalidInstructionData));
     }

--- a/programs/axelar-solana-gas-service/tests/module/native/add_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/add_gas.rs
@@ -34,11 +34,13 @@ async fn test_add_native_gas() {
     let refund_address = Pubkey::new_unique();
     let gas_amount = 1_000_000;
     let tx_hash = [42; 64];
-    let log_index = 1232;
+    let ix_index = 1;
+    let event_ix_index = 2;
     let ix = axelar_solana_gas_service::instructions::add_native_gas_instruction(
         &payer.pubkey(),
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
     )
@@ -72,7 +74,8 @@ async fn test_add_native_gas() {
     let expected_event = NativeGasAddedEvent {
         config_pda: gas_utils.config_pda,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         refund_address,
         gas_fee_amount: gas_amount,
     };
@@ -132,11 +135,13 @@ async fn fails_if_payer_not_signer() {
     let refund_address = Pubkey::new_unique();
     let gas_amount = 1_000_000;
     let tx_hash = [42; 64];
-    let log_index = 1232;
+    let ix_index = 1;
+    let event_ix_index = 2;
     let mut ix = axelar_solana_gas_service::instructions::add_native_gas_instruction(
         &payer.pubkey(),
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
     )

--- a/programs/axelar-solana-gas-service/tests/module/native/refund_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/refund_gas.rs
@@ -28,12 +28,14 @@ async fn test_refund_native() {
     // Action
     let gas_amount = 1_000_000;
     let tx_hash = [42; 64];
-    let log_index = 1232;
+    let ix_index = 1;
+    let event_ix_index = 2;
     let ix = axelar_solana_gas_service::instructions::refund_native_fees_instruction(
         &gas_utils.operator.pubkey(),
         &refunded_user.pubkey(),
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
     )
     .unwrap();
@@ -66,7 +68,8 @@ async fn test_refund_native() {
     let expected_event = NativeGasRefundedEvent {
         config_pda: gas_utils.config_pda,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         receiver: refunded_user.pubkey(),
         fees: gas_amount,
     };
@@ -123,12 +126,14 @@ async fn test_refund_native_fails_if_not_signed_by_authority() {
     let refunded_user = Keypair::new();
     let gas_amount = 1_000_000;
     let tx_hash = [42; 64];
-    let log_index = 1232;
+    let ix_index = 1;
+    let event_ix_index = 2;
     let mut ix = axelar_solana_gas_service::instructions::refund_native_fees_instruction(
         &gas_utils.operator.pubkey(),
         &refunded_user.pubkey(),
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
     )
     .unwrap();
@@ -163,12 +168,14 @@ async fn test_refund_native_fails_with_zero_fee() {
     let refunded_user = Keypair::new();
     let gas_amount = 0; // Zero fee should fail
     let tx_hash = [42; 64];
-    let log_index = 1232;
+    let ix_index = 1;
+    let event_ix_index = 2;
     let ix = axelar_solana_gas_service::instructions::refund_native_fees_instruction(
         &gas_utils.operator.pubkey(),
         &refunded_user.pubkey(),
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
     )
     .unwrap();

--- a/programs/axelar-solana-gas-service/tests/module/spl/add_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/add_gas.rs
@@ -50,7 +50,8 @@ async fn test_add_spl_gas(#[case] token_program_id: Pubkey) {
     // Prepare args
     let refund_address = Pubkey::new_unique();
     let tx_hash = [42; 64];
-    let log_index = 123;
+    let ix_index = 1;
+    let event_ix_index = 2;
 
     // Create the instruction for paying gas fees with SPL tokens
     let ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
@@ -60,7 +61,8 @@ async fn test_add_spl_gas(#[case] token_program_id: Pubkey) {
         &token_program_id,
         &[],
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
         decimals,
@@ -98,7 +100,8 @@ async fn test_add_spl_gas(#[case] token_program_id: Pubkey) {
         mint,
         token_program_id,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         refund_address,
         gas_fee_amount: gas_amount,
     };
@@ -167,7 +170,8 @@ async fn test_add_spl_gas_missing_signer(#[case] token_program_id: Pubkey) {
     // Create the instruction without making the payer a signer
     let refund_address = Pubkey::new_unique();
     let tx_hash = [42; 64];
-    let log_index = 123;
+    let ix_index = 1;
+    let event_ix_index = 2;
 
     let mut ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
         &payer.pubkey(),
@@ -176,7 +180,8 @@ async fn test_add_spl_gas_missing_signer(#[case] token_program_id: Pubkey) {
         &token_program_id,
         &[],
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
         decimals,
@@ -248,7 +253,8 @@ async fn test_add_spl_gas_invalid_sender_ata_wrong_mint(#[case] token_program_id
     // Create the instruction with mismatched mint/ATA
     let refund_address = Pubkey::new_unique();
     let tx_hash = [42; 64];
-    let log_index = 123;
+    let ix_index = 1;
+    let event_ix_index = 2;
 
     let ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
         &payer.pubkey(),
@@ -257,7 +263,8 @@ async fn test_add_spl_gas_invalid_sender_ata_wrong_mint(#[case] token_program_id
         &token_program_id,
         &[],
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
         decimals,
@@ -318,7 +325,8 @@ async fn test_add_spl_gas_invalid_sender_ata_wrong_owner(#[case] token_program_i
     // Create the instruction with wrong owner's ATA
     let refund_address = Pubkey::new_unique();
     let tx_hash = [42; 64];
-    let log_index = 123;
+    let ix_index = 1;
+    let event_ix_index = 2;
 
     let ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
         &payer.pubkey(),  // Payer is the signer
@@ -327,7 +335,8 @@ async fn test_add_spl_gas_invalid_sender_ata_wrong_owner(#[case] token_program_i
         &token_program_id,
         &[],
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
         decimals,
@@ -393,7 +402,8 @@ async fn test_add_spl_gas_invalid_config_pda_ata_wrong_mint(#[case] token_progra
     // Create the instruction with mismatched config ATA
     let refund_address = Pubkey::new_unique();
     let tx_hash = [42; 64];
-    let log_index = 123;
+    let ix_index = 1;
+    let event_ix_index = 2;
 
     // Manually construct the instruction to use wrong config_pda_ata
     let mut ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
@@ -403,7 +413,8 @@ async fn test_add_spl_gas_invalid_config_pda_ata_wrong_mint(#[case] token_progra
         &token_program_id,
         &[],
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
         decimals,
@@ -467,7 +478,8 @@ async fn test_add_spl_gas_invalid_config_pda_ata_wrong_owner(#[case] token_progr
     // Create the instruction with wrong owner's ATA as config_pda_ata
     let refund_address = Pubkey::new_unique();
     let tx_hash = [42; 64];
-    let log_index = 123;
+    let ix_index = 1;
+    let event_ix_index = 2;
 
     let mut ix = axelar_solana_gas_service::instructions::add_spl_gas_instruction(
         &payer.pubkey(),
@@ -476,7 +488,8 @@ async fn test_add_spl_gas_invalid_config_pda_ata_wrong_owner(#[case] token_progr
         &token_program_id,
         &[],
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         refund_address,
         decimals,

--- a/programs/axelar-solana-gas-service/tests/module/spl/refund_gas.rs
+++ b/programs/axelar-solana-gas-service/tests/module/spl/refund_gas.rs
@@ -49,14 +49,16 @@ async fn test_refund_spl_fees(#[case] token_program_id: Pubkey) {
 
     // Create the instruction for paying gas fees with SPL tokens
     let tx_hash = [132; 64];
-    let log_index = 42;
+    let ix_index = 1;
+    let event_ix_index = 2;
     let ix = axelar_solana_gas_service::instructions::refund_spl_fees_instruction(
         &gas_utils.operator.pubkey(),
         &token_program_id,
         &mint,
         &receiver_ata,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         gas_amount,
         decimals,
     )
@@ -93,7 +95,8 @@ async fn test_refund_spl_fees(#[case] token_program_id: Pubkey) {
         token_program_id,
         tx_hash,
         config_pda: gas_utils.config_pda,
-        log_index,
+        ix_index,
+        event_ix_index,
         receiver: receiver_ata,
         fees: gas_amount,
     };


### PR DESCRIPTION
**Summary of changes**

In order to accommodate CPI events this PR changes the `log_index` to a more suitable pair of instruction index and "inner instruction" index or the "event instruction index" (being the CPI event instruction). This stems from the following discussion: https://github.com/axelarnetwork/axelar-amplifier/pull/1048#discussion_r2373492249

I've used `u8` for both indexes, the available docs mention that there is an upper limit of 63 CPI calls so we should be fine.

**Reviewer recommendations**

Should be easy to follow.
