### PR TITLE
feat: add Solana offchain prefix to signature verification

### DIFF
--- a/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
+++ b/programs/axelar-solana-gateway/tests/integration/verify_signature.rs
@@ -4,7 +4,7 @@ use axelar_solana_encoding::types::messages::Messages;
 use axelar_solana_encoding::types::payload::Payload;
 use axelar_solana_encoding::types::pubkey::{PublicKey, Signature};
 use axelar_solana_gateway::error::GatewayError;
-use axelar_solana_gateway::state::signature_verification::verify_ecdsa_signature;
+use axelar_solana_gateway::state::signature_verification::verify_ecdsa_signature_with_prefix;
 use axelar_solana_gateway_test_fixtures::base::FindLog;
 use axelar_solana_gateway_test_fixtures::gateway::{
     make_verifier_set, random_bytes, random_message, GetGatewayError,
@@ -394,7 +394,7 @@ fn can_verify_signatures_with_ecrecover_recovery_id() {
         panic!("unexpected pubkey type");
     };
 
-    let is_valid = verify_ecdsa_signature(&pubkey, &signature, &message_hash);
+    let is_valid = verify_ecdsa_signature_with_prefix(&pubkey, &signature, &message_hash);
     assert!(is_valid);
 }
 
@@ -412,7 +412,7 @@ fn can_verify_signatures_with_standard_recovery_id() {
         panic!("unexpected pubkey type");
     };
 
-    let is_valid = verify_ecdsa_signature(&pubkey, &signature, &message_hash);
+    let is_valid = verify_ecdsa_signature_with_prefix(&pubkey, &signature, &message_hash);
     assert!(is_valid);
 }
 


### PR DESCRIPTION
This PR implements the `\xffsolana offchain` prefix requirement for all signature verifications in the `axelar-solana-gateway` crate.

## Changes

### Core Implementation
- **Added wrapper functions**: `verify_ecdsa_signature_with_prefix()` and `verify_eddsa_signature_with_prefix()`
- **Made original functions private**: `verify_ecdsa_signature()` and `verify_eddsa_signature()` are no longer public
- **Updated verification flow**: `verify_digital_signature()`, the "entrypoint" for verifying signatures, now calls wrapper functions
- **Prefix handling**: All signatures are verified against `keccak256(b"\xffsolana offchain" + message)`

### Test Compatibility
- **Updated test fixtures**: `TestSigningKey::sign()` now generates signatures with the prefix
- **Updated integration tests**: Import and use prefixed verification functions
- **Updated unit tests**: Generate test signatures with prefix+hash approach

## Technical Details

### TLDR;
_(read "message" as the cryptographic message being signed, do not mistake it for Axelar's Message concept)_
```
Original: message → verify
New:      message → [prefix + message] → hash → verify
```

### Implementation overview
```rust
const SOLANA_OFFCHAIN_PREFIX: &[u8] = b"\xffsolana offchain";

pub fn verify_ecdsa_signature_with_prefix(
    pubkey: &Secp256k1Pubkey,
    signature: &EcdsaRecoverableSignature,
    message: &[u8; 32],
) -> bool {
    let mut prefixed_message = Vec::new();
    prefixed_message.extend_from_slice(SOLANA_OFFCHAIN_PREFIX);
    prefixed_message.extend_from_slice(message);
    let hashed_message = hash(&prefixed_message);
    verify_ecdsa_signature(pubkey, signature, &hashed_message) // same old function, just changed it to be private now
}
```

## Breaking Changes

**External signature generators (`multisig-prover`) must update their implementation:**

1. **Prefix the message**: Prepend `\xffsolana offchain` to the original message
2. **Hash the result**: Apply keccak256 to the prefixed message
3. **Sign the hash**: Generate signature against the hashed result

```rust
// Required for external systems
let prefixed = [b"\xffsolana offchain", &original_message].concat();
let message_to_sign = keccak256(&prefixed);
let signature = sign(&message_to_sign);
```
