### PR TITLE
fix(its): emit FlowLimitSet even when removing limit

### DIFF
--- a/programs/axelar-solana-its/src/events.rs
+++ b/programs/axelar-solana-its/src/events.rs
@@ -109,7 +109,7 @@ pub struct RevokeRemoteInterchainTokenApproval {
 pub struct FlowLimitSet {
     pub token_id: [u8; 32],
     pub operator: Pubkey,
-    pub flow_limit: u64,
+    pub flow_limit: Option<u64>,
 }
 
 #[event]

--- a/programs/axelar-solana-its/src/processor/mod.rs
+++ b/programs/axelar-solana-its/src/processor/mod.rs
@@ -252,13 +252,11 @@ pub fn process_instruction<'a>(
                 flow_limit,
             )?;
 
-            if let Some(limit) = flow_limit {
-                emit_cpi!(events::FlowLimitSet {
-                    token_id: token_manager.token_id,
-                    operator: *operator_account.key,
-                    flow_limit: limit,
-                });
-            }
+            emit_cpi!(events::FlowLimitSet {
+                token_id: token_manager.token_id,
+                operator: *operator_account.key,
+                flow_limit,
+            });
 
             Ok(())
         }

--- a/programs/axelar-solana-its/src/processor/token_manager.rs
+++ b/programs/axelar-solana-its/src/processor/token_manager.rs
@@ -485,13 +485,11 @@ pub(crate) fn process_set_flow_limit<'a>(
         flow_limit,
     )?;
 
-    if let Some(limit) = flow_limit {
-        emit_cpi!(events::FlowLimitSet {
-            token_id: token_manager.token_id,
-            operator: *flow_limiter.key,
-            flow_limit: limit,
-        });
-    }
+    emit_cpi!(events::FlowLimitSet {
+        token_id: token_manager.token_id,
+        operator: *flow_limiter.key,
+        flow_limit,
+    });
 
     Ok(())
 }


### PR DESCRIPTION
If limit is `None` it means there's no limit. We should still emit the event.