### PR TITLE
refactor(its): improve account handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-discriminators",
  "borsh 1.5.7",
+ "solana-program",
 ]
 
 [[package]]

--- a/helpers/event-cpi/Cargo.toml
+++ b/helpers/event-cpi/Cargo.toml
@@ -9,3 +9,4 @@ workspace = true
 [dependencies]
 anchor-discriminators.workspace = true
 borsh.workspace = true
+solana-program.workspace = true

--- a/helpers/event-cpi/src/lib.rs
+++ b/helpers/event-cpi/src/lib.rs
@@ -18,3 +18,26 @@ pub const EVENT_AUTHORITY_SEED: &[u8] = b"__event_authority";
 pub trait CpiEvent: BorshSerialize + BorshDeserialize + Discriminator {
     fn data(&self) -> Vec<u8>;
 }
+
+/// Trait for structs that contain event CPI accounts.
+///
+/// This trait should be implemented by account structs that need to emit events via CPI.
+/// The macro `#[event_cpi]` from the `event-cpi-macros` crate can automatically
+/// implement this trait for structs with the required fields:
+/// - `__event_cpi_authority_info: &'a AccountInfo<'a>`
+/// - `__event_cpi_program_account: &'a AccountInfo<'a>`
+///
+/// # Example
+/// ```ignore
+/// use event_cpi::EventAccounts;
+/// use solana_program::account_info::AccountInfo;
+///
+/// #[event_cpi_macros::event_cpi]
+/// pub struct MyAccounts<'a> {
+///     pub user: &'a AccountInfo<'a>,
+/// }
+/// ```
+pub trait EventAccounts<'a> {
+    /// Returns the two accounts required for event CPI: authority and program account.
+    fn event_accounts(&self) -> [&'a solana_program::account_info::AccountInfo<'a>; 2];
+}

