### PR TITLE
refactor(gateway): optimize payload verification session intitialization

### DIFF
--- a/bindings/anchor_lib/axelar-solana-gateway.rs
+++ b/bindings/anchor_lib/axelar-solana-gateway.rs
@@ -152,6 +152,7 @@ pub struct InitializePayloadVerificationSession<'info> {
     gateway_config_pda: AccountInfo<'info>,
     #[account(mut)]
     verification_session_pda: AccountInfo<'info>,
+    verifier_set_tracker_pda: AccountInfo<'info>,
     system_program: Program<'info, System>,
 }
 

--- a/programs/axelar-solana-gateway/src/instructions.rs
+++ b/programs/axelar-solana-gateway/src/instructions.rs
@@ -85,12 +85,11 @@ pub enum GatewayInstruction {
     /// 0. [WRITE, SIGNER] Funding account
     /// 1. [] Gateway Root Config PDA account
     /// 2. [WRITE] Verification session PDA buffer account
-    /// 3. [] System Program account
+    /// 3. [] Verifier Set Tracker PDA account
+    /// 4. [] System Program account
     InitializePayloadVerificationSession {
         /// The Merkle root for the Payload being verified.
         payload_merkle_root: [u8; 32],
-        /// The hash of the verifier set that signed the payload.
-        signing_verifier_set_hash: [u8; 32],
     },
 
     /// Verifies a signature within a Payload verification session
@@ -411,13 +410,12 @@ pub fn initialize_payload_verification_session(
         AccountMeta::new(payer, true),
         AccountMeta::new_readonly(gateway_config_pda, false),
         AccountMeta::new(verification_session_pda, false),
-        AccountMeta::new(verifier_set_tracker_pda, false),
+        AccountMeta::new_readonly(verifier_set_tracker_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
 
     let data = to_vec(&GatewayInstruction::InitializePayloadVerificationSession {
         payload_merkle_root,
-        signing_verifier_set_hash,
     })?;
 
     Ok(Instruction {

--- a/programs/axelar-solana-gateway/src/processor.rs
+++ b/programs/axelar-solana-gateway/src/processor.rs
@@ -97,14 +97,12 @@ impl Processor {
 
             GatewayInstruction::InitializePayloadVerificationSession {
                 payload_merkle_root,
-                signing_verifier_set_hash,
             } => {
                 msg!("Instruction: Initialize Verification Session");
                 Self::process_initialize_payload_verification_session(
                     program_id,
                     accounts,
                     payload_merkle_root,
-                    signing_verifier_set_hash,
                 )
             }
 

--- a/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
+++ b/programs/axelar-solana-gateway/src/processor/initialize_payload_verification_session.rs
@@ -12,7 +12,7 @@ use crate::error::GatewayError;
 use crate::state::signature_verification_pda::SignatureVerificationSessionData;
 use crate::state::verifier_set_tracker::VerifierSetTracker;
 use crate::state::GatewayConfig;
-use crate::{assert_valid_verifier_set_tracker_pda, get_verifier_set_tracker_pda, seed_prefixes};
+use crate::{assert_valid_verifier_set_tracker_pda, seed_prefixes};
 
 impl Processor {
     /// Initializes a signature verification session PDA account for a given Axelar payload (former
@@ -42,7 +42,6 @@ impl Processor {
         program_id: &Pubkey,
         accounts: &[AccountInfo<'_>],
         merkle_root: [u8; 32],
-        signing_verifier_set_hash: [u8; 32],
     ) -> ProgramResult {
         // Accounts
         let accounts_iter = &mut accounts.iter();
@@ -78,37 +77,26 @@ impl Processor {
         assert_initialized_and_valid_gateway_root_pda(gateway_root_pda)?;
 
         // Check: Signing verifier set is valid and sufficiently recent
-        {
-            let (expected_verifier_set_tracker_pda, _) =
-                get_verifier_set_tracker_pda(signing_verifier_set_hash);
-            if *verifier_set_tracker_account.key != expected_verifier_set_tracker_pda {
-                return Err(GatewayError::InvalidVerifierSetTrackerProvided.into());
-            }
+        verifier_set_tracker_account.check_initialized_pda_without_deserialization(program_id)?;
+        let verifier_set_data = verifier_set_tracker_account.try_borrow_data()?;
+        let verifier_set_tracker = VerifierSetTracker::read(&verifier_set_data)
+            .ok_or(GatewayError::BytemuckDataLenInvalid)?;
+        assert_valid_verifier_set_tracker_pda(
+            verifier_set_tracker,
+            verifier_set_tracker_account.key,
+        )?;
 
-            verifier_set_tracker_account
-                .check_initialized_pda_without_deserialization(program_id)?;
-            let verifier_set_data = verifier_set_tracker_account.try_borrow_data()?;
-            let verifier_set_tracker = VerifierSetTracker::read(&verifier_set_data)
-                .ok_or(GatewayError::BytemuckDataLenInvalid)?;
-            assert_valid_verifier_set_tracker_pda(
-                verifier_set_tracker,
-                verifier_set_tracker_account.key,
-            )?;
+        // Check: Verifier set isn't expired
+        gateway_root_pda.try_borrow_data().map(|data| {
+            GatewayConfig::read(&data)
+                .ok_or(GatewayError::BytemuckDataLenInvalid)
+                .and_then(|gateway_config| {
+                    gateway_config.assert_valid_epoch(verifier_set_tracker.epoch)
+                })
+        })??;
 
-            // Check: Verifier set isn't expired
-            gateway_root_pda.try_borrow_data().map(|data| {
-                GatewayConfig::read(&data)
-                    .ok_or(GatewayError::BytemuckDataLenInvalid)
-                    .and_then(|gateway_config| {
-                        gateway_config.assert_valid_epoch(verifier_set_tracker.epoch)
-                    })
-            })??;
-
-            // Check: Verifier set hash matches what we expect
-            if verifier_set_tracker.verifier_set_hash != signing_verifier_set_hash {
-                return Err(GatewayError::InvalidVerifierSetTrackerProvided.into());
-            }
-        }
+        // Read the signing verifier set hash from the tracker
+        let signing_verifier_set_hash = verifier_set_tracker.verifier_set_hash;
 
         // Check: Verification PDA can be derived from provided seeds.
         // using canonical bump for the session account


### PR DESCRIPTION
Post-merge fixes considering #292

**Changes:**
1. Remove the first PDA validation that uses expensive find_program_address. The second check via `assert_valid_verifier_set_tracker_pda` is sufficient.

2. Remove `signing_verifier_set_hash` parameter from `InitializePayloadVerificationSession` instruction data. The hash is now read directly from the `verifier_set_tracker` account data, which is already validated and loaded.