--- a/programs/axelar-solana-its/src/accounts.rs
+++ b/programs/axelar-solana-its/src/accounts.rs
@@ -1,0 +1,1338 @@
+use event_cpi_macros::event_cpi;
+use program_utils::next_optional_account_info;
+use program_utils::validate_mpl_token_metadata_key;
+use program_utils::validate_rent_key;
+use program_utils::validate_spl_associated_token_account_key;
+use program_utils::validate_system_account_key;
+use program_utils::validate_sysvar_instructions_key;
+use solana_program::account_info::next_account_info;
+use solana_program::account_info::AccountInfo;
+use solana_program::msg;
+use solana_program::program_error::ProgramError;
+use solana_program::pubkey::Pubkey;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token_2022::check_spl_token_program_account;
+use spl_token_2022::extension::StateWithExtensions;
+use spl_token_2022::state::Account as TokenAccount;
+
+/// Checks if an account is a valid Token account for the given mint and owner.
+pub(crate) fn is_valid_token_account(
+    account: &AccountInfo,
+    token_program: &Pubkey,
+    expected_mint: &Pubkey,
+) -> bool {
+    // Check account owner is the token program
+    if account.owner != token_program {
+        return false;
+    }
+
+    // Try to unpack as TokenAccount and verify mint/owner
+    let account_data = account.data.borrow();
+    if let Ok(token_account) = StateWithExtensions::<TokenAccount>::unpack(&account_data) {
+        return token_account.base.mint == *expected_mint;
+    }
+
+    false
+}
+
+/// Account validation trait
+pub(crate) trait Validate {
+    fn validate(&self) -> Result<(), ProgramError>;
+}
+
+#[event_cpi]
+pub(crate) struct ExecuteAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) gateway_incoming_message: &'a AccountInfo<'a>,
+    pub(crate) gateway_message_payload: &'a AccountInfo<'a>,
+    pub(crate) gateway_signing: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) ata_program: &'a AccountInfo<'a>,
+    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
+    pub(crate) remaining_accounts: &'a [AccountInfo<'a>],
+}
+
+impl<'a> ExecuteAccounts<'a> {
+    pub(crate) fn gateway_validation_accounts(&self) -> Vec<AccountInfo<'a>> {
+        vec![
+            self.payer.clone(),
+            self.gateway_incoming_message.clone(),
+            self.gateway_message_payload.clone(),
+            self.gateway_signing.clone(),
+            self.gateway_root.clone(),
+            self.gateway_event_authority.clone(),
+            self.gateway_program.clone(),
+        ]
+    }
+
+    pub(crate) fn its_accounts(&self) -> Vec<AccountInfo<'a>> {
+        let mut accounts = vec![
+            self.system_program.clone(),
+            self.its_root.clone(),
+            self.token_manager.clone(),
+            self.mint.clone(),
+            self.token_manager_ata.clone(),
+            self.token_program.clone(),
+            self.ata_program.clone(),
+            self.rent_sysvar.clone(),
+            self.__event_cpi_authority_info.clone(),
+            self.__event_cpi_program_account.clone(),
+        ];
+
+        accounts.extend(self.remaining_accounts.iter().cloned());
+
+        accounts
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for ExecuteAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            gateway_incoming_message: next_account_info(accounts_iter)?,
+            gateway_message_payload: next_account_info(accounts_iter)?,
+            gateway_signing: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            token_manager_ata: next_account_info(accounts_iter)?,
+            token_program: next_account_info(accounts_iter)?,
+            ata_program: next_account_info(accounts_iter)?,
+            rent_sysvar: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+            remaining_accounts: accounts_iter.as_slice(),
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl Validate for ExecuteAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+
+        Ok(())
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct CallContractAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_root: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) _gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) program: &'a AccountInfo<'a>,
+}
+
+impl Validate for CallContractAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+        axelar_solana_gateway::check_program_account(*self.gateway_program.key)?;
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for CallContractAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_root: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            _gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct DeployCanonicalTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) token_metadata: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) ata_program: &'a AccountInfo<'a>,
+    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
+}
+
+impl Validate for DeployCanonicalTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for DeployCanonicalTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            token_metadata: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            token_manager_ata: next_account_info(accounts_iter)?,
+            token_program: next_account_info(accounts_iter)?,
+            ata_program: next_account_info(accounts_iter)?,
+            rent_sysvar: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> TryFrom<DeployCanonicalTokenAccounts<'a>> for DeployTokenManagerAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: DeployCanonicalTokenAccounts<'a>) -> Result<Self, Self::Error> {
+        let converted = Self {
+            payer: value.payer,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            mint: value.mint,
+            token_manager_ata: value.token_manager_ata,
+            token_program: value.token_program,
+            ata_program: value.ata_program,
+            rent_sysvar: value.rent_sysvar,
+            operator: None,
+            operator_roles: None,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct DeployCustomTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) deployer: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) ata_program: &'a AccountInfo<'a>,
+    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
+    pub(crate) operator: Option<&'a AccountInfo<'a>>,
+    pub(crate) operator_roles: Option<&'a AccountInfo<'a>>,
+}
+
+impl Validate for DeployCustomTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        if !self.deployer.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for DeployCustomTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            deployer: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            token_manager_ata: next_account_info(accounts_iter)?,
+            token_program: next_account_info(accounts_iter)?,
+            ata_program: next_account_info(accounts_iter)?,
+            rent_sysvar: next_account_info(accounts_iter)?,
+            operator: next_optional_account_info(accounts_iter, &crate::ID)?,
+            operator_roles: next_optional_account_info(accounts_iter, &crate::ID)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> TryFrom<DeployCustomTokenAccounts<'a>> for DeployTokenManagerAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: DeployCustomTokenAccounts<'a>) -> Result<Self, Self::Error> {
+        let converted = Self {
+            payer: value.payer,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            mint: value.mint,
+            token_manager_ata: value.token_manager_ata,
+            token_program: value.token_program,
+            ata_program: value.ata_program,
+            rent_sysvar: value.rent_sysvar,
+            operator: value.operator,
+            operator_roles: value.operator_roles,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct TakeTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) authority: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) source_ata: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_root: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) its_program: &'a AccountInfo<'a>,
+}
+
+impl Validate for TakeTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+        spl_token_2022::check_spl_token_program_account(self.token_program.key)?;
+
+        if !self.payer.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if !self.authority.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if self.mint.owner != self.token_program.key {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for TakeTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            authority: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            source_ata: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            token_manager_ata: next_account_info(accounts_iter)?,
+            token_program: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_root: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            its_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> TryFrom<TakeTokenAccounts<'a>> for CallContractAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: TakeTokenAccounts<'a>) -> Result<Self, Self::Error> {
+        let converted = Self {
+            payer: value.payer,
+            gateway_root: value.gateway_root,
+            gateway_event_authority: value.gateway_event_authority,
+            gateway_program: value.gateway_program,
+            gas_service_root: value.gas_service_root,
+            gas_service_event_authority: value.gas_service_event_authority,
+            _gas_service_program: value.gas_service_program,
+            call_contract_signing: value.call_contract_signing,
+            program: value.its_program,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct GiveTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_message_payload: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) ata_program: &'a AccountInfo<'a>,
+    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
+    pub(crate) destination: &'a AccountInfo<'a>,
+    pub(crate) destination_ata: &'a AccountInfo<'a>,
+    pub(crate) interchain_transfer_execute: Option<&'a AccountInfo<'a>>,
+    pub(crate) remaining_accounts: &'a [AccountInfo<'a>],
+}
+
+impl Validate for GiveTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+        validate_spl_associated_token_account_key(self.ata_program.key)?;
+        validate_rent_key(self.rent_sysvar.key)?;
+        spl_token_2022::check_spl_token_program_account(self.token_program.key)?;
+
+        if self.mint.owner != self.token_program.key {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<ExecuteAccounts<'a>> for GiveTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: ExecuteAccounts<'a>) -> Result<Self, Self::Error> {
+        let remaining_accounts_iter = &mut value.remaining_accounts.iter();
+        let mut converted = Self {
+            payer: value.payer,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            gateway_message_payload: value.gateway_message_payload,
+            token_manager: value.token_manager,
+            mint: value.mint,
+            token_manager_ata: value.token_manager_ata,
+            token_program: value.token_program,
+            ata_program: value.ata_program,
+            rent_sysvar: value.rent_sysvar,
+            destination: next_account_info(remaining_accounts_iter)?,
+            destination_ata: next_account_info(remaining_accounts_iter)?,
+            interchain_transfer_execute: next_optional_account_info(
+                remaining_accounts_iter,
+                &crate::ID,
+            )?,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+            remaining_accounts: remaining_accounts_iter.as_slice(),
+        };
+
+        if is_valid_token_account(
+            converted.destination,
+            converted.token_program.key,
+            converted.mint.key,
+        ) {
+            converted.destination_ata = converted.destination;
+        } else {
+            crate::create_associated_token_account_idempotent(
+                converted.payer,
+                converted.mint,
+                converted.destination_ata,
+                converted.destination,
+                converted.system_program,
+                converted.token_program,
+            )?;
+        }
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+pub(crate) struct AxelarInterchainTokenExecutableAccounts<'a> {
+    pub(crate) gateway_message_payload: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) destination_program_ata: &'a AccountInfo<'a>,
+    pub(crate) interchain_transfer_execute: &'a AccountInfo<'a>,
+    pub(crate) destination_program_accounts: &'a [AccountInfo<'a>],
+}
+
+impl Validate for AxelarInterchainTokenExecutableAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<GiveTokenAccounts<'a>> for AxelarInterchainTokenExecutableAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: GiveTokenAccounts<'a>) -> Result<Self, Self::Error> {
+        let converted = Self {
+            gateway_message_payload: value.gateway_message_payload,
+            token_program: value.token_program,
+            mint: value.mint,
+            destination_program_ata: value.destination_ata,
+            destination_program_accounts: value.remaining_accounts,
+            interchain_transfer_execute: value
+                .interchain_transfer_execute
+                .ok_or(ProgramError::NotEnoughAccountKeys)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+pub(crate) struct FlowTrackingAccounts<'a> {
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+}
+
+impl<'a> From<&TakeTokenAccounts<'a>> for FlowTrackingAccounts<'a> {
+    fn from(value: &TakeTokenAccounts<'a>) -> Self {
+        Self {
+            system_program: value.system_program,
+            payer: value.payer,
+            token_manager: value.token_manager,
+        }
+    }
+}
+
+impl<'a> From<&GiveTokenAccounts<'a>> for FlowTrackingAccounts<'a> {
+    fn from(value: &GiveTokenAccounts<'a>) -> Self {
+        Self {
+            system_program: value.system_program,
+            payer: value.payer,
+            token_manager: value.token_manager,
+        }
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct DeployTokenManagerAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) ata_program: &'a AccountInfo<'a>,
+    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
+    pub(crate) operator: Option<&'a AccountInfo<'a>>,
+    pub(crate) operator_roles: Option<&'a AccountInfo<'a>>,
+}
+
+impl Validate for DeployTokenManagerAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+        check_spl_token_program_account(self.token_program.key)?;
+        validate_spl_associated_token_account_key(self.ata_program.key)?;
+        validate_rent_key(self.rent_sysvar.key)?;
+
+        if !self.payer.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if self.token_program.key != self.mint.owner {
+            msg!("Mint and program account mismatch");
+            return Err(ProgramError::IncorrectProgramId);
+        }
+
+        if &get_associated_token_address_with_program_id(
+            self.token_manager.key,
+            self.mint.key,
+            self.token_program.key,
+        ) != self.token_manager_ata.key
+        {
+            msg!("Wrong ata account key");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<ExecuteAccounts<'a>> for DeployTokenManagerAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: ExecuteAccounts<'a>) -> Result<Self, Self::Error> {
+        let accounts_iter = &mut value.remaining_accounts.iter();
+
+        Ok(Self {
+            payer: value.payer,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            mint: value.mint,
+            token_manager_ata: value.token_manager_ata,
+            token_program: value.token_program,
+            ata_program: value.ata_program,
+            rent_sysvar: value.rent_sysvar,
+            operator: next_optional_account_info(accounts_iter, &crate::ID)?,
+            operator_roles: next_optional_account_info(accounts_iter, &crate::ID)?,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        })
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct DeployInterchainTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) deployer: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
+    pub(crate) token_program: &'a AccountInfo<'a>,
+    pub(crate) ata_program: &'a AccountInfo<'a>,
+    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
+    pub(crate) sysvar_instructions: &'a AccountInfo<'a>,
+    pub(crate) mpl_token_metadata_program: &'a AccountInfo<'a>,
+    pub(crate) mpl_token_metadata: &'a AccountInfo<'a>,
+    pub(crate) deployer_ata: &'a AccountInfo<'a>,
+    pub(crate) minter: Option<&'a AccountInfo<'a>>,
+    pub(crate) minter_roles: Option<&'a AccountInfo<'a>>,
+}
+
+impl Validate for DeployInterchainTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+        validate_spl_associated_token_account_key(self.ata_program.key)?;
+        validate_rent_key(self.rent_sysvar.key)?;
+        validate_sysvar_instructions_key(self.sysvar_instructions.key)?;
+        validate_mpl_token_metadata_key(self.mpl_token_metadata_program.key)?;
+        spl_token_2022::check_program_account(self.token_program.key)?;
+
+        if !self.payer.is_signer {
+            msg!("Payer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if !self.deployer.is_signer {
+            msg!("Deployer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        // If it's a cross-chain message, payer_ata is not set (i.e., is set to program id)
+        if *self.deployer_ata.key != crate::id() {
+            crate::assert_valid_ata(
+                self.deployer_ata.key,
+                self.token_program.key,
+                self.mint.key,
+                self.deployer.key,
+            )?;
+        }
+
+        crate::assert_valid_ata(
+            self.token_manager_ata.key,
+            self.token_program.key,
+            self.mint.key,
+            self.token_manager.key,
+        )?;
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for DeployInterchainTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            deployer: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            token_manager_ata: next_account_info(accounts_iter)?,
+            token_program: next_account_info(accounts_iter)?,
+            ata_program: next_account_info(accounts_iter)?,
+            rent_sysvar: next_account_info(accounts_iter)?,
+            sysvar_instructions: next_account_info(accounts_iter)?,
+            mpl_token_metadata_program: next_account_info(accounts_iter)?,
+            mpl_token_metadata: next_account_info(accounts_iter)?,
+            deployer_ata: next_account_info(accounts_iter)?,
+            minter: next_optional_account_info(accounts_iter, &crate::ID)?,
+            minter_roles: next_optional_account_info(accounts_iter, &crate::ID)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> From<DeployInterchainTokenAccounts<'a>> for DeployTokenManagerAccounts<'a> {
+    fn from(value: DeployInterchainTokenAccounts<'a>) -> Self {
+        Self {
+            payer: value.payer,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            mint: value.mint,
+            token_manager_ata: value.token_manager_ata,
+            token_program: value.token_program,
+            ata_program: value.ata_program,
+            rent_sysvar: value.rent_sysvar,
+            operator: value.minter,
+            operator_roles: value.minter_roles,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        }
+    }
+}
+
+impl<'a> TryFrom<ExecuteAccounts<'a>> for DeployInterchainTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: ExecuteAccounts<'a>) -> Result<Self, Self::Error> {
+        let accounts_iter = &mut value.remaining_accounts.iter();
+
+        Ok(Self {
+            payer: value.payer,
+            deployer: value.payer,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            mint: value.mint,
+            token_manager_ata: value.token_manager_ata,
+            token_program: value.token_program,
+            ata_program: value.ata_program,
+            rent_sysvar: value.rent_sysvar,
+            sysvar_instructions: next_account_info(accounts_iter)?,
+            mpl_token_metadata_program: next_account_info(accounts_iter)?,
+            mpl_token_metadata: next_account_info(accounts_iter)?,
+            deployer_ata: next_account_info(accounts_iter)?,
+            minter: next_optional_account_info(accounts_iter, &crate::ID)?,
+            minter_roles: next_optional_account_info(accounts_iter, &crate::ID)?,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        })
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct DeployRemoteInterchainTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) deployer: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) mpl_token_metadata: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_root: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) its_program: &'a AccountInfo<'a>,
+}
+
+impl Validate for DeployRemoteInterchainTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        if !self.payer.is_signer {
+            msg!("Payer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if !self.deployer.is_signer {
+            msg!("Deployer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for DeployRemoteInterchainTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            deployer: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            mpl_token_metadata: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_root: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            its_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug, Clone)]
+pub(crate) struct DeployRemoteInterchainTokenWithMinterAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) deployer: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) mpl_token_metadata: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) minter: &'a AccountInfo<'a>,
+    pub(crate) deployment_approval: &'a AccountInfo<'a>,
+    pub(crate) minter_roles: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_root: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) its_program: &'a AccountInfo<'a>,
+}
+
+impl Validate for DeployRemoteInterchainTokenWithMinterAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        if !self.payer.is_signer {
+            msg!("Payer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if !self.deployer.is_signer {
+            msg!("Deployer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for DeployRemoteInterchainTokenWithMinterAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            deployer: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            mpl_token_metadata: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            minter: next_account_info(accounts_iter)?,
+            deployment_approval: next_account_info(accounts_iter)?,
+            minter_roles: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_root: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            its_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct DeployRemoteCanonicalInterchainTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) mpl_token_metadata: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_config: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) its_program: &'a AccountInfo<'a>,
+}
+
+impl Validate for DeployRemoteCanonicalInterchainTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        if !self.payer.is_signer {
+            msg!("Payer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for DeployRemoteCanonicalInterchainTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            mpl_token_metadata: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_config: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            its_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> TryFrom<DeployRemoteCanonicalInterchainTokenAccounts<'a>> for CallContractAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(
+        value: DeployRemoteCanonicalInterchainTokenAccounts<'a>,
+    ) -> Result<Self, Self::Error> {
+        let converted = Self {
+            payer: value.payer,
+            gateway_root: value.gateway_root,
+            gateway_event_authority: value.gateway_event_authority,
+            gateway_program: value.gateway_program,
+            gas_service_root: value.gas_service_config,
+            gas_service_event_authority: value.gas_service_event_authority,
+            _gas_service_program: value.gas_service_program,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            call_contract_signing: value.call_contract_signing,
+            program: value.its_program,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+pub(crate) type CommonDeployRemoteInterchainTokenAccounts<'a> =
+    DeployRemoteCanonicalInterchainTokenAccounts<'a>;
+
+impl<'a> TryFrom<DeployRemoteInterchainTokenAccounts<'a>>
+    for CommonDeployRemoteInterchainTokenAccounts<'a>
+{
+    type Error = ProgramError;
+
+    fn try_from(value: DeployRemoteInterchainTokenAccounts<'a>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            payer: value.payer,
+            mint: value.mint,
+            mpl_token_metadata: value.mpl_token_metadata,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            gateway_root: value.gateway_root,
+            gateway_event_authority: value.gateway_event_authority,
+            gateway_program: value.gateway_program,
+            gas_service_config: value.gas_service_root,
+            gas_service_event_authority: value.gas_service_event_authority,
+            gas_service_program: value.gas_service_program,
+            system_program: value.system_program,
+            call_contract_signing: value.call_contract_signing,
+            its_program: value.its_program,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        })
+    }
+}
+
+impl<'a> TryFrom<DeployRemoteInterchainTokenWithMinterAccounts<'a>>
+    for CommonDeployRemoteInterchainTokenAccounts<'a>
+{
+    type Error = ProgramError;
+
+    fn try_from(
+        value: DeployRemoteInterchainTokenWithMinterAccounts<'a>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            payer: value.payer,
+            mint: value.mint,
+            mpl_token_metadata: value.mpl_token_metadata,
+            its_root: value.its_root,
+            token_manager: value.token_manager,
+            gateway_root: value.gateway_root,
+            gateway_event_authority: value.gateway_event_authority,
+            gateway_program: value.gateway_program,
+            gas_service_config: value.gas_service_root,
+            gas_service_event_authority: value.gas_service_event_authority,
+            gas_service_program: value.gas_service_program,
+            system_program: value.system_program,
+            call_contract_signing: value.call_contract_signing,
+            its_program: value.its_program,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        })
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct LinkTokenAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) deployer: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) token_manager: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_root: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) its_program: &'a AccountInfo<'a>,
+}
+
+impl Validate for LinkTokenAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        if !self.payer.is_signer {
+            msg!("Payer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if !self.deployer.is_signer {
+            msg!("Deployer should be signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for LinkTokenAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            deployer: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            token_manager: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_root: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            its_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> TryFrom<LinkTokenAccounts<'a>> for CallContractAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: LinkTokenAccounts<'a>) -> Result<Self, Self::Error> {
+        let converted = Self {
+            payer: value.payer,
+            gateway_root: value.gateway_root,
+            gateway_event_authority: value.gateway_event_authority,
+            gateway_program: value.gateway_program,
+            gas_service_root: value.gas_service_root,
+            gas_service_event_authority: value.gas_service_event_authority,
+            _gas_service_program: value.gas_service_program,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            call_contract_signing: value.call_contract_signing,
+            program: value.its_program,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct RegisterTokenMetadataAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) mint: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_root: &'a AccountInfo<'a>,
+    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gateway_program: &'a AccountInfo<'a>,
+    pub(crate) gas_service_root: &'a AccountInfo<'a>,
+    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
+    pub(crate) gas_service_program: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+    pub(crate) call_contract_signing: &'a AccountInfo<'a>,
+    pub(crate) its_program: &'a AccountInfo<'a>,
+}
+
+impl Validate for RegisterTokenMetadataAccounts<'_> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        if !self.payer.is_signer {
+            msg!("Payer should be a signer");
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for RegisterTokenMetadataAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error>
+    where
+        Self: Sized + Validate,
+    {
+        let accounts_iter = &mut value.iter();
+
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            mint: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            gateway_root: next_account_info(accounts_iter)?,
+            gateway_event_authority: next_account_info(accounts_iter)?,
+            gateway_program: next_account_info(accounts_iter)?,
+            gas_service_root: next_account_info(accounts_iter)?,
+            gas_service_event_authority: next_account_info(accounts_iter)?,
+            gas_service_program: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            call_contract_signing: next_account_info(accounts_iter)?,
+            its_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+impl<'a> TryFrom<RegisterTokenMetadataAccounts<'a>> for CallContractAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: RegisterTokenMetadataAccounts<'a>) -> Result<Self, Self::Error> {
+        let converted = Self {
+            payer: value.payer,
+            gateway_root: value.gateway_root,
+            gateway_event_authority: value.gateway_event_authority,
+            gateway_program: value.gateway_program,
+            gas_service_root: value.gas_service_root,
+            gas_service_event_authority: value.gas_service_event_authority,
+            _gas_service_program: value.gas_service_program,
+            system_program: value.system_program,
+            its_root: value.its_root,
+            call_contract_signing: value.call_contract_signing,
+            program: value.its_program,
+            __event_cpi_authority_info: value.__event_cpi_authority_info,
+            __event_cpi_program_account: value.__event_cpi_program_account,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+#[event_cpi]
+#[derive(Debug)]
+pub(crate) struct SetTrustedChainAccounts<'a> {
+    pub(crate) payer: &'a AccountInfo<'a>,
+    pub(crate) authority: &'a AccountInfo<'a>,
+    pub(crate) authority_roles: &'a AccountInfo<'a>,
+    pub(crate) program_data: &'a AccountInfo<'a>,
+    pub(crate) its_root: &'a AccountInfo<'a>,
+    pub(crate) system_program: &'a AccountInfo<'a>,
+}
+
+impl<'a> Validate for SetTrustedChainAccounts<'a> {
+    fn validate(&self) -> Result<(), ProgramError> {
+        validate_system_account_key(self.system_program.key)?;
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<&'a [AccountInfo<'a>]> for SetTrustedChainAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(value: &'a [AccountInfo<'a>]) -> Result<Self, Self::Error> {
+        let accounts_iter = &mut value.iter();
+        let converted = Self {
+            payer: next_account_info(accounts_iter)?,
+            authority: next_account_info(accounts_iter)?,
+            authority_roles: next_account_info(accounts_iter)?,
+            program_data: next_account_info(accounts_iter)?,
+            its_root: next_account_info(accounts_iter)?,
+            system_program: next_account_info(accounts_iter)?,
+            __event_cpi_authority_info: next_account_info(accounts_iter)?,
+            __event_cpi_program_account: next_account_info(accounts_iter)?,
+        };
+
+        converted.validate()?;
+
+        Ok(converted)
+    }
+}
+
+pub(crate) type RemoveTrustedChainAccounts<'a> = SetTrustedChainAccounts<'a>;

--- a/programs/axelar-solana-its/src/instruction.rs
+++ b/programs/axelar-solana-its/src/instruction.rs
@@ -146,10 +146,8 @@ pub enum InterchainTokenServiceInstruction {
     /// 7. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
     /// 8. [] The Associated Token Account program account (`spl_associated_token_account`)
     /// 9. [] The rent sysvar account
-    /// 10. [] The ITS program account
-    /// 11. [] The ITS program account (duplicate)
-    /// 12. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
-    /// 13. [] The ITS program account.
+    /// 10. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
+    /// 11. [] The ITS program account.
     RegisterCanonicalInterchainToken,
 
     /// Deploys a canonical interchain token on a remote chain.
@@ -159,15 +157,15 @@ pub enum InterchainTokenServiceInstruction {
     /// 0. [writable,signer] The account which is paying for the transaction
     /// 1. [] The mint account (token address) to deploy
     /// 2. [] The Metaplex metadata account associated with the mint
-    /// 3. [] The token manager account associated with the interchain token
-    /// 4. [] The GMP gateway root account
-    /// 5. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 6. [] The GMP gateway program account
-    /// 7. [writable] The GMP gas configuration account
-    /// 8. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 9. [] The GMP gas service program account
-    /// 10. [] The system program account
-    /// 11. [] The ITS root account
+    /// 3. [] The ITS root account
+    /// 4. [] The token manager account associated with the interchain token
+    /// 5. [] The GMP gateway root account
+    /// 6. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 7. [] The GMP gateway program account
+    /// 8. [writable] The GMP gas configuration account
+    /// 9. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 10. [] The GMP gas service program account
+    /// 11. [] The system program account
     /// 12. [] The GMP call contract signing account
     /// 13. [] The ITS program account
     /// 14. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
@@ -189,23 +187,22 @@ pub enum InterchainTokenServiceInstruction {
     /// 1. [signer] The address of the owner or delegate of the source account of the
     ///    transfer. In case it's the `TokenManager`, it shouldn't be set as signer as the signing
     ///    happens on chain.
-    /// 2. [writable] The source account from which the tokens are being transferred
-    /// 3. [writable] The mint account (token address)
-    /// 4. [writable] The token manager account associated with the interchain token
-    /// 5. [writable] The token manager Associated Token Account associated with the mint
-    /// 6. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
-    /// 7. [] The GMP gateway root account
-    /// 8. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 9. [] The GMP gateway program account
-    /// 10. [writable] The GMP gas configuration account
-    /// 11. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 12. [] The GMP gas service program account
-    /// 13. [] The system program account
-    /// 14. [] The ITS root account
-    /// 15. [] The GMP call contract signing account
-    /// 16. [] The ITS program account
-    /// 17. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
-    /// 18. [] The ITS program account.
+    /// 2. [] The ITS root account
+    /// 3. [writable] The source account from which the tokens are being transferred
+    /// 4. [writable] The mint account (token address)
+    /// 5. [writable] The token manager account associated with the interchain token
+    /// 6. [writable] The token manager Associated Token Account associated with the mint
+    /// 7. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
+    /// 8. [] The system program account
+    /// 9. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
+    /// 10. [] The ITS program account.
+    /// 11. [] The GMP gateway root account
+    /// 12. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 13. [] The GMP gateway program account
+    /// 14. [writable] The GMP gas configuration account
+    /// 15. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 16. [] The GMP gas service program account
+    /// 17. [] The GMP call contract signing account
     InterchainTransfer {
         /// The token id associated with the token
         token_id: [u8; 32],
@@ -236,23 +233,22 @@ pub enum InterchainTokenServiceInstruction {
     /// 1. [signer] The address of the owner or delegate of the source account of the
     ///    transfer. In case it's the `TokenManager`, it shouldn't be set as signer as the signing
     ///    happens on chain.
-    /// 2. [writable] The source account from which the tokens are being transferred
-    /// 3. [writable] The mint account (token address)
-    /// 4. [writable] The token manager account associated with the interchain token
-    /// 5. [writable] The token manager Associated Token Account associated with the mint
-    /// 6. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
-    /// 7. [] The GMP gateway root account
-    /// 8. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 9. [] The GMP gateway program account
-    /// 10. [writable] The GMP gas configuration account
-    /// 11. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 12. [] The GMP gas service program account
-    /// 13. [] The system program account
-    /// 14. [] The ITS root account
-    /// 15. [] The GMP call contract signing account
-    /// 16. [] The ITS program account
-    /// 17. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
-    /// 18. [] The ITS program account.
+    /// 2. [] The ITS root account
+    /// 3. [writable] The source account from which the tokens are being transferred
+    /// 4. [writable] The mint account (token address)
+    /// 5. [writable] The token manager account associated with the interchain token
+    /// 6. [writable] The token manager Associated Token Account associated with the mint
+    /// 7. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
+    /// 8. [] The system program account
+    /// 9. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
+    /// 10. [] The ITS program account.
+    /// 11. [] The GMP gateway root account
+    /// 12. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 13. [] The GMP gateway program account
+    /// 14. [writable] The GMP gas configuration account
+    /// 15. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 16. [] The GMP gas service program account
+    /// 17. [] The GMP call contract signing account
     CpiInterchainTransfer {
         /// The token id associated with the token
         token_id: [u8; 32],
@@ -328,15 +324,15 @@ pub enum InterchainTokenServiceInstruction {
     /// 1. [signer] The account of the deployer
     /// 2. [] The mint account (token address)
     /// 3. [] The Metaplex metadata account associated with the mint
-    /// 4. [] The token manager account associated with the interchain token
-    /// 5. [] The GMP gateway root account
-    /// 6. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 7. [] The GMP gateway program account
-    /// 8. [writable] The GMP gas configuration account
-    /// 9. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 10. [] The GMP gas service program account
-    /// 11. [] The system program account
-    /// 12. [] The ITS root account
+    /// 4. [] The ITS root account
+    /// 5. [] The token manager account associated with the interchain token
+    /// 6. [] The GMP gateway root account
+    /// 7. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 8. [] The GMP gateway program account
+    /// 9. [writable] The GMP gas configuration account
+    /// 10. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 11. [] The GMP gas service program account
+    /// 12. [] The system program account
     /// 13. [] The GMP call contract signing account
     /// 14. [] The ITS program account
     /// 15. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
@@ -363,18 +359,18 @@ pub enum InterchainTokenServiceInstruction {
     /// 1. [signer] The account of the deployer
     /// 2. [] The mint account (token address)
     /// 3. [] The Metaplex metadata account associated with the mint
-    /// 4. [] The token manager account associated with the interchain token
-    /// 5. [] The account of the minter that approved the deployment
-    /// 6. [writable] The account holding the approval for the deployment
-    /// 7. [] The account holding the roles of the minter on the token manager
-    /// 8. [] The GMP gateway root account
-    /// 9. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 10. [] The GMP gateway program account
-    /// 11. [writable] The GMP gas configuration account
-    /// 12. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 13. [] The GMP gas service program account
-    /// 14. [] The system program account
-    /// 15. [] The ITS root account
+    /// 4. [] The ITS root account
+    /// 5. [] The token manager account associated with the interchain token
+    /// 6. [] The account of the minter that approved the deployment
+    /// 7. [writable] The account holding the approval for the deployment
+    /// 8. [] The account holding the roles of the minter on the token manager
+    /// 9. [] The GMP gateway root account
+    /// 10. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 11. [] The GMP gateway program account
+    /// 12. [writable] The GMP gas configuration account
+    /// 13. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 14. [] The GMP gas service program account
+    /// 15. [] The system program account
     /// 16. [] The GMP call contract signing account
     /// 17. [] The ITS program account
     /// 18. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
@@ -402,14 +398,14 @@ pub enum InterchainTokenServiceInstruction {
     ///
     /// 0. [writable,signer] The address of the payer
     /// 1. [] The mint account (token address)
-    /// 2. [] The GMP gateway root account
-    /// 3. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 4. [] The GMP gateway program account
-    /// 5. [writable] The GMP gas configuration account
-    /// 6. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 7. [] The GMP gas service program account
-    /// 8. [] The system program account
-    /// 9. [] The ITS root account
+    /// 2. [] The ITS root account
+    /// 3. [] The GMP gateway root account
+    /// 4. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 5. [] The GMP gateway program account
+    /// 6. [writable] The GMP gas configuration account
+    /// 7. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 8. [] The GMP gas service program account
+    /// 9. [] The system program account
     /// 10. [] The GMP call contract signing account
     /// 11. [] The ITS program account
     /// 12. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
@@ -455,15 +451,15 @@ pub enum InterchainTokenServiceInstruction {
     ///
     /// 0. [writable,signer] The account which is paying for the transaction
     /// 1. [signer] The account of the deployer
-    /// 2. [] The `TokenManager` account associated with the token being linked
-    /// 3. [] The GMP gateway root account
-    /// 4. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 5. [] The GMP gateway program account
-    /// 6. [writable] The GMP gas configuration account
-    /// 7. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 8. [] The GMP gas service program account
-    /// 9. [] The system program account
-    /// 10. [] The ITS root account
+    /// 2. [] The ITS root account
+    /// 3. [] The `TokenManager` account associated with the token being linked
+    /// 4. [] The GMP gateway root account
+    /// 5. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 6. [] The GMP gateway program account
+    /// 7. [writable] The GMP gas configuration account
+    /// 8. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 9. [] The GMP gas service program account
+    /// 10. [] The system program account
     /// 11. [] The GMP call contract signing account
     /// 12. [] The ITS program account
     /// 13. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
@@ -495,23 +491,22 @@ pub enum InterchainTokenServiceInstruction {
     /// 1. [signer] The address of the owner or delegate of the source account of the
     ///    transfer. In case it's the `TokenManager`, it shouldn't be set as signer as the signing
     ///    happens on chain.
-    /// 2. [writable] The source account from which the tokens are being transferred
-    /// 3. [writable] The mint account (token address)
-    /// 4. [] The token manager account associated with the interchain token
-    /// 5. [writable] The token manager Associated Token Account associated with the mint
-    /// 6. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
-    /// 7. [] The GMP gateway root account
-    /// 8. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 9. [] The GMP gateway program account
-    /// 10. [writable] The GMP gas configuration account
-    /// 11. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 12. [] The GMP gas service program account
-    /// 13. [] The system program account
-    /// 14. [] The ITS root account
-    /// 15. [] The GMP call contract signing account
-    /// 16. [] The ITS program account
-    /// 17. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
-    /// 18. [] The ITS program account.
+    /// 2. [] The ITS root account
+    /// 3. [writable] The source account from which the tokens are being transferred
+    /// 4. [writable] The mint account (token address)
+    /// 5. [writable] The token manager account associated with the interchain token
+    /// 6. [writable] The token manager Associated Token Account associated with the mint
+    /// 7. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
+    /// 8. [] The system program account
+    /// 9. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
+    /// 10. [] The ITS program account.
+    /// 11. [] The GMP gateway root account
+    /// 12. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 13. [] The GMP gateway program account
+    /// 14. [writable] The GMP gas configuration account
+    /// 15. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 16. [] The GMP gas service program account
+    /// 17. [] The GMP call contract signing account
     CallContractWithInterchainToken {
         /// The token id associated with the token
         token_id: [u8; 32],
@@ -545,23 +540,22 @@ pub enum InterchainTokenServiceInstruction {
     /// 1. [signer] The address of the owner or delegate of the source account of the
     ///    transfer. In case it's the `TokenManager`, it shouldn't be set as signer as the signing
     ///    happens on chain.
-    /// 2. [writable] The source account from which the tokens are being transferred
-    /// 3. [writable] The mint account (token address)
-    /// 4. [writable] The token manager account associated with the interchain token
-    /// 5. [writable] The token manager Associated Token Account associated with the mint
-    /// 6. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
-    /// 7. [] The GMP gateway root account
-    /// 8. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
-    /// 9. [] The GMP gateway program account
-    /// 10. [writable] The GMP gas configuration account
-    /// 11. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
-    /// 12. [] The GMP gas service program account
-    /// 13. [] The system program account
-    /// 14. [] The ITS root account
-    /// 15. [] The GMP call contract signing account
-    /// 16. [] The ITS program account
-    /// 17. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
-    /// 18. [] The ITS program account.
+    /// 2. [] The ITS root account
+    /// 3. [writable] The source account from which the tokens are being transferred
+    /// 4. [writable] The mint account (token address)
+    /// 5. [writable] The token manager account associated with the interchain token
+    /// 6. [writable] The token manager Associated Token Account associated with the mint
+    /// 7. [] The token program account that was used to create the mint (`spl_token` vs `spl_token_2022`)
+    /// 8. [] The system program account
+    /// 9. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
+    /// 10. [] The ITS program account.
+    /// 11. [] The GMP gateway root account
+    /// 12. [] The gateway event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gateway program ID).
+    /// 13. [] The GMP gateway program account
+    /// 14. [writable] The GMP gas configuration account
+    /// 15. [] The gas service event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and gas service program ID).
+    /// 16. [] The GMP gas service program account
+    /// 17. [] The GMP call contract signing account
     CpiCallContractWithInterchainToken {
         /// The token id associated with the token
         token_id: [u8; 32],
@@ -684,6 +678,8 @@ pub enum InterchainTokenServiceInstruction {
     /// 3. [writable] The [`TokenManager`] PDA account.
     /// 4. [] The PDA account with the flow limiter's roles on the [`TokenManager`].
     /// 5. [] System program account.
+    /// 6. [] The event authority PDA (derived from event_cpi::EVENT_AUTHORITY_SEED and ITS program ID).
+    /// 7. [] The ITS program account.
     SetTokenManagerFlowLimit {
         /// The new flow limit.
         flow_limit: Option<u64>,
@@ -1147,8 +1143,6 @@ pub fn register_canonical_interchain_token(
         AccountMeta::new_readonly(token_program, false),
         AccountMeta::new_readonly(spl_associated_token_account::ID, false),
         AccountMeta::new_readonly(sysvar::rent::ID, false),
-        AccountMeta::new_readonly(crate::ID, false),
-        AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
         AccountMeta::new_readonly(crate::ID, false),
     ];
@@ -1197,6 +1191,7 @@ pub fn deploy_remote_canonical_interchain_token(
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(mint, false),
         AccountMeta::new_readonly(metadata_account_key, false),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(token_manager, false),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(gateway_event_authority, false),
@@ -1205,7 +1200,6 @@ pub fn deploy_remote_canonical_interchain_token(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1338,6 +1332,7 @@ pub fn deploy_remote_interchain_token(
         AccountMeta::new_readonly(deployer, true),
         AccountMeta::new_readonly(mint, false),
         AccountMeta::new_readonly(metadata_account_key, false),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(token_manager, false),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(gateway_event_authority, false),
@@ -1346,7 +1341,6 @@ pub fn deploy_remote_interchain_token(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1413,6 +1407,7 @@ pub fn deploy_remote_interchain_token_with_minter(
         AccountMeta::new_readonly(deployer, true),
         AccountMeta::new_readonly(mint, false),
         AccountMeta::new_readonly(metadata_account_key, false),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(minter, false),
         AccountMeta::new(deploy_approval, false),
@@ -1424,7 +1419,6 @@ pub fn deploy_remote_interchain_token_with_minter(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1477,6 +1471,7 @@ pub fn register_token_metadata(
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(gateway_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gateway::ID, false),
@@ -1484,7 +1479,6 @@ pub fn register_token_metadata(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1539,6 +1533,7 @@ pub fn register_custom_token(
         AccountMeta::new_readonly(sysvar::rent::ID, false),
     ];
 
+    // Add optional operator accounts (uses program_id as sentinel for None)
     if let Some(operator) = operator {
         let (operator_roles_pda, _) =
             role_management::find_user_roles_pda(&crate::ID, &token_manager_pda, &operator);
@@ -1549,6 +1544,7 @@ pub fn register_custom_token(
         accounts.push(AccountMeta::new_readonly(crate::ID, false));
     }
 
+    // Event CPI accounts
     accounts.push(AccountMeta::new_readonly(event_authority, false));
     accounts.push(AccountMeta::new_readonly(crate::ID, false));
 
@@ -1601,6 +1597,7 @@ pub fn link_token(
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(deployer, true),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(token_manager_pda, false),
         AccountMeta::new_readonly(gateway_root_pda, false),
         AccountMeta::new_readonly(gateway_event_authority, false),
@@ -1609,7 +1606,6 @@ pub fn link_token(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1673,6 +1669,7 @@ pub fn interchain_transfer(
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(authority, true),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(source_account, false),
         AccountMeta::new(mint, false),
         AccountMeta::new(token_manager_pda, false),
@@ -1685,7 +1682,6 @@ pub fn interchain_transfer(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1751,6 +1747,7 @@ pub fn cpi_interchain_transfer(
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(authority, true),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(source_account, false),
         AccountMeta::new(mint, false),
         AccountMeta::new(token_manager_pda, false),
@@ -1763,7 +1760,6 @@ pub fn cpi_interchain_transfer(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1829,9 +1825,10 @@ pub fn call_contract_with_interchain_token(
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(authority, true),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(source_account, false),
         AccountMeta::new(mint, false),
-        AccountMeta::new_readonly(token_manager_pda, false),
+        AccountMeta::new(token_manager_pda, false),
         AccountMeta::new(token_manager_ata, false),
         AccountMeta::new_readonly(token_program, false),
         AccountMeta::new_readonly(gateway_root_pda, false),
@@ -1841,7 +1838,6 @@ pub fn call_contract_with_interchain_token(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),
@@ -1911,6 +1907,7 @@ pub fn cpi_call_contract_with_interchain_token(
     let accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(authority, true),
+        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new(source_account, false),
         AccountMeta::new(mint, false),
         AccountMeta::new(token_manager_pda, false),
@@ -1923,7 +1920,6 @@ pub fn cpi_call_contract_with_interchain_token(
         AccountMeta::new_readonly(gas_service_event_authority, false),
         AccountMeta::new_readonly(axelar_solana_gas_service::ID, false),
         AccountMeta::new_readonly(system_program::ID, false),
-        AccountMeta::new_readonly(its_root_pda, false),
         AccountMeta::new_readonly(call_contract_signing_pda, false),
         AccountMeta::new_readonly(crate::ID, false),
         AccountMeta::new_readonly(event_authority, false),

--- a/programs/axelar-solana-its/src/lib.rs
+++ b/programs/axelar-solana-its/src/lib.rs
@@ -14,6 +14,7 @@ use solana_program::pubkey::Pubkey;
 use state::interchain_transfer_execute::InterchainTransferExecute;
 use state::InterchainTokenService;
 
+mod accounts;
 mod entrypoint;
 pub mod events;
 pub mod executable;
@@ -61,37 +62,6 @@ pub const CHAIN_NAME_HASH: [u8; 32] = [
     110, 239, 41, 235, 176, 58, 162, 20, 74, 26, 107, 98, 18, 206, 116, 245, 4, 163, 77, 183, 153,
     184, 22, 26, 33, 20, 0, 23, 232, 13, 61, 138,
 ]; // keccak256("solana")
-
-pub(crate) trait Validate {
-    fn validate(&self) -> Result<(), ProgramError>;
-}
-
-pub(crate) trait FromAccountInfoSlice<'a> {
-    type Context;
-
-    fn from_account_info_slice(
-        accounts: &'a [AccountInfo<'a>],
-        context: &Self::Context,
-    ) -> Result<Self, ProgramError>
-    where
-        Self: Sized + Validate,
-    {
-        let obj = Self::extract_accounts(accounts, context)?;
-        obj.validate()?;
-        Ok(obj)
-    }
-
-    fn extract_accounts(
-        accounts: &'a [AccountInfo<'a>],
-        context: &Self::Context,
-    ) -> Result<Self, ProgramError>
-    where
-        Self: Sized + Validate;
-}
-
-pub(crate) trait EventAccounts<'a> {
-    fn event_accounts(&self) -> [&'a AccountInfo<'a>; 2];
-}
 
 /// Seed prefixes for different PDAs initialized by the program
 pub mod seed_prefixes {
@@ -441,8 +411,8 @@ pub fn find_interchain_transfer_execute_pda(destination_program: &Pubkey) -> (Pu
 }
 
 /// Either create the interchain_transfer_execute PDA or read it, and ensure it is derived properly.
-pub(crate) fn assert_valid_interchain_transfer_execute_pda<'a>(
-    interchain_transfer_execute_pda_account: &AccountInfo<'a>,
+pub(crate) fn assert_valid_interchain_transfer_execute_pda(
+    interchain_transfer_execute_pda_account: &AccountInfo<'_>,
     destination_program: &Pubkey,
 ) -> Result<u8, ProgramError> {
     let bump = if interchain_transfer_execute_pda_account.is_initialized_pda(&crate::id()) {

--- a/programs/axelar-solana-its/src/processor/gmp.rs
+++ b/programs/axelar-solana-its/src/processor/gmp.rs
@@ -4,136 +4,31 @@ use axelar_solana_gateway::executable::validate_with_gmp_metadata;
 use axelar_solana_gateway::state::message_payload::ImmutMessagePayload;
 use interchain_token_transfer_gmp::{GMPPayload, SendToHub};
 use itertools::{self, Itertools};
-use program_utils::{pda::BorshPda, validate_system_account_key};
-use solana_program::account_info::{next_account_info, AccountInfo};
+use program_utils::pda::BorshPda;
+use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
 use solana_program::program::invoke;
 use solana_program::program::invoke_signed;
 use solana_program::program_error::ProgramError;
 
+use crate::accounts::CallContractAccounts;
+use crate::accounts::ExecuteAccounts;
+use crate::instruction;
 use crate::processor::interchain_token;
 use crate::processor::interchain_transfer::process_inbound_transfer;
 use crate::processor::link_token;
 use crate::state::token_manager::TokenManager;
 use crate::state::InterchainTokenService;
 use crate::{
-    assert_its_not_paused, assert_valid_its_root_pda, check_program_account, EventAccounts,
-    Validate, ITS_HUB_CHAIN_NAME,
+    assert_its_not_paused, assert_valid_its_root_pda, check_program_account, ITS_HUB_CHAIN_NAME,
 };
-use crate::{instruction, FromAccountInfoSlice};
 
-pub(crate) struct ItsExecuteAccounts<'a> {
-    pub(crate) payer: &'a AccountInfo<'a>,
-    pub(crate) gateway_approved_message_pda: &'a AccountInfo<'a>,
-    pub(crate) gateway_payload_account: &'a AccountInfo<'a>,
-    pub(crate) gateway_signing_pda: &'a AccountInfo<'a>,
-    pub(crate) gateway_root_pda: &'a AccountInfo<'a>,
-    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
-    pub(crate) gateway_program_id: &'a AccountInfo<'a>,
-    pub(crate) system_program: &'a AccountInfo<'a>,
-    pub(crate) its_root_pda: &'a AccountInfo<'a>,
-    pub(crate) token_manager_pda: &'a AccountInfo<'a>,
-    pub(crate) token_mint: &'a AccountInfo<'a>,
-    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
-    pub(crate) token_program: &'a AccountInfo<'a>,
-    pub(crate) ata_program: &'a AccountInfo<'a>,
-    pub(crate) rent_sysvar: &'a AccountInfo<'a>,
-    pub(crate) __event_cpi_authority_info: &'a AccountInfo<'a>,
-    pub(crate) __event_cpi_program_account: &'a AccountInfo<'a>,
-    // Remaining accounts are payload specific
-    pub(crate) remaining_accounts: &'a [AccountInfo<'a>],
-}
+pub(crate) fn process_execute(accounts: ExecuteAccounts, message: Message) -> ProgramResult {
+    validate_with_gmp_metadata(&accounts.gateway_validation_accounts(), &message)?;
 
-impl<'a> ItsExecuteAccounts<'a> {
-    fn gateway_validation_accounts(&self) -> Vec<AccountInfo<'a>> {
-        vec![
-            self.payer.clone(),
-            self.gateway_approved_message_pda.clone(),
-            self.gateway_payload_account.clone(),
-            self.gateway_signing_pda.clone(),
-            self.gateway_signing_pda.clone(),
-            self.gateway_root_pda.clone(),
-            self.gateway_event_authority.clone(),
-            self.gateway_program_id.clone(),
-        ]
-    }
-
-    fn its_accounts(&self) -> Vec<AccountInfo<'a>> {
-        let mut accounts = vec![
-            self.system_program.clone(),
-            self.its_root_pda.clone(),
-            self.token_manager_pda.clone(),
-            self.token_mint.clone(),
-            self.token_manager_ata.clone(),
-            self.token_program.clone(),
-            self.ata_program.clone(),
-            self.rent_sysvar.clone(),
-            self.__event_cpi_authority_info.clone(),
-            self.__event_cpi_program_account.clone(),
-        ];
-
-        accounts.extend(self.remaining_accounts.iter().cloned());
-
-        accounts
-    }
-}
-
-impl<'a> FromAccountInfoSlice<'a> for ItsExecuteAccounts<'a> {
-    type Context = ();
-
-    fn extract_accounts(
-        accounts: &'a [AccountInfo<'a>],
-        _context: &Self::Context,
-    ) -> Result<Self, ProgramError>
-    where
-        Self: Sized + Validate,
-    {
-        let accounts_iter = &mut accounts.iter();
-
-        Ok(Self {
-            payer: next_account_info(accounts_iter)?,
-            gateway_approved_message_pda: next_account_info(accounts_iter)?,
-            gateway_payload_account: next_account_info(accounts_iter)?,
-            gateway_signing_pda: next_account_info(accounts_iter)?,
-            gateway_root_pda: next_account_info(accounts_iter)?,
-            gateway_event_authority: next_account_info(accounts_iter)?,
-            gateway_program_id: next_account_info(accounts_iter)?,
-            system_program: next_account_info(accounts_iter)?,
-            its_root_pda: next_account_info(accounts_iter)?,
-            token_manager_pda: next_account_info(accounts_iter)?,
-            token_mint: next_account_info(accounts_iter)?,
-            token_manager_ata: next_account_info(accounts_iter)?,
-            token_program: next_account_info(accounts_iter)?,
-            ata_program: next_account_info(accounts_iter)?,
-            rent_sysvar: next_account_info(accounts_iter)?,
-            __event_cpi_authority_info: next_account_info(accounts_iter)?,
-            __event_cpi_program_account: next_account_info(accounts_iter)?,
-            remaining_accounts: accounts_iter.as_slice(),
-        })
-    }
-}
-
-impl<'a> Validate for ItsExecuteAccounts<'a> {
-    fn validate(&self) -> Result<(), ProgramError> {
-        validate_system_account_key(self.system_program.key)?;
-
-        Ok(())
-    }
-}
-
-pub(crate) fn process_execute<'a>(
-    accounts: &'a [AccountInfo<'a>],
-    message: Message,
-) -> ProgramResult {
-    let its_execute_accounts = ItsExecuteAccounts::from_account_info_slice(accounts, &())?;
-    validate_with_gmp_metadata(
-        &its_execute_accounts.gateway_validation_accounts(),
-        &message,
-    )?;
-
-    let its_root_config = InterchainTokenService::load(its_execute_accounts.its_root_pda)?;
-    assert_valid_its_root_pda(its_execute_accounts.its_root_pda, its_root_config.bump)?;
+    let its_root_config = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_root_config.bump)?;
     assert_its_not_paused(&its_root_config)?;
 
     if message.source_address != its_root_config.its_hub_address {
@@ -141,9 +36,7 @@ pub(crate) fn process_execute<'a>(
         return Err(ProgramError::InvalidInstructionData);
     }
 
-    let payload_account_data = its_execute_accounts
-        .gateway_payload_account
-        .try_borrow_data()?;
+    let payload_account_data = accounts.gateway_message_payload.try_borrow_data()?;
     let message_payload: ImmutMessagePayload<'_> = (**payload_account_data).try_into()?;
 
     let GMPPayload::ReceiveFromHub(inner) = GMPPayload::decode(message_payload.raw_payload)
@@ -161,14 +54,14 @@ pub(crate) fn process_execute<'a>(
     let payload =
         GMPPayload::decode(&inner.payload).map_err(|_err| ProgramError::InvalidInstructionData)?;
 
-    validate_its_accounts(&its_execute_accounts.its_accounts(), &payload)?;
+    validate_its_accounts(&accounts.its_accounts(), &payload)?;
 
     match payload {
         GMPPayload::InterchainTransfer(transfer) => {
-            process_inbound_transfer(message, its_execute_accounts, &transfer, inner.source_chain)
+            process_inbound_transfer(accounts.try_into()?, message, &transfer, inner.source_chain)
         }
         GMPPayload::DeployInterchainToken(deploy) => interchain_token::process_inbound_deploy(
-            its_execute_accounts.try_into()?,
+            accounts.try_into()?,
             deploy.token_id.0,
             deploy.name,
             deploy.symbol,
@@ -176,7 +69,7 @@ pub(crate) fn process_execute<'a>(
             0,
         ),
         GMPPayload::LinkToken(payload) => {
-            link_token::process_inbound(its_execute_accounts.try_into()?, &payload)
+            link_token::process_inbound(accounts.try_into()?, &payload)
         }
         GMPPayload::SendToHub(_)
         | GMPPayload::ReceiveFromHub(_)
@@ -184,83 +77,19 @@ pub(crate) fn process_execute<'a>(
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct GmpAccounts<'a> {
-    pub(crate) gateway_root_account: &'a AccountInfo<'a>,
-    pub(crate) gateway_event_authority: &'a AccountInfo<'a>,
-    pub(crate) gateway_program_id: &'a AccountInfo<'a>,
-    pub(crate) gas_service_config_account: &'a AccountInfo<'a>,
-    pub(crate) gas_service_event_authority: &'a AccountInfo<'a>,
-    pub(crate) _gas_service: &'a AccountInfo<'a>,
-    pub(crate) system_program: &'a AccountInfo<'a>,
-    pub(crate) its_root_account: &'a AccountInfo<'a>,
-    pub(crate) call_contract_signing_account: &'a AccountInfo<'a>,
-    pub(crate) program_account: &'a AccountInfo<'a>,
-    pub(crate) __event_cpi_authority_info: &'a AccountInfo<'a>,
-    pub(crate) __event_cpi_program_account: &'a AccountInfo<'a>,
-}
-
-impl Validate for GmpAccounts<'_> {
-    fn validate(&self) -> Result<(), ProgramError> {
-        validate_system_account_key(self.system_program.key)?;
-        axelar_solana_gateway::check_program_account(*self.gateway_program_id.key)?;
-
-        Ok(())
-    }
-}
-
-impl<'a> FromAccountInfoSlice<'a> for GmpAccounts<'a> {
-    type Context = ();
-
-    fn extract_accounts(
-        accounts: &'a [AccountInfo<'a>],
-        _context: &Self::Context,
-    ) -> Result<Self, ProgramError>
-    where
-        Self: Sized + Validate,
-    {
-        let accounts_iter = &mut accounts.iter();
-
-        Ok(Self {
-            gateway_root_account: next_account_info(accounts_iter)?,
-            gateway_event_authority: next_account_info(accounts_iter)?,
-            gateway_program_id: next_account_info(accounts_iter)?,
-            gas_service_config_account: next_account_info(accounts_iter)?,
-            gas_service_event_authority: next_account_info(accounts_iter)?,
-            _gas_service: next_account_info(accounts_iter)?,
-            system_program: next_account_info(accounts_iter)?,
-            its_root_account: next_account_info(accounts_iter)?,
-            call_contract_signing_account: next_account_info(accounts_iter)?,
-            program_account: next_account_info(accounts_iter)?,
-            __event_cpi_authority_info: next_account_info(accounts_iter)?,
-            __event_cpi_program_account: next_account_info(accounts_iter)?,
-        })
-    }
-}
-
-impl<'a> EventAccounts<'a> for GmpAccounts<'a> {
-    fn event_accounts(&self) -> [&'a AccountInfo<'a>; 2] {
-        [
-            self.__event_cpi_authority_info,
-            self.__event_cpi_program_account,
-        ]
-    }
-}
-
-pub(crate) fn process_outbound<'a>(
-    payer: &'a AccountInfo<'a>,
-    accounts: &GmpAccounts<'a>,
+pub(crate) fn process_call_contract(
+    accounts: &CallContractAccounts,
     payload: &GMPPayload,
     destination_chain: String,
     gas_value: u64,
     signing_pda_bump: u8,
     wrapped: bool,
 ) -> ProgramResult {
-    let its_root_config = InterchainTokenService::load(accounts.its_root_account)?;
-    assert_valid_its_root_pda(accounts.its_root_account, its_root_config.bump)?;
+    let its_root_config = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_root_config.bump)?;
     assert_its_not_paused(&its_root_config)?;
 
-    check_program_account(*accounts.program_account.key)?;
+    check_program_account(*accounts.program.key)?;
 
     if !its_root_config.is_trusted_chain(&destination_chain)
         && destination_chain != ITS_HUB_CHAIN_NAME
@@ -272,7 +101,7 @@ pub(crate) fn process_outbound<'a>(
     let signing_pda =
         axelar_solana_gateway::create_call_contract_signing_pda(crate::ID, signing_pda_bump)?;
 
-    if signing_pda.ne(accounts.call_contract_signing_account.key) {
+    if signing_pda.ne(accounts.call_contract_signing.key) {
         msg!("invalid call contract signing account / signing pda bump");
         return Err(ProgramError::InvalidAccountData);
     }
@@ -293,7 +122,7 @@ pub(crate) fn process_outbound<'a>(
     let payload_hash = solana_program::keccak::hashv(&[&payload]).to_bytes();
     let call_contract_ix = axelar_solana_gateway::instructions::call_contract(
         axelar_solana_gateway::id(),
-        *accounts.gateway_root_account.key,
+        *accounts.gateway_root.key,
         crate::ID,
         Some((signing_pda, signing_pda_bump)),
         crate::ITS_HUB_CHAIN_NAME.to_owned(),
@@ -303,8 +132,8 @@ pub(crate) fn process_outbound<'a>(
 
     if gas_value > 0 {
         pay_gas(
-            payer,
-            accounts.gas_service_config_account,
+            accounts.payer,
+            accounts.gas_service_root,
             accounts.gas_service_event_authority,
             accounts.system_program,
             payload_hash,
@@ -316,9 +145,9 @@ pub(crate) fn process_outbound<'a>(
     invoke_signed(
         &call_contract_ix,
         &[
-            accounts.program_account.clone(),
-            accounts.call_contract_signing_account.clone(),
-            accounts.gateway_root_account.clone(),
+            accounts.program.clone(),
+            accounts.call_contract_signing.clone(),
+            accounts.gateway_root.clone(),
             accounts.gateway_event_authority.clone(),
         ],
         &[&[

--- a/programs/axelar-solana-its/src/processor/interchain_transfer.rs
+++ b/programs/axelar-solana-its/src/processor/interchain_transfer.rs
@@ -5,12 +5,8 @@ use axelar_solana_gateway::executable::AxelarMessagePayload;
 use axelar_solana_gateway::state::incoming_message::command_id;
 use event_cpi_macros::{emit_cpi, event_cpi_accounts};
 use interchain_token_transfer_gmp::{GMPPayload, InterchainTransfer};
-use program_utils::next_optional_account_info;
-use program_utils::{
-    pda::BorshPda, validate_rent_key, validate_spl_associated_token_account_key,
-    validate_system_account_key,
-};
-use solana_program::account_info::{next_account_info, AccountInfo};
+use program_utils::pda::BorshPda;
+use solana_program::account_info::AccountInfo;
 use solana_program::clock::Clock;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
@@ -22,39 +18,23 @@ use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::Sysvar;
 use spl_token_2022::extension::transfer_fee::TransferFeeConfig;
 use spl_token_2022::extension::{BaseStateWithExtensions, StateWithExtensions};
-use spl_token_2022::state::{Account as TokenAccount, Mint};
+use spl_token_2022::state::Mint;
 
+use crate::accounts::{
+    AxelarInterchainTokenExecutableAccounts, FlowTrackingAccounts, GiveTokenAccounts,
+    TakeTokenAccounts,
+};
 use crate::executable::{AxelarInterchainTokenExecuteInfo, AXELAR_INTERCHAIN_TOKEN_EXECUTE};
 use crate::processor::token_manager as token_manager_processor;
 use crate::state::flow_limit::FlowDirection;
 use crate::state::token_manager::{self, TokenManager};
 use crate::{
     assert_valid_interchain_transfer_execute_pda, assert_valid_token_manager_pda, events,
-    initiate_interchain_execute_pda_if_empty, seed_prefixes, EventAccounts, FromAccountInfoSlice,
-    Validate,
+    initiate_interchain_execute_pda_if_empty, seed_prefixes,
 };
+use event_cpi::EventAccounts;
 
-use super::gmp::{self, GmpAccounts, ItsExecuteAccounts};
-
-/// Checks if an account is a valid Token account for the given mint and owner.
-pub(super) fn is_valid_token_account(
-    account: &AccountInfo,
-    token_program: &Pubkey,
-    expected_mint: &Pubkey,
-) -> bool {
-    // Check account owner is the token program
-    if account.owner != token_program {
-        return false;
-    }
-
-    // Try to unpack as TokenAccount and verify mint/owner
-    let account_data = account.data.borrow();
-    if let Ok(token_account) = StateWithExtensions::<TokenAccount>::unpack(&account_data) {
-        return token_account.base.mint == *expected_mint;
-    }
-
-    false
-}
+use super::gmp;
 
 /// Processes an incoming [`InterchainTransfer`] GMP message.
 ///
@@ -101,17 +81,16 @@ pub(super) fn is_valid_token_account(
 ///
 /// An error occurred when processing the message. The reason can be derived
 /// from the logs.
-pub(crate) fn process_inbound_transfer<'a>(
+pub(crate) fn process_inbound_transfer(
+    accounts: GiveTokenAccounts,
     message: Message,
-    execute_accounts: ItsExecuteAccounts<'a>,
     payload: &InterchainTransfer,
     source_chain: String,
 ) -> ProgramResult {
-    let accounts = GiveTokenAccounts::try_from(execute_accounts)?;
-    let token_manager = TokenManager::load(accounts.token_manager_pda)?;
+    let token_manager = TokenManager::load(accounts.token_manager)?;
     assert_valid_token_manager_pda(
-        accounts.token_manager_pda,
-        accounts.its_root_pda.key,
+        accounts.token_manager,
+        accounts.its_root.key,
         &token_manager.token_id,
         token_manager.bump,
     )?;
@@ -144,7 +123,7 @@ pub(crate) fn process_inbound_transfer<'a>(
 
     if !payload.data.is_empty() {
         let program_account = accounts.destination;
-        let system_account = accounts.system_account;
+        let system_account = accounts.system_program;
         let payer = accounts.payer;
 
         let destination_payload = AxelarMessagePayload::decode(payload.data.as_ref())?;
@@ -161,19 +140,19 @@ pub(crate) fn process_inbound_transfer<'a>(
         }
 
         let axelar_transfer_execute_bump = assert_valid_interchain_transfer_execute_pda(
-            axelar_executable_accounts.interchain_transfer_execute_pda,
+            axelar_executable_accounts.interchain_transfer_execute,
             program_account.key,
         )?;
 
         let account_infos = [
             &[
                 axelar_executable_accounts
-                    .interchain_transfer_execute_pda
+                    .interchain_transfer_execute
                     .clone(),
-                axelar_executable_accounts.message_payload_pda.clone(),
+                axelar_executable_accounts.gateway_message_payload.clone(),
                 axelar_executable_accounts.token_program.clone(),
-                axelar_executable_accounts.token_mint.clone(),
-                axelar_executable_accounts.program_ata.clone(),
+                axelar_executable_accounts.mint.clone(),
+                axelar_executable_accounts.destination_program_ata.clone(),
             ],
             axelar_executable_accounts.destination_program_accounts,
         ]
@@ -199,7 +178,7 @@ pub(crate) fn process_inbound_transfer<'a>(
         )?;
 
         initiate_interchain_execute_pda_if_empty(
-            axelar_executable_accounts.interchain_transfer_execute_pda,
+            axelar_executable_accounts.interchain_transfer_execute,
             payer,
             system_account,
             program_account.key,
@@ -212,7 +191,7 @@ pub(crate) fn process_inbound_transfer<'a>(
 
 fn build_axelar_interchain_token_execute(
     message: Message,
-    axelar_its_executable_accounts: &AxelarInterchainTokenExecutableAccounts<'_>,
+    axelar_its_executable_accounts: &AxelarInterchainTokenExecutableAccounts,
     program_id: Pubkey,
     mut program_accounts: Vec<AccountMeta>,
     payload: &InterchainTransfer,
@@ -221,23 +200,26 @@ fn build_axelar_interchain_token_execute(
     let command_id = command_id(&message.cc_id.chain, &message.cc_id.id);
     let source_address = payload.source_address.to_vec();
     let source_chain = message.cc_id.chain;
-    let token = axelar_its_executable_accounts.token_mint.key.to_bytes();
+    let token = axelar_its_executable_accounts.mint.key.to_bytes();
     let token_id = payload.token_id.0;
 
     let mut accounts = vec![
         AccountMeta::new(
             *axelar_its_executable_accounts
-                .interchain_transfer_execute_pda
+                .interchain_transfer_execute
                 .key,
             true,
         ),
         AccountMeta::new_readonly(
-            *axelar_its_executable_accounts.message_payload_pda.key,
+            *axelar_its_executable_accounts.gateway_message_payload.key,
             false,
         ),
         AccountMeta::new_readonly(*axelar_its_executable_accounts.token_program.key, false),
-        AccountMeta::new(*axelar_its_executable_accounts.token_mint.key, false),
-        AccountMeta::new(*axelar_its_executable_accounts.program_ata.key, false),
+        AccountMeta::new(*axelar_its_executable_accounts.mint.key, false),
+        AccountMeta::new(
+            *axelar_its_executable_accounts.destination_program_ata.key,
+            false,
+        ),
     ];
     accounts.append(&mut program_accounts);
 
@@ -266,8 +248,8 @@ fn build_axelar_interchain_token_execute(
 /// This function handles transfers where the source address should be the sender
 /// (user account). It validates that the sender is a user account and not a
 /// program or PDA to ensure proper source attribution in the transfer events.
-pub(crate) fn process_user_interchain_transfer<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn process_user_interchain_transfer(
+    accounts: TakeTokenAccounts,
     token_id: [u8; 32],
     destination_chain: String,
     destination_address: Vec<u8>,
@@ -276,21 +258,17 @@ pub(crate) fn process_user_interchain_transfer<'a>(
     signing_pda_bump: u8,
     data: Option<Vec<u8>>,
 ) -> ProgramResult {
-    let accounts_iter = &mut accounts.iter();
-    let _payer = next_account_info(accounts_iter)?;
     // Check that the sender is a user account, not a program or PDA
-    // We get the sender from the first account
-    let sender = next_account_info(accounts_iter)?;
-
     // User accounts should be owned by the System Program
-    if sender.owner != &solana_program::system_program::ID {
+    if accounts.authority.owner != &solana_program::system_program::ID {
         msg!(
             "Sender is not owned by System Program, owner: {}",
-            sender.owner
+            accounts.authority.owner
         );
         return Err(ProgramError::InvalidAccountData);
     }
 
+    let source_address = *accounts.authority.key;
     process_outbound_transfer(
         accounts,
         token_id,
@@ -300,13 +278,13 @@ pub(crate) fn process_user_interchain_transfer<'a>(
         gas_value,
         signing_pda_bump,
         data,
-        *sender.key,
+        source_address,
     )
 }
 
 /// Processes an interchain transfer initiated via Cross-Program Invocation (CPI) by a PDA.
-pub(crate) fn process_cpi_interchain_transfer<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn process_cpi_interchain_transfer(
+    accounts: TakeTokenAccounts,
     token_id: [u8; 32],
     destination_chain: String,
     destination_address: Vec<u8>,
@@ -317,15 +295,12 @@ pub(crate) fn process_cpi_interchain_transfer<'a>(
     pda_seeds: Vec<Vec<u8>>,
     data: Option<Vec<u8>>,
 ) -> ProgramResult {
-    let accounts_iter = &mut accounts.iter();
-    let _payer = next_account_info(accounts_iter)?;
     // The sender should be a PDA owned by the source program
-    let sender = next_account_info(accounts_iter)?;
-    if sender.owner != &source_id {
+    if accounts.authority.owner != &source_id {
         msg!(
             "Sender account must be owned by the source program. Expected: {}, Got: {}",
             source_id,
-            sender.owner
+            accounts.authority.owner
         );
         return Err(ProgramError::InvalidAccountData);
     }
@@ -335,11 +310,11 @@ pub(crate) fn process_cpi_interchain_transfer<'a>(
     let (expected_pda, _bump) =
         solana_program::pubkey::Pubkey::find_program_address(&seeds_refs, &source_id);
 
-    if expected_pda != *sender.key {
+    if expected_pda != *accounts.authority.key {
         msg!(
             "PDA derivation mismatch. Expected: {}, Got: {}",
             expected_pda,
-            sender.key
+            accounts.authority.key
         );
         return Err(ProgramError::InvalidAccountData);
     }
@@ -357,8 +332,8 @@ pub(crate) fn process_cpi_interchain_transfer<'a>(
     )
 }
 
-pub(crate) fn process_outbound_transfer<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn process_outbound_transfer(
+    accounts: TakeTokenAccounts,
     token_id: [u8; 32],
     destination_chain: String,
     destination_address: Vec<u8>,
@@ -368,45 +343,40 @@ pub(crate) fn process_outbound_transfer<'a>(
     data: Option<Vec<u8>>,
     source_address: Pubkey,
 ) -> ProgramResult {
-    const GMP_ACCOUNTS_IDX: usize = 7;
-    let take_token_accounts = TakeTokenAccounts::from_account_info_slice(accounts, &())?;
-    let (_other, outbound_message_accounts) = accounts.split_at(GMP_ACCOUNTS_IDX);
-    let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
-
     msg!("Instruction: OutboundTransfer");
 
-    let token_manager = TokenManager::load(take_token_accounts.token_manager_pda)?;
+    let token_manager = TokenManager::load(accounts.token_manager)?;
 
     assert_valid_token_manager_pda(
-        take_token_accounts.token_manager_pda,
-        take_token_accounts.its_root_pda.key,
+        accounts.token_manager,
+        accounts.its_root.key,
         &token_id,
         token_manager.bump,
     )?;
 
     let expected_token_manager_ata =
         spl_associated_token_account::get_associated_token_address_with_program_id(
-            take_token_accounts.token_manager_pda.key,
-            take_token_accounts.token_mint.key,
-            take_token_accounts.token_program.key,
+            accounts.token_manager.key,
+            accounts.mint.key,
+            accounts.token_program.key,
         );
-    if *take_token_accounts.token_manager_ata.key != expected_token_manager_ata {
+    if *accounts.token_manager_ata.key != expected_token_manager_ata {
         msg!("Provided token_manager_ata doesn't match expected derivation");
         return Err(ProgramError::InvalidAccountData);
     }
 
-    if token_manager.token_address != *take_token_accounts.token_mint.key {
+    if token_manager.token_address != *accounts.mint.key {
         msg!("Mint and token ID don't match");
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let amount_minus_fees = take_token(&take_token_accounts, &token_manager, amount)?;
+    let amount_minus_fees = take_token(&accounts, &token_manager, amount)?;
     amount = amount_minus_fees;
 
     let transfer_event = events::InterchainTransfer {
         token_id,
         source_address,
-        source_token_account: *take_token_accounts.source_ata.key,
+        source_token_account: *accounts.source_ata.key,
         destination_chain,
         destination_address,
         amount,
@@ -420,7 +390,7 @@ pub(crate) fn process_outbound_transfer<'a>(
             [0; 32]
         },
     };
-    let event_accounts_iter = &mut gmp_accounts.event_accounts().into_iter();
+    let event_accounts_iter = &mut accounts.event_accounts().into_iter();
     event_cpi_accounts!(event_accounts_iter);
     emit_cpi!(transfer_event);
 
@@ -435,9 +405,8 @@ pub(crate) fn process_outbound_transfer<'a>(
         data: data.unwrap_or_default().into(),
     });
 
-    gmp::process_outbound(
-        take_token_accounts.payer,
-        &gmp_accounts,
+    gmp::process_call_contract(
+        &accounts.try_into()?,
         &payload,
         transfer_event.destination_chain,
         gas_value,
@@ -447,28 +416,28 @@ pub(crate) fn process_outbound_transfer<'a>(
 }
 
 pub(crate) fn take_token(
-    accounts: &TakeTokenAccounts<'_>,
+    accounts: &TakeTokenAccounts,
     token_manager: &TokenManager,
     amount: u64,
 ) -> Result<u64, ProgramError> {
     token_manager_processor::validate_token_manager_type(
         token_manager.ty,
-        accounts.token_mint,
-        accounts.token_manager_pda,
+        accounts.mint,
+        accounts.token_manager,
     )?;
 
     handle_take_token_transfer(accounts, token_manager, amount)
 }
 
 fn give_token(
-    accounts: &GiveTokenAccounts<'_>,
+    accounts: &GiveTokenAccounts,
     token_manager: &TokenManager,
     amount: u64,
 ) -> Result<u64, ProgramError> {
     token_manager_processor::validate_token_manager_type(
         token_manager.ty,
-        accounts.token_mint,
-        accounts.token_manager_pda,
+        accounts.mint,
+        accounts.token_manager,
     )?;
 
     let transferred_amount = handle_give_token_transfer(accounts, token_manager, amount)?;
@@ -477,11 +446,11 @@ fn give_token(
 }
 
 fn track_token_flow(
-    accounts: &FlowTrackingAccounts<'_>,
+    accounts: &FlowTrackingAccounts,
     amount: u64,
     direction: FlowDirection,
 ) -> ProgramResult {
-    let mut token_manager = TokenManager::load(accounts.token_manager_pda)?;
+    let mut token_manager = TokenManager::load(accounts.token_manager)?;
 
     if token_manager.flow_slot.flow_limit.is_none() {
         return Ok(());
@@ -499,15 +468,15 @@ fn track_token_flow(
     token_manager.flow_slot.add_flow(amount, direction)?;
     token_manager.store(
         accounts.payer,
-        accounts.token_manager_pda,
-        accounts.system_account,
+        accounts.token_manager,
+        accounts.system_program,
     )?;
 
     Ok(())
 }
 
 fn handle_give_token_transfer(
-    accounts: &GiveTokenAccounts<'_>,
+    accounts: &GiveTokenAccounts,
     token_manager: &TokenManager,
     amount: u64,
 ) -> Result<u64, ProgramError> {
@@ -521,25 +490,25 @@ fn handle_give_token_transfer(
 
     let signer_seeds = &[
         seed_prefixes::TOKEN_MANAGER_SEED,
-        accounts.its_root_pda.key.as_ref(),
+        accounts.its_root.key.as_ref(),
         &token_id,
         &[token_manager_pda_bump],
     ];
     let transferred = match token_manager.ty {
         NativeInterchainToken | MintBurn | MintBurnFrom => {
             mint_to(
-                accounts.its_root_pda,
+                accounts.its_root,
                 accounts.token_program,
-                accounts.token_mint,
+                accounts.mint,
                 accounts.destination_ata,
-                accounts.token_manager_pda,
+                accounts.token_manager,
                 token_manager,
                 amount,
             )?;
             amount
         }
         LockUnlock => {
-            let decimals = get_mint_decimals(accounts.token_mint)?;
+            let decimals = get_mint_decimals(accounts.mint)?;
             let transfer_info =
                 create_give_token_transfer_info(accounts, amount, decimals, None, signer_seeds);
             transfer_to(&transfer_info)?;
@@ -547,7 +516,7 @@ fn handle_give_token_transfer(
             amount
         }
         LockUnlockFee => {
-            let (fee, decimals) = get_fee_and_decimals(accounts.token_mint, amount)?;
+            let (fee, decimals) = get_fee_and_decimals(accounts.mint, amount)?;
             let transfer_info = create_give_token_transfer_info(
                 accounts,
                 amount,
@@ -566,7 +535,7 @@ fn handle_give_token_transfer(
 }
 
 fn handle_take_token_transfer(
-    accounts: &TakeTokenAccounts<'_>,
+    accounts: &TakeTokenAccounts,
     token_manager: &TokenManager,
     amount: u64,
 ) -> Result<u64, ProgramError> {
@@ -581,7 +550,7 @@ fn handle_take_token_transfer(
             burn(
                 accounts.authority,
                 accounts.token_program,
-                accounts.token_mint,
+                accounts.mint,
                 accounts.source_ata,
                 amount,
                 &[],
@@ -589,14 +558,14 @@ fn handle_take_token_transfer(
             amount
         }
         LockUnlock => {
-            let decimals = get_mint_decimals(accounts.token_mint)?;
+            let decimals = get_mint_decimals(accounts.mint)?;
             let transfer_info =
                 create_take_token_transfer_info(accounts, amount, decimals, None, &[]);
             transfer_to(&transfer_info)?;
             amount
         }
         LockUnlockFee => {
-            let (fee, decimals) = get_fee_and_decimals(accounts.token_mint, amount)?;
+            let (fee, decimals) = get_fee_and_decimals(accounts.mint, amount)?;
             let transfer_info =
                 create_take_token_transfer_info(accounts, amount, decimals, Some(fee), &[]);
             transfer_with_fee_to(&transfer_info)?;
@@ -609,16 +578,13 @@ fn handle_take_token_transfer(
     Ok(transferred)
 }
 
-fn get_mint_decimals(token_mint: &AccountInfo<'_>) -> Result<u8, ProgramError> {
+fn get_mint_decimals(token_mint: &AccountInfo) -> Result<u8, ProgramError> {
     let mint_data = token_mint.try_borrow_data()?;
     let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data)?;
     Ok(mint_state.base.decimals)
 }
 
-fn get_fee_and_decimals(
-    token_mint: &AccountInfo<'_>,
-    amount: u64,
-) -> Result<(u64, u8), ProgramError> {
+fn get_fee_and_decimals(token_mint: &AccountInfo, amount: u64) -> Result<(u64, u8), ProgramError> {
     let mint_data = token_mint.try_borrow_data()?;
     let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data)?;
     let fee_config = mint_state.get_extension::<TransferFeeConfig>()?;
@@ -639,7 +605,7 @@ fn create_take_token_transfer_info<'a, 'b>(
 ) -> TransferInfo<'a, 'b> {
     TransferInfo {
         token_program: accounts.token_program,
-        token_mint: accounts.token_mint,
+        token_mint: accounts.mint,
         destination: accounts.token_manager_ata,
         authority: accounts.authority,
         source: accounts.source_ata,
@@ -659,9 +625,9 @@ fn create_give_token_transfer_info<'a, 'b>(
 ) -> TransferInfo<'a, 'b> {
     TransferInfo {
         token_program: accounts.token_program,
-        token_mint: accounts.token_mint,
+        token_mint: accounts.mint,
         destination: accounts.destination_ata,
-        authority: accounts.token_manager_pda,
+        authority: accounts.token_manager,
         source: accounts.token_manager_ata,
         signers_seeds,
         amount,
@@ -743,7 +709,7 @@ struct TransferInfo<'a, 'b> {
     fee: Option<u64>,
 }
 
-fn transfer_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
+fn transfer_to(info: &TransferInfo) -> ProgramResult {
     invoke_signed(
         &spl_token_2022::instruction::transfer_checked(
             info.token_program.key,
@@ -766,7 +732,7 @@ fn transfer_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
     Ok(())
 }
 
-fn transfer_with_fee_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
+fn transfer_with_fee_to(info: &TransferInfo) -> ProgramResult {
     invoke_signed(
         &spl_token_2022::extension::transfer_fee::instruction::transfer_checked_with_fee(
             info.token_program.key,
@@ -788,223 +754,4 @@ fn transfer_with_fee_to(info: &TransferInfo<'_, '_>) -> ProgramResult {
         &[info.signers_seeds],
     )?;
     Ok(())
-}
-
-#[derive(Debug)]
-pub(crate) struct TakeTokenAccounts<'a> {
-    pub(crate) payer: &'a AccountInfo<'a>,
-    pub(crate) authority: &'a AccountInfo<'a>,
-    pub(crate) source_ata: &'a AccountInfo<'a>,
-    pub(crate) token_mint: &'a AccountInfo<'a>,
-    pub(crate) token_manager_pda: &'a AccountInfo<'a>,
-    pub(crate) token_manager_ata: &'a AccountInfo<'a>,
-    pub(crate) token_program: &'a AccountInfo<'a>,
-    pub(crate) system_account: &'a AccountInfo<'a>,
-    pub(crate) its_root_pda: &'a AccountInfo<'a>,
-}
-
-impl Validate for TakeTokenAccounts<'_> {
-    fn validate(&self) -> Result<(), ProgramError> {
-        validate_system_account_key(self.system_account.key)?;
-        spl_token_2022::check_spl_token_program_account(self.token_program.key)?;
-
-        if !self.payer.is_signer {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
-
-        if !self.authority.is_signer {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
-
-        if self.token_mint.owner != self.token_program.key {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        Ok(())
-    }
-}
-
-impl<'a> FromAccountInfoSlice<'a> for TakeTokenAccounts<'a> {
-    type Context = ();
-    fn extract_accounts(
-        accounts: &'a [AccountInfo<'a>],
-        _context: &Self::Context,
-    ) -> Result<Self, ProgramError> {
-        let accounts_iter = &mut accounts.iter();
-
-        Ok(TakeTokenAccounts {
-            payer: next_account_info(accounts_iter)?,
-            authority: next_account_info(accounts_iter)?,
-            source_ata: next_account_info(accounts_iter)?,
-            token_mint: next_account_info(accounts_iter)?,
-            token_manager_pda: next_account_info(accounts_iter)?,
-            token_manager_ata: next_account_info(accounts_iter)?,
-            token_program: next_account_info(accounts_iter)?,
-            system_account: {
-                next_account_info(accounts_iter)?;
-                next_account_info(accounts_iter)?;
-                next_account_info(accounts_iter)?;
-                next_account_info(accounts_iter)?;
-                next_account_info(accounts_iter)?;
-                next_account_info(accounts_iter)?;
-                next_account_info(accounts_iter)?
-            },
-            its_root_pda: next_account_info(accounts_iter)?,
-        })
-    }
-}
-
-#[derive(Debug)]
-struct GiveTokenAccounts<'a> {
-    payer: &'a AccountInfo<'a>,
-    system_account: &'a AccountInfo<'a>,
-    its_root_pda: &'a AccountInfo<'a>,
-    message_payload_pda: &'a AccountInfo<'a>,
-    token_manager_pda: &'a AccountInfo<'a>,
-    token_mint: &'a AccountInfo<'a>,
-    token_manager_ata: &'a AccountInfo<'a>,
-    token_program: &'a AccountInfo<'a>,
-    ata_program: &'a AccountInfo<'a>,
-    rent_sysvar: &'a AccountInfo<'a>,
-    destination: &'a AccountInfo<'a>,
-    destination_ata: &'a AccountInfo<'a>,
-    interchain_transfer_execute_pda: Option<&'a AccountInfo<'a>>,
-    __event_cpi_authority_info: &'a AccountInfo<'a>,
-    __event_cpi_program_account: &'a AccountInfo<'a>,
-    remaining_accounts: &'a [AccountInfo<'a>],
-}
-
-impl Validate for GiveTokenAccounts<'_> {
-    fn validate(&self) -> Result<(), ProgramError> {
-        validate_system_account_key(self.system_account.key)?;
-        validate_spl_associated_token_account_key(self.ata_program.key)?;
-        validate_rent_key(self.rent_sysvar.key)?;
-        spl_token_2022::check_spl_token_program_account(self.token_program.key)?;
-
-        if self.token_mint.owner != self.token_program.key {
-            return Err(ProgramError::InvalidAccountData);
-        }
-
-        Ok(())
-    }
-}
-
-impl<'a> TryFrom<ItsExecuteAccounts<'a>> for GiveTokenAccounts<'a> {
-    type Error = ProgramError;
-
-    fn try_from(value: ItsExecuteAccounts<'a>) -> Result<Self, Self::Error> {
-        let remaining_accounts_iter = &mut value.remaining_accounts.iter();
-        let mut converted = Self {
-            payer: value.payer,
-            system_account: value.system_program,
-            its_root_pda: value.its_root_pda,
-            message_payload_pda: value.gateway_payload_account,
-            token_manager_pda: value.token_manager_pda,
-            token_mint: value.token_mint,
-            token_manager_ata: value.token_manager_ata,
-            token_program: value.token_program,
-            ata_program: value.ata_program,
-            rent_sysvar: value.rent_sysvar,
-            destination: next_account_info(remaining_accounts_iter)?,
-            destination_ata: next_account_info(remaining_accounts_iter)?,
-            interchain_transfer_execute_pda: next_optional_account_info(
-                remaining_accounts_iter,
-                &crate::ID,
-            )?,
-            __event_cpi_authority_info: value.__event_cpi_authority_info,
-            __event_cpi_program_account: value.__event_cpi_program_account,
-            remaining_accounts: remaining_accounts_iter.as_slice(),
-        };
-
-        if is_valid_token_account(
-            converted.destination,
-            converted.token_program.key,
-            converted.token_mint.key,
-        ) {
-            converted.destination_ata = converted.destination;
-        } else {
-            crate::create_associated_token_account_idempotent(
-                converted.payer,
-                converted.token_mint,
-                converted.destination_ata,
-                converted.destination,
-                converted.system_account,
-                converted.token_program,
-            )?;
-        }
-
-        converted.validate()?;
-
-        Ok(converted)
-    }
-}
-
-impl<'a> EventAccounts<'a> for GiveTokenAccounts<'a> {
-    fn event_accounts(&self) -> [&'a AccountInfo<'a>; 2] {
-        [
-            self.__event_cpi_authority_info,
-            self.__event_cpi_program_account,
-        ]
-    }
-}
-
-struct AxelarInterchainTokenExecutableAccounts<'a> {
-    message_payload_pda: &'a AccountInfo<'a>,
-    token_program: &'a AccountInfo<'a>,
-    token_mint: &'a AccountInfo<'a>,
-    program_ata: &'a AccountInfo<'a>,
-    destination_program_accounts: &'a [AccountInfo<'a>],
-    interchain_transfer_execute_pda: &'a AccountInfo<'a>,
-}
-
-impl Validate for AxelarInterchainTokenExecutableAccounts<'_> {
-    fn validate(&self) -> Result<(), ProgramError> {
-        Ok(())
-    }
-}
-
-impl<'a> TryFrom<GiveTokenAccounts<'a>> for AxelarInterchainTokenExecutableAccounts<'a> {
-    type Error = ProgramError;
-
-    fn try_from(value: GiveTokenAccounts<'a>) -> Result<Self, Self::Error> {
-        let converted = Self {
-            message_payload_pda: value.message_payload_pda,
-            token_program: value.token_program,
-            token_mint: value.token_mint,
-            program_ata: value.destination_ata,
-            destination_program_accounts: value.remaining_accounts,
-            interchain_transfer_execute_pda: value
-                .interchain_transfer_execute_pda
-                .ok_or(ProgramError::NotEnoughAccountKeys)?,
-        };
-
-        converted.validate()?;
-
-        Ok(converted)
-    }
-}
-
-struct FlowTrackingAccounts<'a> {
-    system_account: &'a AccountInfo<'a>,
-    payer: &'a AccountInfo<'a>,
-    token_manager_pda: &'a AccountInfo<'a>,
-}
-
-impl<'a> From<&TakeTokenAccounts<'a>> for FlowTrackingAccounts<'a> {
-    fn from(value: &TakeTokenAccounts<'a>) -> Self {
-        Self {
-            system_account: value.system_account,
-            payer: value.payer,
-            token_manager_pda: value.token_manager_pda,
-        }
-    }
-}
-
-impl<'a> From<&GiveTokenAccounts<'a>> for FlowTrackingAccounts<'a> {
-    fn from(value: &GiveTokenAccounts<'a>) -> Self {
-        Self {
-            system_account: value.system_account,
-            payer: value.payer,
-            token_manager_pda: value.token_manager_pda,
-        }
-    }
 }

--- a/programs/axelar-solana-its/src/processor/link_token.rs
+++ b/programs/axelar-solana-its/src/processor/link_token.rs
@@ -3,7 +3,6 @@
 use event_cpi_macros::{emit_cpi, event_cpi_accounts};
 use interchain_token_transfer_gmp::{GMPPayload, LinkToken, RegisterTokenMetadata};
 use program_utils::pda::BorshPda;
-use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
 use solana_program::program::set_return_data;
@@ -12,18 +11,22 @@ use solana_program::pubkey::Pubkey;
 use spl_token_2022::extension::{BaseStateWithExtensions, ExtensionType, StateWithExtensions};
 use spl_token_2022::state::Mint;
 
-use crate::processor::gmp::{self, GmpAccounts};
+use crate::accounts::{
+    DeployCanonicalTokenAccounts, DeployCustomTokenAccounts, DeployTokenManagerAccounts,
+    LinkTokenAccounts, RegisterTokenMetadataAccounts,
+};
+use crate::processor::gmp;
 use crate::processor::interchain_token;
-use crate::processor::token_manager::{DeployTokenManagerAccounts, DeployTokenManagerInternal};
+use crate::processor::token_manager::DeployTokenManagerInternal;
 use crate::state::token_manager::TokenManager;
 use crate::state::{token_manager, InterchainTokenService};
 use crate::{
     assert_its_not_paused, assert_valid_its_root_pda, assert_valid_token_manager_pda, events,
-    EventAccounts, FromAccountInfoSlice,
 };
+use event_cpi::EventAccounts;
 
-pub(crate) fn process_inbound<'a>(
-    accounts: DeployTokenManagerAccounts<'a>,
+pub(crate) fn process_inbound(
+    accounts: DeployTokenManagerAccounts,
     payload: &LinkToken,
 ) -> ProgramResult {
     let token_manager_type: token_manager::Type = payload.token_manager_type.try_into()?;
@@ -51,12 +54,12 @@ pub(crate) fn process_inbound<'a>(
         None,
     );
 
-    let its_root_pda_bump = InterchainTokenService::load(accounts.its_root_pda)?.bump;
+    let its_root_pda_bump = InterchainTokenService::load(accounts.its_root)?.bump;
 
-    assert_valid_its_root_pda(accounts.its_root_pda, its_root_pda_bump)?;
+    assert_valid_its_root_pda(accounts.its_root, its_root_pda_bump)?;
 
     let (_, token_manager_pda_bump) =
-        crate::find_token_manager_pda(accounts.its_root_pda.key, payload.token_id.as_ref());
+        crate::find_token_manager_pda(accounts.its_root.key, payload.token_id.as_ref());
 
     crate::processor::token_manager::deploy(
         &accounts,
@@ -65,8 +68,8 @@ pub(crate) fn process_inbound<'a>(
     )
 }
 
-pub(crate) fn process_outbound<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn process_outbound(
+    accounts: LinkTokenAccounts,
     salt: [u8; 32],
     destination_chain: String,
     destination_token_address: Vec<u8>,
@@ -75,51 +78,31 @@ pub(crate) fn process_outbound<'a>(
     gas_value: u64,
     signing_pda_bump: u8,
 ) -> ProgramResult {
-    const OUTBOUND_MESSAGE_ACCOUNTS_IDX: usize = 3;
-
-    let ([payer, deployer, token_manager_account], outbound_message_accounts) =
-        accounts.split_at(OUTBOUND_MESSAGE_ACCOUNTS_IDX)
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
-
-    let its_root_config = InterchainTokenService::load(gmp_accounts.its_root_account)?;
-    assert_valid_its_root_pda(gmp_accounts.its_root_account, its_root_config.bump)?;
+    let its_root_config = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_root_config.bump)?;
     if destination_chain == its_root_config.chain_name {
         msg!("Cannot link to another token on the same chain");
         return Err(ProgramError::InvalidInstructionData);
     }
 
-    if !payer.is_signer {
-        msg!("Payer should be signer");
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-
-    if !deployer.is_signer {
-        msg!("Deployer should be signer");
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-
     msg!("Instruction: ProcessOutbound");
-    let deploy_salt = crate::linked_token_deployer_salt(deployer.key, &salt);
+    let deploy_salt = crate::linked_token_deployer_salt(accounts.deployer.key, &salt);
     let token_id = crate::interchain_token_id_internal(&deploy_salt);
 
-    let event_accounts_iter = &mut gmp_accounts.event_accounts().into_iter();
+    let event_accounts_iter = &mut accounts.event_accounts().into_iter();
     event_cpi_accounts!(event_accounts_iter);
 
     emit_cpi!(events::InterchainTokenIdClaimed {
         token_id,
-        deployer: *deployer.key,
+        deployer: *accounts.deployer.key,
         salt: deploy_salt,
     });
 
-    let token_manager = TokenManager::load(token_manager_account)?;
+    let token_manager = TokenManager::load(accounts.token_manager)?;
 
     assert_valid_token_manager_pda(
-        token_manager_account,
-        gmp_accounts.its_root_account.key,
+        accounts.token_manager,
+        accounts.its_root.key,
         &token_id,
         token_manager.bump,
     )?;
@@ -145,9 +128,8 @@ pub(crate) fn process_outbound<'a>(
         link_params: link_started_events.params.into(),
     });
 
-    gmp::process_outbound(
-        payer,
-        &gmp_accounts,
+    gmp::process_call_contract(
+        &accounts.try_into()?,
         &message,
         link_started_events.destination_chain,
         gas_value,
@@ -160,42 +142,32 @@ pub(crate) fn process_outbound<'a>(
     Ok(())
 }
 
-pub(crate) fn register_token_metadata<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn register_token_metadata(
+    accounts: RegisterTokenMetadataAccounts,
     gas_value: u64,
     signing_pda_bump: u8,
 ) -> ProgramResult {
-    const OUTBOUND_MESSAGE_ACCOUNTS_IDX: usize = 2;
-
-    let accounts_iter = &mut accounts.iter();
-    let payer = next_account_info(accounts_iter)?;
-    let mint_account = next_account_info(accounts_iter)?;
-
-    let (_other, outbound_message_accounts) = accounts.split_at(OUTBOUND_MESSAGE_ACCOUNTS_IDX);
-    let gmp_accounts = GmpAccounts::from_account_info_slice(outbound_message_accounts, &())?;
     msg!("Instruction: RegisterTokenMetadata");
 
-    let event_accounts_iter = &mut gmp_accounts.event_accounts().into_iter();
-    event_cpi_accounts!(event_accounts_iter);
-
-    let mint_data = mint_account.try_borrow_data()?;
+    let mint_data = accounts.mint.try_borrow_data()?;
     let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
     let payload = GMPPayload::RegisterTokenMetadata(RegisterTokenMetadata {
         selector: RegisterTokenMetadata::MESSAGE_TYPE_ID
             .try_into()
             .map_err(|_err| ProgramError::ArithmeticOverflow)?,
-        token_address: mint_account.key.to_bytes().into(),
+        token_address: accounts.mint.key.to_bytes().into(),
         decimals: mint.base.decimals,
     });
 
+    let event_accounts_iter = &mut accounts.event_accounts().into_iter();
+    event_cpi_accounts!(event_accounts_iter);
     emit_cpi!(events::TokenMetadataRegistered {
-        token_address: *mint_account.key,
+        token_address: *accounts.mint.key,
         decimals: mint.base.decimals,
     });
 
-    gmp::process_outbound(
-        payer,
-        &gmp_accounts,
+    gmp::process_call_contract(
+        &accounts.try_into()?,
         &payload,
         crate::ITS_HUB_CHAIN_NAME.to_owned(),
         gas_value,
@@ -204,8 +176,8 @@ pub(crate) fn register_token_metadata<'a>(
     )
 }
 
-pub(crate) fn register_custom_token<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn register_custom_token(
+    accounts: DeployCustomTokenAccounts,
     salt: [u8; 32],
     token_manager_type: token_manager::Type,
     operator: Option<Pubkey>,
@@ -214,127 +186,98 @@ pub(crate) fn register_custom_token<'a>(
         return Err(ProgramError::InvalidInstructionData);
     }
 
+    msg!("Instruction: RegisterCustomToken");
+
+    let its_config = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_config.bump)?;
+    assert_its_not_paused(&its_config)?;
+
+    let deployer = *accounts.deployer.key;
+    let deploy_salt = crate::linked_token_deployer_salt(&deployer, &salt);
+
     register_token(
-        accounts,
-        &TokenRegistration::Custom {
-            salt,
-            token_manager_type,
-            operator,
-        },
+        accounts.try_into()?,
+        token_manager_type,
+        deployer,
+        operator,
+        deploy_salt,
     )
 }
 
-pub(crate) fn register_canonical_interchain_token<'a>(
-    accounts: &'a [AccountInfo<'a>],
+pub(crate) fn register_canonical_interchain_token(
+    accounts: DeployCanonicalTokenAccounts,
 ) -> ProgramResult {
-    register_token(accounts, &TokenRegistration::Canonical)
-}
+    msg!("Instruction: RegisterCanonicalInterchainToken");
 
-enum TokenRegistration {
-    Canonical,
-    Custom {
-        salt: [u8; 32],
-        token_manager_type: token_manager::Type,
-        operator: Option<Pubkey>,
-    },
-}
-
-fn register_token<'a>(
-    accounts: &'a [AccountInfo<'a>],
-    registration: &TokenRegistration,
-) -> ProgramResult {
-    const DEPLOY_TOKEN_MANAGER_ACCOUNTS_IDX: usize = 2;
-
-    let ([payer, registration_specific_account], deploy_token_manager_accounts) =
-        accounts.split_at(DEPLOY_TOKEN_MANAGER_ACCOUNTS_IDX)
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    let parsed_accounts = DeployTokenManagerAccounts::from_account_info_slice(
-        deploy_token_manager_accounts,
-        &Some(payer),
-    )?;
-
-    msg!("Instruction: RegisterToken");
-
-    let event_accounts_iter = &mut parsed_accounts.event_accounts().into_iter();
-    event_cpi_accounts!(event_accounts_iter);
-
-    let its_config = InterchainTokenService::load(parsed_accounts.its_root_pda)?;
-    assert_valid_its_root_pda(parsed_accounts.its_root_pda, its_config.bump)?;
+    let its_config = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_config.bump)?;
     assert_its_not_paused(&its_config)?;
-    let mint_data = parsed_accounts.token_mint.try_borrow_data()?;
+
+    if let Err(_err) =
+        interchain_token::get_token_metadata(accounts.mint, Some(accounts.token_metadata))
+    {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let mint_data = accounts.mint.try_borrow_data()?;
     let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
     let has_fee_extension = mint
         .get_extension_types()?
         .contains(&ExtensionType::TransferFeeConfig);
 
-    let (token_manager_type, operator, deploy_salt) = match *registration {
-        TokenRegistration::Canonical => {
-            let metadata_account = registration_specific_account;
-
-            // Metadata is required for canonical tokens
-            if let Err(_err) = interchain_token::get_token_metadata(
-                parsed_accounts.token_mint,
-                Some(metadata_account),
-            ) {
-                return Err(ProgramError::InvalidAccountData);
-            }
-
-            let token_manager_type = if has_fee_extension {
-                token_manager::Type::LockUnlockFee
-            } else {
-                token_manager::Type::LockUnlock
-            };
-
-            (
-                token_manager_type,
-                None,
-                crate::canonical_interchain_token_deploy_salt(parsed_accounts.token_mint.key),
-            )
-        }
-        TokenRegistration::Custom {
-            salt,
-            token_manager_type,
-            operator,
-        } => {
-            let deployer = registration_specific_account;
-
-            (
-                token_manager_type,
-                operator,
-                crate::linked_token_deployer_salt(deployer.key, &salt),
-            )
-        }
+    let token_manager_type = if has_fee_extension {
+        token_manager::Type::LockUnlockFee
+    } else {
+        token_manager::Type::LockUnlock
     };
+
+    let deploy_salt = crate::canonical_interchain_token_deploy_salt(accounts.mint.key);
+
+    register_token(
+        accounts.try_into()?,
+        token_manager_type,
+        crate::ID,
+        None,
+        deploy_salt,
+    )
+}
+
+fn register_token(
+    accounts: DeployTokenManagerAccounts,
+    token_manager_type: token_manager::Type,
+    deployer: Pubkey,
+    operator: Option<Pubkey>,
+    deploy_salt: [u8; 32],
+) -> ProgramResult {
+    let event_accounts_iter = &mut accounts.event_accounts().into_iter();
+    event_cpi_accounts!(event_accounts_iter);
 
     let token_id = crate::interchain_token_id_internal(&deploy_salt);
     let (_, token_manager_pda_bump) =
-        crate::find_token_manager_pda(parsed_accounts.its_root_pda.key, &token_id);
+        crate::find_token_manager_pda(accounts.its_root.key, &token_id);
     crate::assert_valid_token_manager_pda(
-        parsed_accounts.token_manager_pda,
-        parsed_accounts.its_root_pda.key,
+        accounts.token_manager,
+        accounts.its_root.key,
         &token_id,
         token_manager_pda_bump,
     )?;
 
     emit_cpi!(events::InterchainTokenIdClaimed {
         token_id,
-        deployer: *payer.key,
+        deployer,
         salt: deploy_salt,
     });
 
     let deploy_token_manager = DeployTokenManagerInternal::new(
         token_manager_type,
         token_id,
-        *parsed_accounts.token_mint.key,
+        *accounts.mint.key,
         operator,
         None,
     );
 
     crate::processor::token_manager::deploy(
-        &parsed_accounts,
+        &accounts,
         &deploy_token_manager,
         token_manager_pda_bump,
     )?;

--- a/programs/axelar-solana-its/src/processor/mod.rs
+++ b/programs/axelar-solana-its/src/processor/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 //! Program state processor
 use borsh::BorshDeserialize;
+use event_cpi::EventAccounts;
 use event_cpi_macros::{emit_cpi, event_cpi_accounts, event_cpi_handler};
 use program_utils::{
     pda::{BorshPda, ValidPDA},
@@ -18,9 +19,9 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use token_manager::handover_mint_authority;
 
-use crate::instruction::InterchainTokenServiceInstruction;
-use crate::state::token_manager::TokenManager;
 use crate::state::InterchainTokenService;
+use crate::{accounts::RemoveTrustedChainAccounts, state::token_manager::TokenManager};
+use crate::{accounts::SetTrustedChainAccounts, instruction::InterchainTokenServiceInstruction};
 use crate::{assert_valid_its_root_pda, check_program_account, events, Roles};
 
 pub(crate) mod gmp;
@@ -62,13 +63,13 @@ pub fn process_instruction<'a>(
             process_set_pause_status(accounts, paused)
         }
         InterchainTokenServiceInstruction::Execute { message } => {
-            gmp::process_execute(accounts, message)
+            gmp::process_execute(accounts.try_into()?, message)
         }
         InterchainTokenServiceInstruction::SetTrustedChain { chain_name } => {
-            process_set_trusted_chain(accounts, chain_name)
+            process_set_trusted_chain(accounts.try_into()?, chain_name)
         }
         InterchainTokenServiceInstruction::RemoveTrustedChain { chain_name } => {
-            process_remove_trusted_chain(accounts, &chain_name)
+            process_remove_trusted_chain(accounts.try_into()?, &chain_name)
         }
         InterchainTokenServiceInstruction::ApproveDeployRemoteInterchainToken {
             deployer,
@@ -93,14 +94,14 @@ pub fn process_instruction<'a>(
             destination_chain,
         ),
         InterchainTokenServiceInstruction::RegisterCanonicalInterchainToken => {
-            link_token::register_canonical_interchain_token(accounts)
+            link_token::register_canonical_interchain_token(accounts.try_into()?)
         }
         InterchainTokenServiceInstruction::DeployRemoteCanonicalInterchainToken {
             destination_chain,
             gas_value,
             signing_pda_bump,
         } => interchain_token::deploy_remote_canonical_interchain_token(
-            accounts,
+            accounts.try_into()?,
             destination_chain,
             gas_value,
             signing_pda_bump,
@@ -111,19 +112,23 @@ pub fn process_instruction<'a>(
             symbol,
             decimals,
             initial_supply,
-        } => {
-            interchain_token::process_deploy(accounts, salt, name, symbol, decimals, initial_supply)
-        }
+        } => interchain_token::process_deploy(
+            accounts.try_into()?,
+            salt,
+            name,
+            symbol,
+            decimals,
+            initial_supply,
+        ),
         InterchainTokenServiceInstruction::DeployRemoteInterchainToken {
             salt,
             destination_chain,
             gas_value,
             signing_pda_bump,
         } => interchain_token::deploy_remote_interchain_token(
-            accounts,
+            accounts.try_into()?,
             salt,
             destination_chain,
-            None,
             gas_value,
             signing_pda_bump,
         ),
@@ -133,11 +138,11 @@ pub fn process_instruction<'a>(
             destination_minter,
             gas_value,
             signing_pda_bump,
-        } => interchain_token::deploy_remote_interchain_token(
-            accounts,
+        } => interchain_token::deploy_remote_interchain_token_with_minter(
+            accounts.try_into()?,
             salt,
             destination_chain,
-            Some(destination_minter),
+            destination_minter,
             gas_value,
             signing_pda_bump,
         ),
@@ -149,7 +154,7 @@ pub fn process_instruction<'a>(
             gas_value,
             signing_pda_bump,
         } => interchain_transfer::process_user_interchain_transfer(
-            accounts,
+            accounts.try_into()?,
             token_id,
             destination_chain,
             destination_address,
@@ -168,7 +173,7 @@ pub fn process_instruction<'a>(
             source_program_id,
             pda_seeds,
         } => interchain_transfer::process_cpi_interchain_transfer(
-            accounts,
+            accounts.try_into()?,
             token_id,
             destination_chain,
             destination_address,
@@ -182,12 +187,17 @@ pub fn process_instruction<'a>(
         InterchainTokenServiceInstruction::RegisterTokenMetadata {
             gas_value,
             signing_pda_bump,
-        } => link_token::register_token_metadata(accounts, gas_value, signing_pda_bump),
+        } => link_token::register_token_metadata(accounts.try_into()?, gas_value, signing_pda_bump),
         InterchainTokenServiceInstruction::RegisterCustomToken {
             salt,
             token_manager_type,
             operator,
-        } => link_token::register_custom_token(accounts, salt, token_manager_type, operator),
+        } => link_token::register_custom_token(
+            accounts.try_into()?,
+            salt,
+            token_manager_type,
+            operator,
+        ),
         InterchainTokenServiceInstruction::LinkToken {
             salt,
             destination_chain,
@@ -197,7 +207,7 @@ pub fn process_instruction<'a>(
             gas_value,
             signing_pda_bump,
         } => link_token::process_outbound(
-            accounts,
+            accounts.try_into()?,
             salt,
             destination_chain,
             destination_token_address,
@@ -208,44 +218,44 @@ pub fn process_instruction<'a>(
         ),
         InterchainTokenServiceInstruction::SetFlowLimit { flow_limit } => {
             let accounts_iter = &mut accounts.iter();
-            let payer = next_account_info(accounts_iter)?;
-            let operator = next_account_info(accounts_iter)?;
-            let its_root_pda = next_account_info(accounts_iter)?;
-            let its_roles_pda = next_account_info(accounts_iter)?;
-            let token_manager_pda = next_account_info(accounts_iter)?;
-            let system_account = next_account_info(accounts_iter)?;
+            let payer_account = next_account_info(accounts_iter)?;
+            let operator_account = next_account_info(accounts_iter)?;
+            let its_root_account = next_account_info(accounts_iter)?;
+            let its_roles_account = next_account_info(accounts_iter)?;
+            let token_manager_account = next_account_info(accounts_iter)?;
+            let system_program_account = next_account_info(accounts_iter)?;
 
             event_cpi_accounts!(accounts_iter);
 
             msg!("Instruction: SetFlowLimit");
 
-            let its_config_pda = InterchainTokenService::load(its_root_pda)?;
-            assert_valid_its_root_pda(its_root_pda, its_config_pda.bump)?;
+            let its_config_pda = InterchainTokenService::load(its_root_account)?;
+            assert_valid_its_root_pda(its_root_account, its_config_pda.bump)?;
 
-            validate_system_account_key(system_account.key)?;
+            validate_system_account_key(system_program_account.key)?;
 
             ensure_signer_roles(
                 &crate::id(),
-                its_root_pda,
-                operator,
-                its_roles_pda,
+                its_root_account,
+                operator_account,
+                its_roles_account,
                 Roles::OPERATOR,
             )?;
 
-            let token_manager = TokenManager::load(token_manager_pda)?;
+            let token_manager = TokenManager::load(token_manager_account)?;
 
             token_manager::set_flow_limit(
-                payer,
-                token_manager_pda,
-                its_root_pda,
-                system_account,
+                payer_account,
+                token_manager_account,
+                its_root_account,
+                system_program_account,
                 flow_limit,
             )?;
 
             if let Some(limit) = flow_limit {
                 emit_cpi!(events::FlowLimitSet {
                     token_id: token_manager.token_id,
-                    operator: *operator.key,
+                    operator: *operator_account.key,
                     flow_limit: limit,
                 });
             }
@@ -303,7 +313,7 @@ pub fn process_instruction<'a>(
             gas_value,
             signing_pda_bump,
         } => interchain_transfer::process_user_interchain_transfer(
-            accounts,
+            accounts.try_into()?,
             token_id,
             destination_chain,
             destination_address,
@@ -323,7 +333,7 @@ pub fn process_instruction<'a>(
             source_program_id,
             pda_seeds,
         } => interchain_transfer::process_cpi_interchain_transfer(
-            accounts,
+            accounts.try_into()?,
             token_id,
             destination_chain,
             destination_address,
@@ -344,26 +354,26 @@ fn process_initialize(
     its_hub_address: String,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
-    let payer = next_account_info(account_info_iter)?;
+    let payer_account = next_account_info(account_info_iter)?;
     let program_data_account = next_account_info(account_info_iter)?;
-    let its_root_pda_account = next_account_info(account_info_iter)?;
-    let system_account = next_account_info(account_info_iter)?;
-    let operator = next_account_info(account_info_iter)?;
+    let its_root_account = next_account_info(account_info_iter)?;
+    let system_program_account = next_account_info(account_info_iter)?;
+    let operator_account = next_account_info(account_info_iter)?;
     let user_roles_account = next_account_info(account_info_iter)?;
 
     msg!("Instruction: Initialize");
 
     // Check: System Program Account
-    validate_system_account_key(system_account.key)?;
+    validate_system_account_key(system_program_account.key)?;
 
     // Check: Upgrade Authority
-    ensure_upgrade_authority(program_id, payer, program_data_account)?;
+    ensure_upgrade_authority(program_id, payer_account, program_data_account)?;
 
     // Check: PDA Account is not initialized
-    its_root_pda_account.check_uninitialized_pda()?;
+    its_root_account.check_uninitialized_pda()?;
 
     let (its_root_pda, its_root_pda_bump) = crate::find_its_root_pda();
-    if its_root_pda != *its_root_pda_account.key {
+    if its_root_pda != *its_root_account.key {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -371,14 +381,14 @@ fn process_initialize(
         InterchainTokenService::new(its_root_pda_bump, chain_name, its_hub_address);
     its_root_config.init(
         &crate::id(),
-        system_account,
-        payer,
-        its_root_pda_account,
+        system_program_account,
+        payer_account,
+        its_root_account,
         &[crate::seed_prefixes::ITS_SEED, &[its_root_pda_bump]],
     )?;
 
     let (user_roles_pda, user_roles_pda_bump) =
-        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, operator.key);
+        role_management::find_user_roles_pda(&crate::id(), &its_root_pda, operator_account.key);
     if user_roles_pda != *user_roles_account.key {
         return Err(ProgramError::InvalidAccountData);
     }
@@ -387,14 +397,14 @@ fn process_initialize(
     let signer_seeds = &[
         role_management::seed_prefixes::USER_ROLES_SEED,
         its_root_pda.as_ref(),
-        operator.key.as_ref(),
+        operator_account.key.as_ref(),
         &[user_roles_pda_bump],
     ];
 
     operator_user_roles.init(
         program_id,
-        system_account,
-        payer,
+        system_program_account,
+        payer_account,
         user_roles_account,
         signer_seeds,
     )?;
@@ -405,15 +415,15 @@ fn process_initialize(
 fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
-    let system_account = next_account_info(accounts_iter)?;
-    let payer = next_account_info(accounts_iter)?;
+    let system_program_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
-    let resource = next_account_info(accounts_iter)?;
+    let resource_account = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
 
-    validate_system_account_key(system_account.key)?;
+    validate_system_account_key(system_program_account.key)?;
 
     if origin_user_account.key == destination_user_account.key {
         msg!("Source and destination accounts are the same");
@@ -422,25 +432,25 @@ fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> Program
 
     msg!("Instruction: TransferOperatorship");
 
-    let its_config = InterchainTokenService::load(resource)?;
-    assert_valid_its_root_pda(resource, its_config.bump)?;
+    let its_config = InterchainTokenService::load(resource_account)?;
+    assert_valid_its_root_pda(resource_account, its_config.bump)?;
 
     let role_add_accounts = RoleAddAccounts {
-        system_account,
-        payer,
+        system_account: system_program_account,
+        payer: payer_account,
         authority_user_account: origin_user_account,
         authority_roles_account: origin_roles_account,
-        resource,
+        resource: resource_account,
         target_user_account: destination_user_account,
         target_roles_account: destination_roles_account,
     };
 
     let role_remove_accounts = RoleRemoveAccounts {
-        system_account,
-        payer,
+        system_account: system_program_account,
+        payer: payer_account,
         authority_user_account: origin_user_account,
         authority_roles_account: origin_roles_account,
-        resource,
+        resource: resource_account,
         target_user_account: origin_user_account,
         target_roles_account: origin_roles_account,
     };
@@ -463,28 +473,28 @@ fn process_transfer_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> Program
 fn process_propose_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
 
-    let system_account = next_account_info(accounts_iter)?;
-    let payer = next_account_info(accounts_iter)?;
+    let system_program_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
     let proposer_user_account = next_account_info(accounts_iter)?;
     let proposer_roles_account = next_account_info(accounts_iter)?;
-    let resource = next_account_info(accounts_iter)?;
+    let resource_account = next_account_info(accounts_iter)?;
     let destination_user_account = next_account_info(accounts_iter)?;
     let destination_roles_account = next_account_info(accounts_iter)?;
     let proposal_account = next_account_info(accounts_iter)?;
 
     msg!("Instruction: ProposeOperatorship");
 
-    validate_system_account_key(system_account.key)?;
+    validate_system_account_key(system_program_account.key)?;
 
-    let its_config = InterchainTokenService::load(resource)?;
-    assert_valid_its_root_pda(resource, its_config.bump)?;
+    let its_config = InterchainTokenService::load(resource_account)?;
+    assert_valid_its_root_pda(resource_account, its_config.bump)?;
 
     let role_management_accounts = RoleTransferWithProposalAccounts {
-        system_account,
-        payer,
+        system_account: system_program_account,
+        payer: payer_account,
         origin_user_account: proposer_user_account,
         origin_roles_account: proposer_roles_account,
-        resource,
+        resource: resource_account,
         destination_user_account,
         destination_roles_account,
         proposal_account,
@@ -495,23 +505,23 @@ fn process_propose_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramR
 
 fn process_accept_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
-    let system_account = next_account_info(accounts_iter)?;
-    let payer = next_account_info(accounts_iter)?;
+    let system_program_account = next_account_info(accounts_iter)?;
+    let payer_account = next_account_info(accounts_iter)?;
     let role_receiver_account = next_account_info(accounts_iter)?;
     let role_receiver_roles_account = next_account_info(accounts_iter)?;
-    let resource = next_account_info(accounts_iter)?;
+    let resource_account = next_account_info(accounts_iter)?;
     let origin_user_account = next_account_info(accounts_iter)?;
     let origin_roles_account = next_account_info(accounts_iter)?;
     let proposal_account = next_account_info(accounts_iter)?;
 
     msg!("Instruction: AcceptOperatorship");
 
-    validate_system_account_key(system_account.key)?;
+    validate_system_account_key(system_program_account.key)?;
 
     let role_management_accounts = RoleTransferWithProposalAccounts {
-        system_account,
-        payer,
-        resource,
+        system_account: system_program_account,
+        payer: payer_account,
+        resource: resource_account,
         destination_user_account: role_receiver_account,
         destination_roles_account: role_receiver_roles_account,
         origin_user_account,
@@ -524,43 +534,41 @@ fn process_accept_operatorship<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramRe
 
 fn process_set_pause_status<'a>(accounts: &'a [AccountInfo<'a>], paused: bool) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
-    let owner = next_account_info(accounts_iter)?;
+    let owner_account = next_account_info(accounts_iter)?;
     let program_data_account = next_account_info(accounts_iter)?;
-    let its_root_pda = next_account_info(accounts_iter)?;
-    let system_account = next_account_info(accounts_iter)?;
+    let its_root_account = next_account_info(accounts_iter)?;
+    let system_program_account = next_account_info(accounts_iter)?;
 
-    validate_system_account_key(system_account.key)?;
+    validate_system_account_key(system_program_account.key)?;
 
     msg!("Instruction: SetPauseStatus");
 
-    ensure_upgrade_authority(&crate::id(), owner, program_data_account)?;
+    ensure_upgrade_authority(&crate::id(), owner_account, program_data_account)?;
 
-    let mut its_root_config = InterchainTokenService::load(its_root_pda)?;
-    assert_valid_its_root_pda(its_root_pda, its_root_config.bump)?;
+    let mut its_root_config = InterchainTokenService::load(its_root_account)?;
+    assert_valid_its_root_pda(its_root_account, its_root_config.bump)?;
 
     its_root_config.paused = paused;
-    its_root_config.store(owner, its_root_pda, system_account)?;
+    its_root_config.store(owner_account, its_root_account, system_program_account)?;
 
     Ok(())
 }
 
-fn process_set_trusted_chain<'a>(
-    accounts: &'a [AccountInfo<'a>],
+fn process_set_trusted_chain(
+    accounts: SetTrustedChainAccounts,
     chain_name: String,
 ) -> ProgramResult {
-    let accounts_iter = &mut accounts.iter();
-    let (payer, authority, authority_roles, program_data_account, its_root_pda, system_account) =
-        get_trusted_chain_accounts(accounts, accounts_iter)?;
     msg!("Instruction: SetTrustedChain");
 
-    event_cpi_accounts!(accounts_iter);
+    let event_accounts = &mut accounts.event_accounts().into_iter();
+    event_cpi_accounts!(event_accounts);
 
-    if ensure_upgrade_authority(&crate::id(), authority, program_data_account).is_err()
+    if ensure_upgrade_authority(&crate::id(), accounts.authority, accounts.program_data).is_err()
         && ensure_signer_roles(
             &crate::id(),
-            its_root_pda,
-            authority,
-            authority_roles,
+            accounts.its_root,
+            accounts.authority,
+            accounts.authority_roles,
             Roles::OPERATOR,
         )
         .is_err()
@@ -569,35 +577,32 @@ fn process_set_trusted_chain<'a>(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    let mut its_root_config = InterchainTokenService::load(its_root_pda)?;
-    assert_valid_its_root_pda(its_root_pda, its_root_config.bump)?;
+    let mut its_root = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_root.bump)?;
 
     let trusted_chain_event = events::TrustedChainSet { chain_name };
     emit_cpi!(trusted_chain_event);
-    its_root_config.add_trusted_chain(trusted_chain_event.chain_name);
-    its_root_config.store(payer, its_root_pda, system_account)?;
+    its_root.add_trusted_chain(trusted_chain_event.chain_name);
+    its_root.store(accounts.payer, accounts.its_root, accounts.system_program)?;
 
     Ok(())
 }
 
-fn process_remove_trusted_chain<'a>(
-    accounts: &'a [AccountInfo<'a>],
+fn process_remove_trusted_chain(
+    accounts: RemoveTrustedChainAccounts,
     chain_name: &str,
 ) -> ProgramResult {
-    let accounts_iter = &mut accounts.iter();
-    let (payer, authority, authority_roles, program_data_account, its_root_pda, system_account) =
-        get_trusted_chain_accounts(accounts, accounts_iter)?;
-
     msg!("Instruction: RemoveTrustedChain");
 
-    event_cpi_accounts!(accounts_iter);
+    let event_accounts = &mut accounts.event_accounts().into_iter();
+    event_cpi_accounts!(event_accounts);
 
-    if ensure_upgrade_authority(&crate::id(), authority, program_data_account).is_err()
+    if ensure_upgrade_authority(&crate::id(), accounts.authority, accounts.program_data).is_err()
         && ensure_signer_roles(
             &crate::id(),
-            its_root_pda,
-            authority,
-            authority_roles,
+            accounts.its_root,
+            accounts.authority,
+            accounts.authority_roles,
             Roles::OPERATOR,
         )
         .is_err()
@@ -605,47 +610,15 @@ fn process_remove_trusted_chain<'a>(
         msg!("Account passed as authority is neither upgrade authority nor operator");
         return Err(ProgramError::MissingRequiredSignature);
     }
-    let mut its_root_config = InterchainTokenService::load(its_root_pda)?;
-    assert_valid_its_root_pda(its_root_pda, its_root_config.bump)?;
+    let mut its_root = InterchainTokenService::load(accounts.its_root)?;
+    assert_valid_its_root_pda(accounts.its_root, its_root.bump)?;
 
     emit_cpi!(events::TrustedChainRemoved {
         chain_name: chain_name.to_owned(),
     });
 
-    its_root_config.remove_trusted_chain(chain_name)?;
-    its_root_config.store(payer, its_root_pda, system_account)?;
+    its_root.remove_trusted_chain(chain_name)?;
+    its_root.store(accounts.payer, accounts.its_root, accounts.system_program)?;
 
     Ok(())
-}
-
-fn get_trusted_chain_accounts<'a>(
-    _accounts: &'a [AccountInfo<'a>],
-    accounts_iter: &mut core::slice::Iter<'a, AccountInfo<'a>>,
-) -> Result<
-    (
-        &'a AccountInfo<'a>,
-        &'a AccountInfo<'a>,
-        &'a AccountInfo<'a>,
-        &'a AccountInfo<'a>,
-        &'a AccountInfo<'a>,
-        &'a AccountInfo<'a>,
-    ),
-    ProgramError,
-> {
-    let payer = next_account_info(accounts_iter)?;
-    let authority = next_account_info(accounts_iter)?;
-    let authority_roles_account = next_account_info(accounts_iter)?;
-    let program_data_account = next_account_info(accounts_iter)?;
-    let its_root_pda = next_account_info(accounts_iter)?;
-    let system_account = next_account_info(accounts_iter)?;
-
-    validate_system_account_key(system_account.key)?;
-    Ok((
-        payer,
-        authority,
-        authority_roles_account,
-        program_data_account,
-        its_root_pda,
-        system_account,
-    ))
 }

--- a/programs/axelar-solana-its/tests/module/deploy_manager_mismatch.rs
+++ b/programs/axelar-solana-its/tests/module/deploy_manager_mismatch.rs
@@ -100,7 +100,7 @@ async fn attempt_deployment_with_specific_token_manager(
     let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
     let fake_token_manager_pda =
         axelar_solana_its::find_token_manager_pda(&its_root_pda, &manager_token_id).0;
-    deploy_remote_ix.accounts[4].pubkey = fake_token_manager_pda;
+    deploy_remote_ix.accounts[5].pubkey = fake_token_manager_pda;
 
     ctx.solana_chain
         .fixture

--- a/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
+++ b/programs/axelar-solana-its/tests/module/from_solana_to_evm.rs
@@ -1015,7 +1015,7 @@ async fn test_ata_must_match_pda_derivation(ctx: &mut ItsTestContext) -> anyhow:
     .unwrap();
 
     // Now inject an arbitrary ATA that does not match the token manager PDA
-    transfer_ix.accounts[5].pubkey = {
+    transfer_ix.accounts[6].pubkey = {
         let attacker_wallet = Keypair::new();
 
         // Fund the attacker wallet (for transaction fees)


### PR DESCRIPTION
This PR tries to improve how the accounts are handled within ITS and hopefully also help the migration to Anchor. We're getting rid of most of the instances where the accounts slices are indexed with constants.